### PR TITLE
Fix: Typos - Chaos Space Marines

### DIFF
--- a/Chaos - Chaos Space Marines.cat
+++ b/Chaos - Chaos Space Marines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cb54-c035-5759-7697" name="Chaos - Chaos Space Marines" revision="148" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="158" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cb54-c035-5759-7697" name="Chaos - Chaos Space Marines" revision="149" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="158" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cb54-c035-pubN125652" name="Codex: Heretic Astartes - Chaos Space Marines"/>
     <publication id="cb54-c035-pubN153092" name="Imperium Nihilus: Vigilus Ablaze"/>

--- a/Chaos - Chaos Space Marines.cat
+++ b/Chaos - Chaos Space Marines.cat
@@ -8327,7 +8327,7 @@ If your summoning roll included any doubles, your character then suffers a morta
         </profile>
         <profile id="9ef4-81e6-3365-bfba" name="Crazed" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of any phase in which this model suffers any unsaved wounds or mortal wounds, roll a D6. On a roll of 6, this model immediately makes a shooting attack as if it were your Shooting phase if there are no enemies within 1&quot;, or a piles in and fights as if it were in the Fight phase if there are enemies within 1&quot;. If there is no visible target within range, nothing happens.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of any phase in which this model suffers any unsaved wounds or mortal wounds, roll a D6. On a roll of 6, this model immediately makes a shooting attack as if it were your Shooting phase if there are no enemies within 1&quot;, or piles in and fights as if it were in the Fight phase if there are enemies within 1&quot;. If there is no visible target within range, nothing happens.</characteristic>
           </characteristics>
         </profile>
         <profile id="a3d2-cbb8-77f5-44d3" name="Battering Onslaught" hidden="true" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -12911,7 +12911,7 @@ If your summoning roll included any doubles, your character then suffers a morta
       <profiles>
         <profile id="40ea-7ad2-2212-38f9" name="The Daemon&apos;s Eye" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the start of your Shooting phase, pick a friendly DEVASTATION BATTERY unit within 6&quot; of the bearer. Enemy units do no receive the benefit of cover against that unit&apos;s weapons this phase.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the start of your Shooting phase, pick a friendly DEVASTATION BATTERY unit within 6&quot; of the bearer. Enemy units do not receive the benefit of cover against that unit&apos;s weapons this phase.</characteristic>
           </characteristics>
         </profile>
       </profiles>


### PR DESCRIPTION
Even Traitors deserve good grammar.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.