### PR TITLE
Fix: Typos - Drukhari

### DIFF
--- a/Aeldari - Drukhari.cat
+++ b/Aeldari - Drukhari.cat
@@ -6724,7 +6724,7 @@
                           <profiles>
                             <profile id="7082-8b61-67f5-d876" name="Obsessive Collectors" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                               <characteristics>
-                                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When an enemy unit is destroyed as a result of an attack made with a melee weapon by a model in a unit from your army with this obsession, you can select one model in the attacking model’s unit to regain up to D3 lo st wounds .’ If the attacking model is a Wrack, you can instead return up to D3 destroyed models to that unit, placing them on the battlefield and in unit coherency (if the models cannot be placed in this way, they are not returned to the battlefield).</characteristic>
+                                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When an enemy unit is destroyed as a result of an attack made with a melee weapon by a model in a unit from your army with this obsession, you can select one model in the attacking model’s unit to regain up to D3 lost wounds .’ If the attacking model is a Wrack, you can instead return up to D3 destroyed models to that unit, placing them on the battlefield and in unit coherency (if the models cannot be placed in this way, they are not returned to the battlefield).</characteristic>
                               </characteristics>
                             </profile>
                           </profiles>
@@ -6775,7 +6775,7 @@
                   <profiles>
                     <profile id="c455-35db-3d1f-fb47" name="Kabal of the Flayed Skull" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                       <characteristics>
-                        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Add 3&quot; to the Move characteristic of all models with this obsession that can FLY (if such a model has a minimum and maximum Move characteristic, only add 3&quot; to thier maximum one). In addition, enemy units do not recieve the benefit to thier saving throws for being in cover against attacks made by models with this obsession that can  FLY, or by models with this obsession that are embarked upon a TRANSPORT with this obsession that can FLY. Re-roll hit rolls of 1 for such models when attacking with Rapid Fire weapons.</characteristic>
+                        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Add 3&quot; to the Move characteristic of all models with this obsession that can FLY (if such a model has a minimum and maximum Move characteristic, only add 3&quot; to their maximum one). In addition, enemy units do not receive the benefit to their saving throws for being in cover against attacks made by models with this obsession that can  FLY, or by models with this obsession that are embarked upon a TRANSPORT with this obsession that can FLY. Re-roll hit rolls of 1 for such models when attacking with Rapid Fire weapons.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
@@ -7571,9 +7571,9 @@ obsession, it is automatically passed.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9507-6e33-208f-de99" name="Treacherous Deciever" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="9507-6e33-208f-de99" name="Treacherous Deceiver" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="e4ee-40e2-4068-1142" name="Treacherous Deciever" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+        <profile id="e4ee-40e2-4068-1142" name="Treacherous Deceiver" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time you roll an unmodified saving throw of 6 for this Warlord in the Fight phase, the enemy unit that made that attack suffers a mortal wound after it has resolved all of it attacks</characteristic>
           </characteristics>
@@ -8228,7 +8228,7 @@ obsession, it is automatically passed.</characteristic>
           <profiles>
             <profile id="1349-cfde-b975-94f6" name="Writ of the Living Muse" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">KABAL OF THE BLACK HEART Archon only. Re-roll wound rolls of 1 for friendly KABAL OF THE BLACK HEARTunits within 6&quot; of the bearer.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">KABAL OF THE BLACK HEART Archon only. Re-roll wound rolls of 1 for friendly KABAL OF THE BLACK HEART units within 6&quot; of the bearer.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -8662,7 +8662,7 @@ obsession, it is automatically passed.</characteristic>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="36ec-0e25-faf3-0879" name="Treacherous Deciever" hidden="false" collective="false" import="true" targetId="9507-6e33-208f-de99" type="selectionEntry">
+        <entryLink id="36ec-0e25-faf3-0879" name="Treacherous Deceiver" hidden="false" collective="false" import="true" targetId="9507-6e33-208f-de99" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>


### PR DESCRIPTION
Typo and grammar fixes for the nasty pirate space elves

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.