### PR TITLE
Imperium - Blood Angels.cat make default tactical squad valid

### DIFF
--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -5992,7 +5992,7 @@
         <categoryLink id="2e41-4f20-e60f-522f" name="New CategoryLink" hidden="false" targetId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="7dac-b2de-5a48-25f6" name="Space Marines" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="7dac-b2de-5a48-25f6" name="Space Marines" hidden="false" collective="false" import="true" defaultSelectionEntryId="0e69-3a7f-aa7d-d9bf">
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f308-aae9-0288-7f43" type="max"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ded2-20ac-bc92-2c3c" type="min"/>
@@ -6035,7 +6035,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38f8-6e23-47f6-8556" type="max"/>
               </constraints>
               <selectionEntryGroups>
-                <selectionEntryGroup id="a91e-9e19-13d7-44c1" name="Weapon Options" hidden="false" collective="false" import="true">
+                <selectionEntryGroup id="a91e-9e19-13d7-44c1" name="Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="0c83-091b-fbe1-03e1">
                   <modifiers>
                     <modifier type="increment" field="d5bb-65c2-6662-97ca" value="1.0">
                       <conditions>


### PR DESCRIPTION
Closes #7977 

This is a duplicate (without the version number update) of https://github.com/BSData/wh40k/pull/7944

Lmk if you'd rather I re-open that PR