### PR TITLE
Fixes for Astra Militarum Feedback #6

### DIFF
--- a/Imperium - Astra Militarum.cat
+++ b/Imperium - Astra Militarum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Astra Militarum" revision="2" battleScribeVersion="2.01" authorName="Alphalas" authorContact="Gitter: @Alphalas, twitter: @kingoverlord" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Astra Militarum" revision="3" battleScribeVersion="2.01" authorName="Alphalas" authorContact="Gitter: @Alphalas, twitter: @kingoverlord" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -1000,7 +1000,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5d9c650e-5d0d-3490-f151-8161623ea294" name="Commissar" book="Codex: Astra Militarum" page="33" hidden="false" collective="false" type="unit">
+    <selectionEntry id="5d9c650e-5d0d-3490-f151-8161623ea294" name="Commissar" book="Codex: Astra Militarum" page="33" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="369e-e2eb-0c28-a859" name="Commissar" book="Codex: Astra Militarum" page="33" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
           <profiles/>
@@ -1059,76 +1059,66 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="01bb-e5bc-0333-5f8b" name="New CategoryLink" hidden="false" targetId="3263-4233-4344-6228" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="a938-00d9-e89f-892b" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="71df-1c94-dd06-9152" name="New CategoryLink" hidden="false" targetId="fa52-8fb7-1c87-80e6" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5e3b-6993-c50d-5574" name="New CategoryLink" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="fc1c-9075-be58-dd89" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="f628-7d16-260d-e31f" name="Bolt pistol" hidden="false" collective="false">
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="3153-9dbd-423f-b44b" name="Astra Militarum Melee Weapons" hidden="false" targetId="7622-e68e-c5e5-c8e7" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f4a6-258a-c6aa-5fbe" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1442-bd02-875a-ca78" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="524c-88d3-382e-4cb5" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="c060-db37-cfa5-8191" name="New EntryLink" hidden="false" targetId="9ef3-0f17-2aeb-436e" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="4065-06c9-5c94-7dbf" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="1">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="b446-b908-b76e-b67c" name="Melee Weapon" hidden="false" collective="false">
+        </entryLink>
+        <entryLink id="2c9c-2f7c-77ff-b0c4" name="Astra Militarum Ranged Weapons" hidden="false" targetId="9ef3-0f17-2aeb-436e" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d475-449c-b770-87a9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9188-9c40-9906-7a3c" type="min"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="ab80-6667-af80-b518" name="New EntryLink" hidden="false" targetId="7622-e68e-c5e5-c8e7" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="d269-b175-59d9-8ddd" value="2">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="25.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="2.0"/>
@@ -2620,93 +2610,79 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="699f-acea-078e-757c" name="New CategoryLink" hidden="false" targetId="3263-4233-4344-6228" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="abb2-c5e5-04f5-37cb" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="d59f-4bc7-d39b-8d75" name="New CategoryLink" hidden="false" targetId="fa52-8fb7-1c87-80e6" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="8bdf-ffe5-d3ae-648d" name="New CategoryLink" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="40bb-68ee-0b35-c367" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="384d-5414-e387-da3c" name="New CategoryLink" hidden="false" targetId="e316-f1b7-03a5-a928" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="bc4c-8bd5-b344-a147" name="Bolt pistol" hidden="false" collective="false" defaultSelectionEntryId="8b1b-43fa-e3c0-2334">
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="5f5f-93a6-7f8d-028e" name="Astra Militarum Ranged Weapons" hidden="false" targetId="9ef3-0f17-2aeb-436e" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4fbb-743b-60f2-e7fa" type="min"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="be0c-55fe-7834-9362" name="New EntryLink" hidden="false" targetId="9ef3-0f17-2aeb-436e" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="8b1b-43fa-e3c0-2334" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="1">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="868d-7994-5a21-669f" name="Power Sword" hidden="false" collective="false" defaultSelectionEntryId="f6e7-38f5-4daf-89bc">
+        </entryLink>
+        <entryLink id="e3fd-ae29-f401-6103" name="Astra Militarum Melee Weapons" hidden="false" targetId="7622-e68e-c5e5-c8e7" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="maxSelections" value="2">
+            <modifier type="set" field="d269-b175-59d9-8ddd" value="2">
               <repeats/>
