### PR TITLE
AM v287: Fix Astra Militarum doctrine validation

### DIFF
--- a/Imperium - Astra Militarum.cat
+++ b/Imperium - Astra Militarum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Astra Militarum" revision="286" battleScribeVersion="2.03" authorName="Jon K, Joe B" authorContact="Discord: @Alphalas, @CrusherJoe | Twitter: @_alphalas, @theawesomesauce" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="153" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Astra Militarum" revision="287" battleScribeVersion="2.03" authorName="Jon K, Joe B" authorContact="Discord: @Alphalas, @CrusherJoe | Twitter: @_alphalas, @theawesomesauce" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="152" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="99a162d9-4854-cc3b-c35e-b0c3a3cc77d6" name="Commissar Yarrick" hidden="false" collective="false" import="true" targetId="1fe0e11a-5174-b4e9-842e-b254870ae161" type="selectionEntry">
       <modifiers>
@@ -11584,8 +11584,8 @@ Use this Act of Faith at the start of the Morale phase. If successful, the selec
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="73fc-bc45-dbdd-417d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bca9-103d-9ff7-e000" type="atLeast"/>
-                    <condition field="selections" scope="73fc-bc45-dbdd-417d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="acbb-de01-c359-1016" type="atLeast"/>
+                    <condition field="selections" scope="73fc-bc45-dbdd-417d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1f55-4ee0-5c0e-5b35" type="atLeast"/>
+                    <condition field="selections" scope="73fc-bc45-dbdd-417d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="atLeast"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -11598,8 +11598,8 @@ Use this Act of Faith at the start of the Morale phase. If successful, the selec
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="73fc-bc45-dbdd-417d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="acbb-de01-c359-1016" type="atLeast"/>
-                    <condition field="selections" scope="73fc-bc45-dbdd-417d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3041-5432-850f-22dd" type="atLeast"/>
+                    <condition field="selections" scope="73fc-bc45-dbdd-417d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="atLeast"/>
+                    <condition field="selections" scope="73fc-bc45-dbdd-417d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="afa1-3564-cfe2-602b" type="atLeast"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>


### PR DESCRIPTION
Fixes an issue where a user would be able to select regimental, custom regimental and Tempestus regiments at the same time without an error.