### PR TITLE
Blood Angels make default tactical squad valid

### DIFF
--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Adeptus Astartes - Blood Angels" revision="166" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas | Twitter: @_alphalas" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="150" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Adeptus Astartes - Blood Angels" revision="167" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas | Twitter: @_alphalas" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="150" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="eb0f-c144-pubN65537" name="Codex: Blood Angels"/>
   </publications>
@@ -5997,7 +5997,7 @@
         <categoryLink id="2e41-4f20-e60f-522f" name="New CategoryLink" hidden="false" targetId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="7dac-b2de-5a48-25f6" name="Space Marines" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="7dac-b2de-5a48-25f6" name="Space Marines" hidden="false" collective="false" import="true" defaultSelectionEntryId="0e69-3a7f-aa7d-d9bf">
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f308-aae9-0288-7f43" type="max"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ded2-20ac-bc92-2c3c" type="min"/>
@@ -6040,7 +6040,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38f8-6e23-47f6-8556" type="max"/>
               </constraints>
               <selectionEntryGroups>
-                <selectionEntryGroup id="a91e-9e19-13d7-44c1" name="Weapon Options" hidden="false" collective="false" import="true">
+                <selectionEntryGroup id="a91e-9e19-13d7-44c1" name="Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="0c83-091b-fbe1-03e1">
                   <modifiers>
                     <modifier type="increment" field="d5bb-65c2-6662-97ca" value="1.0">
                       <conditions>


### PR DESCRIPTION
Noticed that the default tac squad only had 4 marines, and the sergeant didn't have any weapons. Figured I'd dip my toes in w/ this minor issue :-D