### PR TITLE
T'au: Hide sept specific warlord traits until a sept is chosen

### DIFF
--- a/T'au Empire.cat
+++ b/T'au Empire.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c0bb-c0cd-a715-99c6" name="T&apos;au Empire" revision="64" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Amis92" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="143" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c0bb-c0cd-a715-99c6" name="T&apos;au Empire" revision="65" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Amis92" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="139" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="c0bb-c0cd-pubN68738" name="Codex: T&apos;au Empire"/>
     <publication id="c0bb-c0cd-pubN142484" name="FW: Tiger Shark AX-1-0.pdf (10/2017)"/>
@@ -7551,6 +7551,11 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3b63-2d45-6b9a-a8fb" type="lessThan"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87be-58f3-5dda-b17b" type="max"/>
@@ -7580,6 +7585,11 @@
               </conditions>
             </conditionGroup>
           </conditionGroups>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5f48-5fed-7b98-0e66" type="lessThan"/>
+          </conditions>
         </modifier>
       </modifiers>
       <constraints>
@@ -7611,6 +7621,11 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6c3b-d0e4-8c16-76e1" type="lessThan"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6467-7143-26d7-d86d" type="max"/>
@@ -7640,6 +7655,11 @@
               </conditions>
             </conditionGroup>
           </conditionGroups>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8acf-0d00-a1cb-ecf7" type="lessThan"/>
+          </conditions>
         </modifier>
       </modifiers>
       <constraints>
@@ -7671,6 +7691,11 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="81e2-b5ad-f2ba-33ae" type="lessThan"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa33-f3f3-ffd1-e6e4" type="max"/>
@@ -7700,6 +7725,11 @@
               </conditions>
             </conditionGroup>
           </conditionGroups>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1742-90e4-26f1-d1d2" type="lessThan"/>
+          </conditions>
         </modifier>
       </modifiers>
       <constraints>


### PR DESCRIPTION
- Hides all sept specific warlord traits until a sept tenet is chosen.