### PR TITLE
T'au - Knarloc riders points/weapon fix; FW classification fixes

### DIFF
--- a/T'au Empire.cat
+++ b/T'au Empire.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c0bb-c0cd-a715-99c6" name="T&apos;au Empire" revision="61" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Amis92" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="133" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c0bb-c0cd-a715-99c6" name="T&apos;au Empire" revision="62" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Amis92" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="134" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="c0bb-c0cd-pubN68738" name="Codex: T&apos;au Empire"/>
     <publication id="c0bb-c0cd-pubN142484" name="FW: Tiger Shark AX-1-0.pdf (10/2017)"/>
@@ -4957,12 +4957,12 @@
       <categoryLinks>
         <categoryLink id="6c63-d69b-1a59-73e8" name="New CategoryLink" hidden="false" targetId="8cc3-4e99-e01d-fed8" primary="false"/>
         <categoryLink id="41a0-5673-e0dd-2920" name="New CategoryLink" hidden="false" targetId="77ee-b03b-d244-d535" primary="false"/>
-        <categoryLink id="bc54-329f-07b1-85c5" name="New CategoryLink" hidden="false" targetId="c274d0b0-5866-44bc-9810-91c136ae7438" primary="true"/>
         <categoryLink id="c8d8-11d6-18ec-dd52" name="New CategoryLink" hidden="false" targetId="0caa-53ee-34da-cda1" primary="false"/>
         <categoryLink id="59fd-d6a7-e52e-209d" name="New CategoryLink" hidden="false" targetId="3b77-decb-d468-6bcc" primary="false"/>
         <categoryLink id="1652-57bf-d0ce-2cee" name="New CategoryLink" hidden="false" targetId="092c-6125-af28-ef5d" primary="false"/>
         <categoryLink id="a722-3bed-a625-f562" name="New CategoryLink" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false"/>
         <categoryLink id="2ed4-073d-02dd-d75a" name="XV109 Y&apos;vahra Battlesuit" hidden="false" targetId="e61a-f77a-bae5-e46b" primary="false"/>
+        <categoryLink id="a2aa-9b8c-1d25-e0eb" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4b25-601c-ecb3-12e6" name="Fletchette pod" publicationId="03b4-8286-592c-c370" page="45" hidden="false" collective="false" import="true" type="upgrade">
@@ -5059,8 +5059,8 @@
         <categoryLink id="bf1b-84cf-bd83-4b87" name="New CategoryLink" hidden="false" targetId="77ee-b03b-d244-d535" primary="false"/>
         <categoryLink id="42f7-1f21-7389-1ae2" name="New CategoryLink" hidden="false" targetId="0caa-53ee-34da-cda1" primary="false"/>
         <categoryLink id="8ff5-6d88-82ff-a6f6" name="New CategoryLink" hidden="false" targetId="3b77-decb-d468-6bcc" primary="false"/>
-        <categoryLink id="553c-00e7-ba1b-c85e" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
         <categoryLink id="f4e4-c758-e3dc-f1ec" name="XV107 R&apos;varna Battlesuit" hidden="false" targetId="0ac7-f3eb-bb57-da92" primary="false"/>
+        <categoryLink id="7a46-428c-54c2-b406" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="084f-8527-8fb1-071f" name="Drones (0-2)" publicationId="03b4-8286-592c-c370" page="46" hidden="false" collective="false" import="true">
@@ -8183,9 +8183,16 @@ If you have chosen a sept that does not have an associated Sept Tenet, you can c
                   </characteristics>
                 </profile>
               </profiles>
+              <entryLinks>
+                <entryLink id="5ce7-a489-1acd-6206" name="Kroot rifle" hidden="false" collective="false" import="true" targetId="5d54-f57b-8125-762e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5389-b39f-287e-fe93" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c83b-c003-b10d-4f7a" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
               <costs>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" typeId="points" value="28.0"/>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>

--- a/T'au Empire.cat
+++ b/T'au Empire.cat
@@ -4957,12 +4957,12 @@
       <categoryLinks>
         <categoryLink id="6c63-d69b-1a59-73e8" name="New CategoryLink" hidden="false" targetId="8cc3-4e99-e01d-fed8" primary="false"/>
         <categoryLink id="41a0-5673-e0dd-2920" name="New CategoryLink" hidden="false" targetId="77ee-b03b-d244-d535" primary="false"/>
+        <categoryLink id="bc54-329f-07b1-85c5" name="New CategoryLink" hidden="false" targetId="c274d0b0-5866-44bc-9810-91c136ae7438" primary="true"/>
         <categoryLink id="c8d8-11d6-18ec-dd52" name="New CategoryLink" hidden="false" targetId="0caa-53ee-34da-cda1" primary="false"/>
         <categoryLink id="59fd-d6a7-e52e-209d" name="New CategoryLink" hidden="false" targetId="3b77-decb-d468-6bcc" primary="false"/>
         <categoryLink id="1652-57bf-d0ce-2cee" name="New CategoryLink" hidden="false" targetId="092c-6125-af28-ef5d" primary="false"/>
         <categoryLink id="a722-3bed-a625-f562" name="New CategoryLink" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false"/>
         <categoryLink id="2ed4-073d-02dd-d75a" name="XV109 Y&apos;vahra Battlesuit" hidden="false" targetId="e61a-f77a-bae5-e46b" primary="false"/>
-        <categoryLink id="a2aa-9b8c-1d25-e0eb" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4b25-601c-ecb3-12e6" name="Fletchette pod" publicationId="03b4-8286-592c-c370" page="45" hidden="false" collective="false" import="true" type="upgrade">
@@ -5059,8 +5059,8 @@
         <categoryLink id="bf1b-84cf-bd83-4b87" name="New CategoryLink" hidden="false" targetId="77ee-b03b-d244-d535" primary="false"/>
         <categoryLink id="42f7-1f21-7389-1ae2" name="New CategoryLink" hidden="false" targetId="0caa-53ee-34da-cda1" primary="false"/>
         <categoryLink id="8ff5-6d88-82ff-a6f6" name="New CategoryLink" hidden="false" targetId="3b77-decb-d468-6bcc" primary="false"/>
+        <categoryLink id="553c-00e7-ba1b-c85e" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
         <categoryLink id="f4e4-c758-e3dc-f1ec" name="XV107 R&apos;varna Battlesuit" hidden="false" targetId="0ac7-f3eb-bb57-da92" primary="false"/>
-        <categoryLink id="7a46-428c-54c2-b406" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="084f-8527-8fb1-071f" name="Drones (0-2)" publicationId="03b4-8286-592c-c370" page="46" hidden="false" collective="false" import="true">


### PR DESCRIPTION
- Moves the XV107/XV109 to the Fast Attack category.
- Removes unintended points cost for the Knarloc Riders.
- Adds a Kroot rifle to the default loadout for Knarloc Riders.

Fixes #7463.