### PR TITLE
Fix: Typos - Corsairs

### DIFF
--- a/Aeldari - FW Corsairs.cat
+++ b/Aeldari - FW Corsairs.cat
@@ -1978,7 +1978,7 @@
 -The unit can move as if it were your Movement phase.  It can Advance or Fall Back as part of this move.
 -The unit can, if it is a PSYKER, immediately attempt to manifest a single psychic power as if it were the Psychic phase.
 -The unit can shoot as if it were your Shooting phase, even if it Advanced or Fell Back this turn.
--The unit can charge as if it were the Charge phase, even if it Advanced or Fell Back this turn(enemy units can fire Overwatch as normal).  A unit cannot do this if is within 1&quot; of an enemy unit.
+-The unit can charge as if it were the Charge phase, even if it Advanced or Fell Back this turn(enemy units can fire Overwatch as normal).  A unit cannot do this if it is within 1&quot; of an enemy unit.
 -The Unit can fight as if it were the Fight Phase.
 
 Note that this means that a unit may be able to shoot or fight twice in the same turn.


### PR DESCRIPTION
Single grammar fix for the Forgeworld Elfy lads.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.