-              <conditions>
-                <condition field="selections" scope="2d53-c39f-c97d-5735" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a73-3c97-0d5a-f1b9" type="atLeast"/>
-              </conditions>
+              <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b25c-e72c-e1d3-8a37" type="min"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="8a73-3c97-0d5a-f1b9" name="New EntryLink" hidden="false" targetId="7622-e68e-c5e5-c8e7" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="d269-b175-59d9-8ddd" value="2">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="f6e7-38f5-4daf-89bc" name="New EntryLink" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="50.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="4.0"/>
@@ -3694,7 +3670,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="0ddd-b262-72aa-2c36" name="New EntryLink" hidden="false" targetId="3370-f2d7-fbc3-b5e3" type="selectionEntry">
+            <entryLink id="0ddd-b262-72aa-2c36" name="Sniper Rifle" hidden="false" targetId="3370-f2d7-fbc3-b5e3" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4103,28 +4079,90 @@
       </infoLinks>
       <modifiers/>
       <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="6593-9d0a-53ce-5d6e" name="Chainsword" hidden="false" collective="false">
+      <categoryLinks>
+        <categoryLink id="4902-2488-b9fa-3326" name="New CategoryLink" hidden="false" targetId="1153-9b06-0c18-1f9b" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
+        </categoryLink>
+        <categoryLink id="d672-20f2-d777-8e1b" name="New CategoryLink" hidden="false" targetId="3263-4233-4344-6228" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="cbaa-a618-2026-5e39" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5cff-251c-6844-98d7" name="New CategoryLink" hidden="false" targetId="c315-2646-6ce0-36a0" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="fab1-7feb-96fd-e82e" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="0f2b-b337-70c2-f091" name="New CategoryLink" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="7569-7b72-3b90-59c8" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b7e1-c94c-2afd-c305" name="New CategoryLink" hidden="false" targetId="dd6e-7055-ca6b-b711" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8259-8a0f-72ef-8a3d" name="Melee Weapon" hidden="false" collective="false" defaultSelectionEntryId="1247-164d-73fb-93e4">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bb00-8d91-fa71-76ab" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5e80-7f9e-6595-37ca" type="max"/>
+          </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="5eb7-4ef4-9213-c8a5" name="New EntryLink" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
+            <entryLink id="1247-164d-73fb-93e4" name="Chainsword" hidden="false" targetId="de76-80c5-81db-c463" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7ac3-cff8-e1e3-2dd5" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="21da-968a-b3f9-7090" name="New EntryLink" hidden="false" targetId="7622-e68e-c5e5-c8e7" type="selectionEntryGroup">
+            <entryLink id="f112-552e-2f8c-49a9" name="Astra Militarum Melee Weapons" hidden="false" targetId="7622-e68e-c5e5-c8e7" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4134,17 +4172,20 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c6aa-5814-d6fc-49b6" name="Laspistol" hidden="false" collective="false">
+        <selectionEntryGroup id="c942-641d-d59a-8570" name="Range Weapon" hidden="false" collective="false" defaultSelectionEntryId="be9c-0aa9-f6de-d80a">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c35b-a8f3-bbcf-1730" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2bc6-12c5-1793-4463" type="max"/>
+          </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="205e-de3e-dff2-8eee" name="New EntryLink" hidden="false" targetId="9ef3-0f17-2aeb-436e" type="selectionEntryGroup">
+            <entryLink id="fc93-3ef5-373d-bffd" name="Astra Militarum Ranged Weapons" hidden="false" targetId="9ef3-0f17-2aeb-436e" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4152,24 +4193,39 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="8829-e367-ea5c-9f41" name="New EntryLink" hidden="false" targetId="c10b-e1a4-c913-ae15" type="selectionEntry">
+            <entryLink id="368a-6456-d41f-f52e" name="Shotgun" hidden="false" targetId="2094-c9a6-a426-0970" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="555b-0276-f74d-3b7c" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="be9c-0aa9-f6de-d80a" name="Laspistol" hidden="false" targetId="c10b-e1a4-c913-ae15" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7378-f38b-7f87-2bc2" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="09dc-bbea-1285-241e" name="New EntryLink" hidden="false" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+        <entryLink id="09dc-bbea-1285-241e" name="Frag grenade" hidden="false" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0c17-5210-878d-e20a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6e00-083f-c899-8cb4" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -5522,7 +5578,7 @@
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="247a-bbd1-f1b3-46c7" name="Tempestor Prime" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="247a-bbd1-f1b3-46c7" name="Tempestor Prime" page="0" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="9ae2-bd21-7470-5591" name="Tempestor Prime" book="Codex: Astra Militarum" page="39" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
           <profiles/>
