### PR TITLE
Adds missing 'Jump Pack Assault' rule for The Sanguinor

### DIFF
--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Adeptus Astartes - Blood Angels" revision="166" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas | Twitter: @_alphalas" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="150" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Adeptus Astartes - Blood Angels" revision="167" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas | Twitter: @_alphalas" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="147" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="eb0f-c144-pubN65537" name="Codex: Blood Angels"/>
   </publications>
@@ -3386,6 +3386,7 @@
         <infoLink id="fd6f-c437-74f7-dcbd" name="Savage Echoes" hidden="false" targetId="3006-d1b9-c324-c9be" type="rule"/>
         <infoLink id="ba92-b087-3e15-34a3" name="Angels of Death" hidden="false" targetId="9106-b297-021a-4d72" type="rule"/>
         <infoLink id="f4d1-1ef0-cf70-6171" name="The Red Thirst" hidden="false" targetId="2deb-254e-c616-78b9" type="rule"/>
+        <infoLink id="3d6d-8135-2628-af03" name="Jump Pack Assault" hidden="false" targetId="b1f9-97c2-db25-7761" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="08f7-9316-eac4-f242" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>


### PR DESCRIPTION
Solves: https://github.com/BSData/wh40k/issues/7934