### PR TITLE
Fix: Typos - Renegade and Heretics

### DIFF
--- a/Chaos - FW Renegade and Heretics.cat
+++ b/Chaos - FW Renegade and Heretics.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2ebb-7865-3983-640d" name="Chaos - Renegades &amp; Heretics" revision="50" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="158" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2ebb-7865-3983-640d" name="Chaos - Renegades &amp; Heretics" revision="51" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="158" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="2ebb-7865-pubN72363" name="Codex: Astra Militarum"/>
   </publications>

--- a/Chaos - FW Renegade and Heretics.cat
+++ b/Chaos - FW Renegade and Heretics.cat
@@ -1180,7 +1180,7 @@
             </profile>
             <profile id="0058-c1e6-d079-b15f" name="Supersonic" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time this model moves, first pivot it on the spot up to 90&quot; (this does not contribute to how far the model moves), and then move the model straight forwards. Note that it cannot pivot again after the initial pivot. When this model Advances,  increase it&apos;s Move characteristic by 20&quot; until the end of the phase - do not roll a dice.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time this model moves, first pivot it on the spot up to 90&quot; (this does not contribute to how far the model moves), and then move the model straight forwards. Note that it cannot pivot again after the initial pivot. When this model Advances,  increase its Move characteristic by 20&quot; until the end of the phase - do not roll a dice.</characteristic>
               </characteristics>
             </profile>
             <profile id="4c41-8af4-7e8b-31a3" name="Grav Chute Insertion" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -6257,7 +6257,7 @@
         </profile>
         <profile id="5f0b-0f18-4af0-6eb5" name="Artillery" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">An Earthshaker Carriage Battery can only fire its ranged weapon if a friendly &lt;RENEGADE&gt; guardsman crew model is within 3&quot;. A single Guardsman model cannot operate multiple Earthshaker Carriages in this way in a single turn, if all of the guardsmen crew within 6&quot; of an earthshaker Carriage are slain, it immediately shuts down and is removed from play.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">An Earthshaker Carriage Battery can only fire its ranged weapon if a friendly &lt;RENEGADE&gt; guardsman crew model is within 3&quot;. A single Guardsman model cannot operate multiple Earthshaker Carriages in this way in a single turn, if all of the guardsmen crew within 6&quot; of an Earthshaker Carriage are slain, it immediately shuts down and is removed from play.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -6344,7 +6344,7 @@
         </profile>
         <profile id="c12f-8cc8-d9c2-8eb5" name="Artillery Battery" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">A Medusa Carriage Battery and its Guardsmen Crew must be deployed as a single group within 3&quot; of each other, and must remain within this distance throughout the battle, but are otherwise treated as seperate units. The guardsmen Crew may only be chosen as a target in the shooting phase if they are the closest visible unit to the model that is shooting.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">A Medusa Carriage Battery and its Guardsmen Crew must be deployed as a single group within 3&quot; of each other, and must remain within this distance throughout the battle, but are otherwise treated as separate units. The guardsmen Crew may only be chosen as a target in the shooting phase if they are the closest visible unit to the model that is shooting.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7783,7 +7783,7 @@
           <profiles>
             <profile id="925d-c506-26c6-2f8a" name="Banner of the apostate" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Enemy &lt;IMPERIUM&gt; units substract 1 from their leadership whilst they are within 6&quot; of ony models with a banner of the apostate</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Enemy &lt;IMPERIUM&gt; units subtract 1 from their leadership whilst they are within 6&quot; of ony models with a banner of the apostate</characteristic>
               </characteristics>
             </profile>
           </profiles>


### PR DESCRIPTION
Typo fixes for the traitors.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.