### PR TITLE
Blood Angels v5

### DIFF
--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Blood Angels" book="Index: Imperium 1" revision="4" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Blood Angels" book="Index: Imperium 1" revision="5" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -4145,7 +4145,7 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="02e9-1a1a-77c9-3369" name="Space Marine Veteran" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="02e9-1a1a-77c9-3369" name="Space Marine Veteran" hidden="false" collective="false" type="model">
           <profiles/>
           <rules/>
           <infoLinks>
@@ -4342,7 +4342,7 @@
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="845a-5b46-d631-89a3" name="Veteran Sergeant" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="845a-5b46-d631-89a3" name="Veteran Sergeant" hidden="false" collective="false" type="model">
           <profiles/>
           <rules/>
           <infoLinks>
@@ -4474,7 +4474,7 @@
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="b18a-4f3e-5cd7-43d7" name="New EntryLink" hidden="false" targetId="8eda-5cb2-0c31-56da" type="selectionEntry">
+        <entryLink id="b18a-4f3e-5cd7-43d7" name="Jump Pack" hidden="false" targetId="8eda-5cb2-0c31-56da" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4903,13 +4903,13 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="77ae-2615-cbed-ea69" name="New EntryLink" hidden="false" targetId="2837-2f42-e4d7-56c6" type="selectionEntry">
+            <entryLink id="77ae-2615-cbed-ea69" name="Twin autocannon" hidden="false" targetId="2837-2f42-e4d7-56c6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43dc-dd0a-a500-eb4b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="43dc-dd0a-a500-eb4b" type="max"/>
               </constraints>
               <categoryLinks/>
             </entryLink>
@@ -4927,7 +4927,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="f19c-6432-2e56-00bb" name="New EntryLink" book="" hidden="false" targetId="e0d0-c252-65bb-c06e" type="selectionEntryGroup">
+        <entryLink id="f19c-6432-2e56-00bb" name="Dreadnought heavy weapons" book="" hidden="false" targetId="e0d0-c252-65bb-c06e" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6863,7 +6863,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="25c3-7486-357a-9551" name="New EntryLink" hidden="false" targetId="290a-8ad2-2af9-5ebc" type="selectionEntry">
+                <entryLink id="25c3-7486-357a-9551" name="Heavy bolter" hidden="false" targetId="290a-8ad2-2af9-5ebc" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -6900,6 +6900,16 @@
                   <modifiers/>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fbb-0aad-2a81-970d" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="a411-0256-bf72-d10b" name="Assault cannon" hidden="false" targetId="640e-ce8b-bba2-ce5f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="800b-e39c-a3f5-8030" type="max"/>
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
@@ -6971,7 +6981,10 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="5afb-9914-904b-d3b3" value="This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny one psychic power in each enemy Psychic phase. It knows the Smite power and two psychic powers from the Sanguinary discipline."/>
+            <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny one psychic power in each enemy Psychic phase. It knows the Smite power and two psychic powers from the Sanguinary discipline."/>
+            <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46"/>
+            <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b"/>
           </characteristics>
         </profile>
       </profiles>
@@ -7252,7 +7265,10 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="5afb-9914-904b-d3b3" value="This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny one psychic power in each enemy Psychic phase. It knows the Smite power and two psychic powers from the Sanguinary discipline."/>
+            <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny one psychic power in each enemy Psychic phase. It knows the Smite power and two psychic powers from the Sanguinary discipline."/>
+            <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46"/>
+            <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b"/>
           </characteristics>
         </profile>
       </profiles>
@@ -7495,7 +7511,10 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="5afb-9914-904b-d3b3" value="This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny one psychic power in each enemy Psychic phase. It knows the Smite power and two psychic powers from the Sanguinary discipline."/>
+            <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny one psychic power in each enemy Psychic phase. It knows the Smite power and two psychic powers from the Sanguinary discipline."/>
+            <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46"/>
+            <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b"/>
           </characteristics>
         </profile>
       </profiles>
@@ -9502,7 +9521,7 @@
         <modifier type="increment" field="e356-c769-5920-6e14" value="4">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7368-3677-f327-b4b2" type="greaterThan"/>
+            <condition field="selections" scope="76e4-ef9b-a5fc-8864" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -14052,7 +14071,10 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="5afb-9914-904b-d3b3" value="This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny one psychic power in each enemy Psychic phase. It knows the Smite power and two psychic powers from the Sanguinary discipline."/>
+            <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny one psychic power in each enemy Psychic phase. It knows the Smite power and two psychic powers from the Sanguinary discipline."/>
+            <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46"/>
+            <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b"/>
           </characteristics>
         </profile>
         <profile id="2f17-f189-0537-cc10" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -14283,7 +14305,10 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="5afb-9914-904b-d3b3" value="This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny two psychic powers in each enemy Psychic phase. It knows the Smite power and three psychic powers from the Sanguinary discipline."/>
+            <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny two psychic powers in each enemy Psychic phase. It knows the Smite power and three psychic powers from the Sanguinary discipline."/>
+            <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46"/>
+            <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b"/>
           </characteristics>
         </profile>
         <profile id="b29b-d431-5d1e-0d7e" name="Lord of Death" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -17773,7 +17798,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for friendly &lt;b&gt;FLESH TEARERS&lt;/b&gt; within 6&quot; of Commander Dante."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for friendly &lt;b&gt;FLESH TEARERS&lt;/b&gt; within 6&quot; of Gabriel Seth."/>
           </characteristics>
         </profile>
         <profile id="43ba-5534-7af7-4956" name="Whirlwind of Gore" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">


### PR DESCRIPTION
Land Speeders can now take Assault Cannons. Fixes #417.
Fixed point cost for Company Veterans with Jump Packs. Fixes #439.
Fixed PL for Scout Squads. Fixes #442.
Fixed validation for Dreadnoughts with two Twin Autocannons. Fixes #460.
Fixed Gabriel Seth's identity crisis. Fixes #478.