### PR TITLE
Replace "The Eight" visibility to only be displayed within SHA detachments

### DIFF
--- a/T'au Empire.cat
+++ b/T'au Empire.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c0bb-c0cd-a715-99c6" name="T&apos;au Empire" revision="62" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Amis92" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="134" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c0bb-c0cd-a715-99c6" name="T&apos;au Empire" revision="63" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Amis92" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="134" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="c0bb-c0cd-pubN68738" name="Codex: T&apos;au Empire"/>
     <publication id="c0bb-c0cd-pubN142484" name="FW: Tiger Shark AX-1-0.pdf (10/2017)"/>
@@ -8194,6 +8194,7 @@ If you have chosen a sept that does not have an associated Sept Tenet, you can c
               <costs>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -8487,15 +8488,10 @@ If you have chosen a sept that does not have an associated Sept Tenet, you can c
     </selectionEntry>
     <selectionEntry id="2b21-8566-e761-2d44" name="The Eight" publicationId="4593-a2f0-546a-d6f2" page="48" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="set" field="0f1c-b86d-b610-2de0" value="0.0">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="58c5-1d35-3869-613f" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="224b-1070-218f-fdf4" type="notInstanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="224b-1070-218f-fdf4" type="notInstanceOf"/>
+          </conditions>
         </modifier>
       </modifiers>
       <constraints>

--- a/T'au Empire.cat
+++ b/T'au Empire.cat
@@ -8489,9 +8489,14 @@ If you have chosen a sept that does not have an associated Sept Tenet, you can c
     <selectionEntry id="2b21-8566-e761-2d44" name="The Eight" publicationId="4593-a2f0-546a-d6f2" page="48" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="224b-1070-218f-fdf4" type="notInstanceOf"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="44da-9aaf-181b-5ece" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="224b-1070-218f-fdf4" type="notInstanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>


### PR DESCRIPTION
- Replaces the previous matched gametype check for "The Eight"'s validation and replaces it with a hidden field for any non super heavy auxiliary detachments/unbound armies.