@@ -5567,10 +5623,66 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="e057-8387-62b6-87ee" name="New CategoryLink" hidden="false" targetId="1153-9b06-0c18-1f9b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="c758-bcc8-c688-5818" name="New CategoryLink" hidden="false" targetId="3263-4233-4344-6228" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9fb6-e24a-1c38-b9d5" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="8f85-8c54-7f3f-e6e3" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="0761-3fa2-7cdf-e4d7" name="New CategoryLink" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="7d57-2956-0af2-9f75" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3a60-5026-4e2f-8757" name="New CategoryLink" hidden="false" targetId="dd6e-7055-ca6b-b711" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="7a74-70a8-2e2e-3bcd" name="New CategoryLink" hidden="false" targetId="2aba-e4e7-1d91-1a77" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="0609-61cb-b01d-68e0" name="Ranged Weapon" hidden="false" collective="false">
+        <selectionEntryGroup id="0609-61cb-b01d-68e0" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="a20d-3f2c-e904-aee5">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5593,7 +5705,9 @@
                 </infoLink>
               </infoLinks>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e441-5fd3-d7e6-0496" type="max"/>
+              </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>
@@ -5621,7 +5735,9 @@
                 </infoLink>
               </infoLinks>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="51aa-6195-9292-af1f" type="max"/>
+              </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>
@@ -5643,14 +5759,16 @@
                 </infoLink>
               </infoLinks>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="26ec-9d3b-207e-bdbc" type="max"/>
+              </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" costTypeId="points" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="1.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8c66-7758-0c0f-4851" name="Tempestus Command Rod" hidden="false" collective="false" type="upgrade">
@@ -5669,7 +5787,7 @@
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34ca-c7fd-d0b7-7120" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="34ca-c7fd-d0b7-7120" type="max"/>
               </constraints>
               <categoryLinks/>
               <selectionEntries/>
@@ -5684,104 +5802,37 @@
           <selectionEntryGroups/>
           <entryLinks/>
         </selectionEntryGroup>
-        <selectionEntryGroup id="97e4-4243-a94f-abb2" name="Melee Weapons" hidden="false" collective="false">
+        <selectionEntryGroup id="73b6-bcb9-ab8d-34b3" name="Melee Weapon" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f72f-66aa-3801-ba6e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3fcf-ae16-6084-c82b" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="c1ec-ccce-5a2d-0bf1" name="Chainsword" page="0" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b68a-bb1b-781a-c5a6" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9e39-b5ed-11ea-62b7" name="Power Sword" page="0" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="54d4-876e-e494-44bb" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="4.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b7cc-3144-b85a-589b" name="Power Fist" page="0" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f943-6411-3219-4e7b" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7fa5-a200-2a5e-b140" name="Power Maul" page="0" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3552-26a7-31bb-d392" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="4.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2920-878b-bbaa-df1a" name="Power Axe" page="0" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a42a-79e0-9068-0d79" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="0b6f-383c-ea19-0b24" name="Astra Militarum Melee Weapons" hidden="false" targetId="7622-e68e-c5e5-c8e7" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="53c9-4ca6-cb49-7b2a" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fdda-fd2f-57fd-8d5d" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -12541,7 +12592,6 @@
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8119-8b87-07df-3aff" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34c8-d798-8475-2637" type="max"/>
       </constraints>
       <categoryLinks/>
@@ -12796,7 +12846,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="40ae-6101-8b54-4a7a" name="New EntryLink" hidden="false" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
+        <entryLink id="40ae-6101-8b54-4a7a" name="Heavy bolter" hidden="false" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12830,14 +12880,13 @@
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09fe-8e7d-99a3-f68a" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d269-b175-59d9-8ddd" type="max"/>
       </constraints>
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="4e75-5e59-a375-2698" name="New EntryLink" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
+        <entryLink id="4e75-5e59-a375-2698" name="Power axe" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>


### PR DESCRIPTION
- Fixed Tempestor Prime Weapon options
- Astra Militarum Melee Weapons Group: added max 1 selection constrains to the weapons
- Changed Tempestor Prime type to model and added categories to him
- Fixed Lord Commisar and Commisar weapon options and added categories to him
- Fixed Company Commander weapons and added categories

Note:
THERE ARE TWO "Astra Militarum" CATEGORIES.
Also, the file is only called "Astra Militarum", not "Imperium - Astra Militarum", like all other files.