### PR TITLE
Fix: Typos - Custodes

### DIFF
--- a/Imperium - Adeptus Custodes.cat
+++ b/Imperium - Adeptus Custodes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0fb8-6813-9c29-a03d" name="Imperium - Adeptus Custodes" revision="59" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WindstormSCR" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="156" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0fb8-6813-9c29-a03d" name="Imperium - Adeptus Custodes" revision="60" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WindstormSCR" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="156" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0fb8-6813-pubN67796" name="Supplement: Angels of Death"/>
     <publication id="1a42-cfd6-c4b4-946a" name="Valerian and Aleya Box"/>

--- a/Imperium - Adeptus Custodes.cat
+++ b/Imperium - Adeptus Custodes.cat
@@ -5404,7 +5404,7 @@
           </constraints>
           <rules>
             <rule id="c878-5d43-ba36-0e4f" name="Shield of Honour - 1 CP" hidden="false">
-              <description>Use this Stratagem in any phase when an IMPERIUM CHARACTER unit from your army is chosen as the target of an attack made by a model in an enemy unit. Select one friendly AQUILAN SHIELD INFANTRY or AQUILAN SHIELD DREADNOUGHT unit within 3&quot; of that IMPERIUM CHARACTER unit. Until the end of that phase, hen resolving an attack made by a model in that enemy unit, measure range to that IMPERIUM CHARACTER unit, but resolve attacks made by models in that enemy model&apos;s unit against the unit you selected. If the unit you selected is destroyed, any remaining attacks are lost.</description>
+              <description>Use this Stratagem in any phase when an IMPERIUM CHARACTER unit from your army is chosen as the target of an attack made by a model in an enemy unit. Select one friendly AQUILAN SHIELD INFANTRY or AQUILAN SHIELD DREADNOUGHT unit within 3&quot; of that IMPERIUM CHARACTER unit. Until the end of that phase, when resolving an attack made by a model in that enemy unit, measure range to that IMPERIUM CHARACTER unit, but resolve attacks made by models in that enemy model&apos;s unit against the unit you selected. If the unit you selected is destroyed, any remaining attacks are lost.</description>
             </rule>
           </rules>
           <costs>
@@ -5579,7 +5579,7 @@
               </constraints>
               <rules>
                 <rule id="fb0a-20a2-818a-cca5" name="Auramite and Adamantium  - 1 CP" hidden="false">
-                  <description>Use this Stratagem in any phase, when an ADEPTUS CUSTODES TERMINATOR unit from your army is selected as the target of an attack. Until the end of that phase, when resolving an attack against that unit, an Armour Penetration characteristic of -1 or -2 is resolved as 0 forthat attack.</description>
+                  <description>Use this Stratagem in any phase, when an ADEPTUS CUSTODES TERMINATOR unit from your army is selected as the target of an attack. Until the end of that phase, when resolving an attack against that unit, an Armour Penetration characteristic of -1 or -2 is resolved as 0 for that attack.</description>
                 </rule>
               </rules>
               <costs>
@@ -5639,7 +5639,7 @@
               </constraints>
               <rules>
                 <rule id="bab0-17b2-e77d-6d9d" name="The Emperor&apos;s Auspice - 2 CP" hidden="false">
-                  <description>Use this Stratagem in any phase, when an ADEPTUS CUSTODES unit from your army is chosen as the target of an attack. Until the end of that phase, when resolving an attack against that  unit, your opponent cannot re-roll any dice forthat attack.</description>
+                  <description>Use this Stratagem in any phase, when an ADEPTUS CUSTODES unit from your army is chosen as the target of an attack. Until the end of that phase, when resolving an attack against that  unit, your opponent cannot re-roll any dice for that attack.</description>
                 </rule>
               </rules>
               <costs>
@@ -6199,7 +6199,7 @@ can shoot with Rapid Fire weapons in the following Shooting phase, but must subt
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7110-9d58-d2b2-3a46" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="b0d5-c6c9-b500-78af" name="Fulminaris Agressor" hidden="true" collective="false" import="true" targetId="7954-c01e-89bc-934e" type="selectionEntry">
+        <entryLink id="b0d5-c6c9-b500-78af" name="Fulminaris Aggressor" hidden="true" collective="false" import="true" targetId="7954-c01e-89bc-934e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditionGroups>


### PR DESCRIPTION
The beefy Golden protectors get some typo fixes.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.