### PR TITLE
Close #266

### DIFF
--- a/Imperium - Dark Angels.cat
+++ b/Imperium - Dark Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b8fe-8d38-37ec-90e8" name="Imperium - Dark Angels" book="Index: Imperium 1" revision="6" battleScribeVersion="2.01" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="b8fe-8d38-37ec-90e8" name="Imperium - Dark Angels" book="Index: Imperium 1" revision="7" battleScribeVersion="2.01" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -12290,6 +12290,19 @@
                     <condition field="selections" scope="1f47-c287-f37d-7211" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb73-2c07-8cb4-9cf3" type="atLeast"/>
                   </conditions>
                   <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="0874-6124-944a-2d47" value="0.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="eb73-2c07-8cb4-9cf3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f9da-84e8-58a3-fed8" type="equalTo"/>
+                        <condition field="selections" scope="eb73-2c07-8cb4-9cf3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8b7d-cf45-ceb0-8e4a" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>


### PR DESCRIPTION
Close #266
According to the datasheet, Deathwing Terminators that take a heavy weapon do not replace their Storm Bolter with it.

I added a modification to prevent taking a heavy weapon along with Thunder Hammer & Storm Shield or Pair of Lightning Claws.