### PR TITLE
T'au: Modify The Eight/Shadowsun's points to match app/MFM 

### DIFF
--- a/T'au Empire.cat
+++ b/T'au Empire.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c0bb-c0cd-a715-99c6" name="T&apos;au Empire" revision="65" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Amis92" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="139" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c0bb-c0cd-a715-99c6" name="T&apos;au Empire" revision="66" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Amis92" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="143" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="c0bb-c0cd-pubN68738" name="Codex: T&apos;au Empire"/>
     <publication id="c0bb-c0cd-pubN142484" name="FW: Tiger Shark AX-1-0.pdf (10/2017)"/>
@@ -3903,7 +3903,7 @@
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0e4c-5356-9bfd-3ea1" name="MV62 Command-link Drone" publicationId="4593-a2f0-546a-d6f2" page="33" hidden="false" collective="false" import="true" type="model">
@@ -8674,9 +8674,6 @@ If you have chosen a sept that does not have an associated Sept Tenet, you can c
           </selectionEntries>
           <entryLinks>
             <entryLink id="0d37-4097-2918-c03f" name="MV4 Shield Drone" hidden="false" collective="false" import="true" targetId="741b-98b7-0a87-55b1" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="0.0"/>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23ae-587a-91f0-8496" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d573-7032-832a-8eba" type="max"/>
@@ -8821,9 +8818,6 @@ If you have chosen a sept that does not have an associated Sept Tenet, you can c
           </selectionEntries>
           <entryLinks>
             <entryLink id="e5d9-33c2-96d1-90c1" name="MV1 Gun Drone" hidden="false" collective="false" import="true" targetId="f92a-bbbb-13b7-6761" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="0.0"/>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="baec-480d-fe51-bf86" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f85a-5edc-e203-a1fa" type="max"/>
@@ -8917,9 +8911,6 @@ If you have chosen a sept that does not have an associated Sept Tenet, you can c
           </selectionEntries>
           <entryLinks>
             <entryLink id="1024-93a3-6eee-afd8" name="MV1 Gun Drone" hidden="false" collective="false" import="true" targetId="f92a-bbbb-13b7-6761" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="0.0"/>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a60-9f20-cfaf-c987" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="748d-2ad4-fc78-a28a" type="max"/>
@@ -9041,9 +9032,6 @@ If you have chosen a sept that does not have an associated Sept Tenet, you can c
           </selectionEntries>
           <entryLinks>
             <entryLink id="6ad1-f9d1-4e8d-fd38" name="MV1 Gun Drone" hidden="false" collective="false" import="true" targetId="f92a-bbbb-13b7-6761" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="0.0"/>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9134-0d13-8c36-45b4" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="669e-5c50-3226-b962" type="max"/>
@@ -9168,9 +9156,6 @@ If you have chosen a sept that does not have an associated Sept Tenet, you can c
           </selectionEntries>
           <entryLinks>
             <entryLink id="cd5d-8c24-d205-fd02" name="MV7 Marker Drone" hidden="false" collective="false" import="true" targetId="652c-3656-4f9f-3405" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="0.0"/>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="032c-f46e-76ba-10cf" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f43-8695-adba-93f3" type="max"/>
@@ -9286,9 +9271,6 @@ If you have chosen a sept that does not have an associated Sept Tenet, you can c
           </selectionEntries>
           <entryLinks>
             <entryLink id="2a76-018d-500b-b2c4" name="MV8 Missile Drone" hidden="false" collective="false" import="true" targetId="be79-b567-ab48-ebf5" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="0.0"/>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47f6-5ce8-504c-399b" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f455-4faf-05a6-ba26" type="max"/>
@@ -9476,9 +9458,6 @@ If you have chosen a sept that does not have an associated Sept Tenet, you can c
           </selectionEntries>
           <entryLinks>
             <entryLink id="0d14-05d7-d7f4-48a6" name="MV84 Shielded Missile Drone" hidden="false" collective="false" import="true" targetId="ca7f-d200-b93b-49a6" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="0.0"/>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2592-bd9d-24e3-d292" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c4-b919-2263-3a60" type="max"/>


### PR DESCRIPTION
This is a slightly controversial one. Per the MFM, both Shadowsun and the Eight include the wargear for the units without drones, so should really have the drones added on top as well, but there's the following issues:

- One of Shadowsun's drones doesn't exist in the MFM, but it has a points value of 10 in the recently updated app.
- MFM references "per model", so The Eight should be over 10000 points. Per the app, the Farsight model is 1250pts, with the other suits being 0. Each drone has a points cost which appears to then be added on top of that.