### PR TITLE
Fix: Typos - Craftworlds

### DIFF
--- a/Aeldari - Craftworlds.cat
+++ b/Aeldari - Craftworlds.cat
@@ -5806,7 +5806,7 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
           <profiles>
             <profile id="c322-f5bd-9983-daf5" name="Warp Jump Generator" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When this unit moves in the Movement phase, they can use their warp jump generators. If they they do, they cannot Advance or Charge this turn, but their Move characteristic is increased by 4D6&quot; and they can FLY until the end of the phase. A unit that uses warp jump generators to Fall Back can still shoot in its Shooting phase.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When this unit moves in the Movement phase, they can use their warp jump generators. If they do, they cannot Advance or Charge this turn, but their Move characteristic is increased by 4D6&quot; and they can FLY until the end of the phase. A unit that uses warp jump generators to Fall Back can still shoot in its Shooting phase.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -8196,7 +8196,7 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
           <profiles>
             <profile id="7aa2-878c-ea9e-be53" name="Unstoppable Revenant (Wraithknight)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">A Wraithknight can Fall Back in the Movement phase and still shoot and/or charge during its turn. When a Wraithknight Falls Back, it can even move over enemy INFANTRY models, though at the end of its move it must be more than 1&quot; from all enemy units. In addition, a Wraithknight can move and fire Heavy weapons without suffering the penalty to its hit rolls. Finally, a Wraithknight only gains a bonus to its save in cover if at least half of the model is obsured from the firer.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">A Wraithknight can Fall Back in the Movement phase and still shoot and/or charge during its turn. When a Wraithknight Falls Back, it can even move over enemy INFANTRY models, though at the end of its move it must be more than 1&quot; from all enemy units. In addition, a Wraithknight can move and fire Heavy weapons without suffering the penalty to its hit rolls. Finally, a Wraithknight only gains a bonus to its save in cover if at least half of the model is obscured from the firer.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -9544,7 +9544,7 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
           <profiles>
             <profile id="8876-33e8-543f-b3ea" name="Catastrophic Collapse (Phantom)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield. On a 5+ it collapes with catastrophic effect, and each unit within 3D6&quot; suffers 2D6 mortal wounds.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield. On a 5+ it collapses with catastrophic effect, and each unit within 3D6&quot; suffers 2D6 mortal wounds.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -9977,7 +9977,7 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
           <profiles>
             <profile id="27df-6771-a41f-01e0" name="Catastrophic Collapse (Revenant)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield. On a 5+ it collapes with catastrophic effect, and each unit within 3D6&quot; suffers D6 mortal wounds.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield. On a 5+ it collapses with catastrophic effect, and each unit within 3D6&quot; suffers D6 mortal wounds.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -10224,7 +10224,7 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
           <profiles>
             <profile id="dcd2-6db1-a6a8-4bf4" name="Catastrophic Collapse (Skathach)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield. On a 5+ it collapes with catastrophic effect, and each unit within 2D6&quot; suffers D6 mortal wounds.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield. On a 5+ it collapses with catastrophic effect, and each unit within 2D6&quot; suffers D6 mortal wounds.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -10290,7 +10290,7 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
                     <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
                     <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
                     <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D6</characteristic>
-                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">If the traget is within half range of this weapon, roll two dice when inflicting damage with it and discard the lowest result.</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">If the target is within half range of this weapon, roll two dice when inflicting damage with it and discard the lowest result.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -12297,7 +12297,7 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
                             <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
                             <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
                             <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
-                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Each hit inflicted with this weapon allows an additional attack to be made with it. As long as each following attak hits, the controlling player may keep making attacks until a total of 3 hits have been inflicted with this weapon.</characteristic>
+                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Each hit inflicted with this weapon allows an additional attack to be made with it. As long as each following attack hits, the controlling player may keep making attacks until a total of 3 hits have been inflicted with this weapon.</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -12600,7 +12600,7 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       <profiles>
         <profile id="d0d1-899e-907e-8469" name="5: Mark of the Incomparable Hunter" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time you select a target for a ranged weapon this Warlordis equipped with, you can ignore the Look Out, Sir rule.’</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time you select a target for a ranged weapon this Warlord is equipped with, you can ignore the Look Out, Sir rule.’</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -12740,7 +12740,7 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
         </profile>
         <profile id="8acb-0b48-40a9-79af" name="Cameleoline Cloak" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Your opponent must subract 1 from their hit rolls for ranged weapons that target Amallyn Shadowguide. In addition, if Amallyn Shadowguide is receiving the benefit of cover, add 2 to her saving throws instead of 1.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Your opponent must subtract 1 from their hit rolls for ranged weapons that target Amallyn Shadowguide. In addition, if Amallyn Shadowguide is receiving the benefit of cover, add 2 to her saving throws instead of 1.</characteristic>
           </characteristics>
         </profile>
         <profile id="d551-ace1-24d9-0aea" name="Amallyn Shadowguide" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -14679,7 +14679,7 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
       </modifiers>
       <description>This ability is common to all YNNARI units.
 
-As soon as any unit is destroyed, All units from your army benefit from Soulburst actions until the end of the turn. Whilst a unit is benefitting from Soulburst Actions, it always fights first in the Fight phase, even if it didn&apos;t charge. If a model that is benefitting from soulburst actions made a charge move this turn, or already has an ability that allows it to always fight first in the Fight phase, then whilst it is benfitting from soulburst actions you also add 1 to hit rolls for attacks made with melee weapons by that model. If the enemy also has units that made a charge move or that have abilities that allow them to always fight first in the fight phase, the alternate units, starting with the player whose turn is taking place.</description>
+As soon as any unit is destroyed, All units from your army benefit from Soulburst actions until the end of the turn. Whilst a unit is benefitting from Soulburst Actions, it always fights first in the Fight phase, even if it didn&apos;t charge. If a model that is benefitting from soulburst actions made a charge move this turn, or already has an ability that allows it to always fight first in the Fight phase, then whilst it is benefitting from soulburst actions you also add 1 to hit rolls for attacks made with melee weapons by that model. If the enemy also has units that made a charge move or that have abilities that allow them to always fight first in the fight phase, the alternate units, starting with the player whose turn is taking place.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>


### PR DESCRIPTION
Craftworld typo and grammar fixes.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.