### PR TITLE
Close #122

### DIFF
--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Blood Angels" book="Index: Imperium 1" revision="1" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Blood Angels" book="Index: Imperium 1" revision="2" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -12090,7 +12090,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="6cfe-bd17-281f-4f89" name="New InfoLink" hidden="false" targetId="34e6-6d54-fe10-c7d3" type="profile">
+            <infoLink id="6cfe-bd17-281f-4f89" name="Terminator" hidden="false" targetId="34e6-6d54-fe10-c7d3" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12197,7 +12197,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="aea3-bdce-c085-7e5f" name="Terminator Squad" hidden="false" collective="false" type="model">
+    <selectionEntry id="aea3-bdce-c085-7e5f" name="Terminator Squad" hidden="false" collective="false" type="unit">
       <profiles>
         <profile id="9947-8ac3-bb3b-dc59" name="Combat Squads" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
           <profiles/>
@@ -12344,7 +12344,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="0661-cc5d-1616-aa14" name="New InfoLink" hidden="false" targetId="34e6-6d54-fe10-c7d3" type="profile">
+            <infoLink id="0661-cc5d-1616-aa14" name="Terminator" hidden="false" targetId="34e6-6d54-fe10-c7d3" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12372,23 +12372,25 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="6686-c309-1d3c-df64" name="New EntryLink" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+                <entryLink id="6686-c309-1d3c-df64" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6230-b9ce-021c-674a" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd39-4503-7ef6-e3cc" type="min"/>
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="2a06-bbf2-4c4f-1f7b" name="New EntryLink" hidden="false" targetId="fdc6-5770-1177-74f4" type="selectionEntry">
+                <entryLink id="2a06-bbf2-4c4f-1f7b" name="Chainfist" hidden="false" targetId="e464-77c1-12bb-e52f" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="305a-1429-b3e6-9534" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad46-8033-bd4f-15cf" type="min"/>
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
@@ -12448,7 +12450,7 @@
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="3b37-96fc-38b2-4987" name="New EntryLink" hidden="false" targetId="8389-43e9-4ab8-bd3e" type="selectionEntry">
+        <entryLink id="3b37-96fc-38b2-4987" name="Teleport homer" hidden="false" targetId="8389-43e9-4ab8-bd3e" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>


### PR DESCRIPTION
Close #122 Corrected issue where selecting Chainfist option for a terminator in a terminator squad would cause Chainfist to be selected for every terminator in the squad.

Chainfist was linked to a collective version. Re-linked to a non local shared version. Additionally changed Power fist link to non local shared version.