### PR TITLE
Fixing #163 and #214 for Grey Knight Psykers and Dreads

### DIFF
--- a/Imperium - Grey Knights.cat
+++ b/Imperium - Grey Knights.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0cc2-3545-6762-a3f7" name="Imperium - Grey Knights" book="Index: Imperium 1" page="" revision="2" battleScribeVersion="2.01" authorName="tekton" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0cc2-3545-6762-a3f7" name="Imperium - Grey Knights" book="Index: Imperium 1" page="" revision="2" battleScribeVersion="2.01" authorName="tekton" authorContact="" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -3507,7 +3507,7 @@
         <modifier type="increment" field="e356-c769-5920-6e14" value="13">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cfea-23e4-ba7f-d27f" type="equalTo"/>
+            <condition field="selections" scope="b7af-7b03-7dfa-e4b5" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cfea-23e4-ba7f-d27f" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -4138,7 +4138,7 @@
         <modifier type="increment" field="e356-c769-5920-6e14" value="9">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="707b-b5f1-e2f2-cdb1" type="equalTo"/>
+            <condition field="selections" scope="5254-e74b-2380-e119" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="707b-b5f1-e2f2-cdb1" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -5754,7 +5754,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="a2fb-c30d-07ba-d193" name="New InfoLink" hidden="false" targetId="a7db-5058-2216-4e6d" type="rule">
+        <infoLink id="a2fb-c30d-07ba-d193" name="Daemon Hunters" hidden="false" targetId="a7db-5058-2216-4e6d" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5783,7 +5783,7 @@
         <modifier type="increment" field="e356-c769-5920-6e14" value="7">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e25c-9b4b-78d9-e6f3" type="equalTo"/>
+            <condition field="selections" scope="45ea-60a2-7f7e-06c7" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e25c-9b4b-78d9-e6f3" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>


### PR DESCRIPTION
Bringing Grand Master to the right rule text and Brother Captain Stern to the right Psychic power limit

Fixes #163 Librarian entry
Fixes #214 Dread issues
Fixes #242 interceptor costs and other units with the same issue