### PR TITLE
Close #194

### DIFF
--- a/Necrons.cat
+++ b/Necrons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="61c6-c8c5-a304-ff5f" name="Necrons" book="Index: Xenos 1" revision="3" battleScribeVersion="2.01" authorName="@kohato" authorContact="https://gitter.im/BSData/wh40k" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="61c6-c8c5-a304-ff5f" name="Necrons" book="Index: Xenos 1" revision="4" battleScribeVersion="2.01" authorName="@kohato" authorContact="https://gitter.im/BSData/wh40k" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks>
@@ -5240,6 +5240,11 @@
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
+                <modifier type="decrement" field="points" value="9">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
               </modifiers>
               <constraints/>
               <categoryLinks/>
@@ -5253,6 +5258,11 @@
                   <repeats>
                     <repeat field="selections" scope="7b8e-775e-8a0f-4455" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="decrement" field="points" value="9">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
@@ -6275,11 +6285,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of each of his Movement phase, Illuminor Szeras can augment one unit of NECRON Warriors or Immortals that is within 1&quot; of him.  Roll a D3 to see what augmentation the unit gains for the rest of the battle.  A unit can only be enhanced by Mechanical Augmentation once per battle.
-
-1) +1 Strength 
-2) +1 Toughness 
-3) Ballistic Skill improved by 1"/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of each of his Movement phase, Illuminor Szeras can augment one unit of NECRON Warriors or Immortals that is within 1&quot; of him.  Roll a D3 to see what augmentation the unit gains for the rest of the battle.  A unit can only be enhanced by Mechanical Augmentation once per battle.  1) +1 Strength  2) +1 Toughness  3) Ballistic Skill improved by 1"/>
           </characteristics>
         </profile>
       </profiles>
@@ -7271,6 +7277,7 @@
       <entryLinks/>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ea01-f5bb-2733-2b8d" name="Lychguard" book="Index: Xenos 1" hidden="false" collective="false" type="model">


### PR DESCRIPTION
Close #194
Unit weapon choice for immortals was not accounting for the initial cost of a single weapon when increasing the cost of the weapon choice for every Immortal model in the unit. Solved simply by decreasing the point cost initially by 9. Fixed for Gauss Blaster and Tesla Carbine.

This is most likely not the most elegant  solution and will have to be modified if the point cost of the weapons ever change.