### PR TITLE
Fix: Typos - Astra Militarum

### DIFF
--- a/Imperium - Astra Militarum - Library.cat
+++ b/Imperium - Astra Militarum - Library.cat
@@ -168,7 +168,7 @@
     <categoryEntry id="988d-d531-0786-58e5" name="Minotaur Artillery Tank" hidden="false"/>
     <categoryEntry id="9db7-2732-6040-c8cd" name="Praetor Armoured Assault Launcher" hidden="false"/>
     <categoryEntry id="c00b-3ffa-0dbc-5154" name="Valdor Tank Hunter" hidden="false"/>
-    <categoryEntry id="0868-3c14-2ea8-1bb6" name="Aquilla Lander" hidden="false"/>
+    <categoryEntry id="0868-3c14-2ea8-1bb6" name="Aquila Lander" hidden="false"/>
     <categoryEntry id="60e2-c8b4-b12b-dd19" name="Arvus Lighter" hidden="false"/>
     <categoryEntry id="beae-1001-7eb5-022e" name="Avenger Strike Fighter" hidden="false"/>
     <categoryEntry id="4a15-0047-cc37-44f7" name="Lightning Strike Fighter" hidden="false"/>
@@ -190,7 +190,7 @@
     <categoryEntry id="74be-b4fc-4598-9bec" name="Tech-Priest" hidden="false"/>
     <categoryEntry id="8622-427c-c483-290f" name="Enginseer" hidden="false"/>
     <categoryEntry id="d3aa-1901-9278-2e3d" name="Servitors" hidden="false"/>
-    <categoryEntry id="28fb-0206-d32a-1fea" name="Orgyn Bodyguard" hidden="false"/>
+    <categoryEntry id="28fb-0206-d32a-1fea" name="Ogryn Bodyguard" hidden="false"/>
     <categoryEntry id="9ef3-50ee-426d-597b" name="Sly Marbo" hidden="false"/>
     <categoryEntry id="9f85-8aad-750e-ccad" name="Ratling" hidden="false"/>
     <categoryEntry id="7ad6-765f-9f57-3049" name="Rein" hidden="false"/>
@@ -617,7 +617,7 @@
             </entryLink>
             <entryLink id="095a-fb52-6022-e2da" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
             <entryLink id="de17-981d-4356-3ba1" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-            <entryLink id="1fb8-4353-3043-1ad3" name="Advanced Counter-measures" hidden="false" collective="false" import="true" targetId="98ef-33e0-c9ec-a8ac" type="selectionEntry"/>
+            <entryLink id="1fb8-4353-3043-1ad3" name="Advanced Countermeasures" hidden="false" collective="false" import="true" targetId="98ef-33e0-c9ec-a8ac" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="105.0"/>
@@ -2301,7 +2301,7 @@
         </profile>
         <profile id="5591-8f10-90c6-ccf6" name="Repair" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of each of the Thunderbolt Heavy Fighter&apos;s Shooting phases, roll a dice. On a 6+, it immediatley regains a single wound lost earlier in the battle.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of each of the Thunderbolt Heavy Fighter&apos;s Shooting phases, roll a dice. On a 6+, it immediately regains a single wound lost earlier in the battle.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -2910,7 +2910,7 @@
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4bf-50da-6f22-27e4" type="max"/>
           </constraints>
           <profiles>
-            <profile id="f3d0-32b7-e14b-c13e" name="Collossus Bombard" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+            <profile id="f3d0-32b7-e14b-c13e" name="Colossus Bombard" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
               <characteristics>
                 <characteristic name="M" typeId="0bdf-a96e-9e38-7779">*</characteristic>
                 <characteristic name="WS" typeId="e7f0-1278-0250-df0c">6+</characteristic>
@@ -2923,7 +2923,7 @@
                 <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
               </characteristics>
             </profile>
-            <profile id="2137-fc72-a85f-f93e" name="Collossus Bombard 1" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
+            <profile id="2137-fc72-a85f-f93e" name="Colossus Bombard 1" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
               <characteristics>
                 <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">6-12+</characteristic>
                 <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">8&quot;</characteristic>
@@ -2931,7 +2931,7 @@
                 <characteristic name="Attacks" typeId="2e64-2e5c-f4d1-52d3">3</characteristic>
               </characteristics>
             </profile>
-            <profile id="dd30-5d94-ecec-c785" name="Collossus Bombard 2" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
+            <profile id="dd30-5d94-ecec-c785" name="Colossus Bombard 2" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
               <characteristics>
                 <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">3-5</characteristic>
                 <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">6&quot;</characteristic>
@@ -2939,7 +2939,7 @@
                 <characteristic name="Attacks" typeId="2e64-2e5c-f4d1-52d3">D3</characteristic>
               </characteristics>
             </profile>
-            <profile id="12ed-a988-1715-6e37" name="Collossus Bombard 3" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
+            <profile id="12ed-a988-1715-6e37" name="Colossus Bombard 3" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
               <characteristics>
                 <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">1-2</characteristic>
                 <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">4&quot;</characteristic>
@@ -3009,7 +3009,7 @@
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During deployment, you can set this unit up underground instead of placing it on the battlefield. At the end of any of your Movement phases, this unit may drill up from the ground and into battle - set it up anywhere on the battlefield that is more than 9&quot; away from enemy models.</characteristic>
           </characteristics>
         </profile>
-        <profile id="1fc8-b024-e2a1-0dff" name="Seperate Orders" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+        <profile id="1fc8-b024-e2a1-0dff" name="Separate Orders" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The first time this unit is set up, the Hades Breaching Drill Squadron must be deployed as a single group with each model within 2&quot; of at least one other model from their unit. From that point on, the Hades Breaching Drill operates independently from the unit of Veterans and both are treated as separate units for all rules purposes.</characteristic>
           </characteristics>
@@ -3958,7 +3958,7 @@
         </profile>
         <profile id="26c6-c7be-4162-b051" name="Artillery Battery" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">An Earthshaker Carriage Battery and it&apos;s Guardsmen Crew must be deployed as a single group within 3&quot; of each other, and must remain within this distance throughout the battle, but are otherwise treated a separate units. The Guardsmen Crew may only be chosen as a targe in the Shooting phase if they are the closest visible unit to the model that is shooting.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">An Earthshaker Carriage Battery and it&apos;s Guardsmen Crew must be deployed as a single group within 3&quot; of each other, and must remain within this distance throughout the battle, but are otherwise treated a separate units. The Guardsmen Crew may only be chosen as a target in the Shooting phase if they are the closest visible unit to the model that is shooting.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5258,7 +5258,7 @@
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="bc4a-00cb-1d77-021b" name="Titanic Expolsion" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+        <profile id="bc4a-00cb-1d77-021b" name="Titanic Explosion" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield. On a 4+ it explodes, and each unit within 2D6&quot; suffers D6 mortal wounds.</characteristic>
           </characteristics>
@@ -5450,7 +5450,7 @@
                     <characteristic name="S" typeId="59b1-319e-ec13-d466">10</characteristic>
                     <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
                     <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
-                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. When Attacking a BUILDING, increas the weapon&apos;s damage to D6</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. When Attacking a BUILDING, increase the weapon&apos;s damage to D6</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="f9fa-7265-7c47-24e0" name="Medusa Siege Gun Standard Shells" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -6112,7 +6112,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9428-029e-4bcd-939b" name="WT (Armadeggon): Ex-gang Leader" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="9428-029e-4bcd-939b" name="WT (Armageddon): Ex-gang Leader" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c738-53b8-43e6-56e5" type="max"/>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1bc9-f5f8-91fa-d7f0" type="max"/>
@@ -6200,7 +6200,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ee13-f7d3-c9f0-85ba" name="WT (Millitarum Tempestus): Faithful Servant of the Throne" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="ee13-f7d3-c9f0-85ba" name="WT (Militarum Tempestus): Faithful Servant of the Throne" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddfe-35ee-19a3-a89f" type="max"/>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="8329-d003-b472-3b9c" type="max"/>
@@ -6225,7 +6225,7 @@
       <profiles>
         <profile id="036e-7654-e46f-4da7" name="Parade Drill" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If the base of every model in an INFANTRY unit with this doctrine is touching the base of at least one other model from the same unit, the unit has +1 Leadership and you can add 1 to hit rolls made for models in that unit when firing Overwatch. You can add 1 to hit rolls made for VEHICLES with this doctrine when firing Overwatch if they are within 3&quot; of one or more other friendly MORDIAN VEHICLES. These modifers to hit rolls are an exception to the normal rules which do not allow modifers when making Overwatch shots – in such cases a result of 7 is also a successful hit.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If the base of every model in an INFANTRY unit with this doctrine is touching the base of at least one other model from the same unit, the unit has +1 Leadership and you can add 1 to hit rolls made for models in that unit when firing Overwatch. You can add 1 to hit rolls made for VEHICLES with this doctrine when firing Overwatch if they are within 3&quot; of one or more other friendly MORDIAN VEHICLES. These modifiers to hit rolls are an exception to the normal rules which do not allow modifiers when making Overwatch shots – in such cases a result of 7 is also a successful hit.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -6800,7 +6800,7 @@
       <profiles>
         <profile id="c670-76a8-4da6-0a56" name="Relic (55th Kappic Eagles): Distraction Charges" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“55TH KAPPIC EAGLESmodel only. When resolving an Overwatch attack made by a friendly 55TH KAPPIC EAGLES model within 3&quot; of a model with this Relic, if that attack scores a hit, the target is slowed until the end of the phase. When a charge roll is made for a slowed unit, halve the result (rounding up)”</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“55TH KAPPIC EAGLES model only. When resolving an Overwatch attack made by a friendly 55TH KAPPIC EAGLES model within 3&quot; of a model with this Relic, if that attack scores a hit, the target is slowed until the end of the phase. When a charge roll is made for a slowed unit, halve the result (rounding up)”</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -6829,7 +6829,7 @@
       <profiles>
         <profile id="4ccd-9982-617d-56bc" name="Relic (43rd Iotan Dragons): Emperor&apos;s Fury" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“43RD IOTAN DRAGONSmodel equipped with a plasma pistol only. This Relic replaces a plasma pistol and has the following profile:</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“43RD IOTAN DRAGONS model equipped with a plasma pistol only. This Relic replaces a plasma pistol and has the following profile:</characteristic>
           </characteristics>
         </profile>
         <profile id="183f-3840-b537-6dc1" name="Relic (43rd Iotan Dragons): Emperor&apos;s Fury Standard" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -6878,7 +6878,7 @@
       <profiles>
         <profile id="f755-eac3-3799-5361" name="Relic (133rd Lambdan Lions): Refractor Field Generator" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“33RD LAMBDAN LIONSmodel only. Friendly 133RD LAMBDAN LIONSmodels have a 5+ invulnerable save whilst within 6&quot; of a model from your army with this Relic.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“33RD LAMBDAN LIONS model only. Friendly 133RD LAMBDAN LIONS models have a 5+ invulnerable save whilst within 6&quot; of a model from your army with this Relic.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -6907,7 +6907,7 @@
       <profiles>
         <profile id="731f-aa25-d1eb-9e2c" name="Relic (32nd Thetoid Eagles): Fire of Judgement" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“32ND THETOID EAGLESmodel equipped with a hot-shot laspistol only. This Relic replaces a hot-shot laspistol and has the following profile:</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“32ND THETOID EAGLES model equipped with a hot-shot laspistol only. This Relic replaces a hot-shot laspistol and has the following profile:</characteristic>
           </characteristics>
         </profile>
         <profile id="9de7-9f45-f63a-7d89" name="Relic (32nd Thetoid Eagles): Fire of Judgement" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -6974,7 +6974,7 @@
       <profiles>
         <profile id="7ead-0584-e7b2-06ae" name="Precision Targeting" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“At the start of your Shooting phase, select one enemy unit within 18&quot; of this Warlord. Until the end of that phase, when resolving an attack made by a friendly 43RD IOTAN DRAGONSmodel whilst its unit is within 6&quot; of this Warlord, that enemy unit does not receive the benefit of cover.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“At the start of your Shooting phase, select one enemy unit within 18&quot; of this Warlord. Until the end of that phase, when resolving an attack made by a friendly 43RD IOTAN DRAGONS model whilst its unit is within 6&quot; of this Warlord, that enemy unit does not receive the benefit of cover.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7010,7 +7010,7 @@
       <profiles>
         <profile id="afb3-7541-5818-22f3" name="Master Vox" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“When using this Warlord’s Voice of Command ability, it can issue orders to friendly 55TH KAPPIC EAGLES INFANTRYunits within 24&quot;. In addition, while this Warlord is embarked within a TRANSPORTmodel it can still use its Voice of Command ability; when doing so, make any measurements from that TRANSPORTmodel’s hull.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“When using this Warlord’s Voice of Command ability, it can issue orders to friendly 55TH KAPPIC EAGLES INFANTRYunits within 24&quot;. In addition, while this Warlord is embarked within a TRANSPORTmodel it can still use its Voice of Command ability; when doing so, make any measurements from that TRANSPORT model’s hull.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7046,7 +7046,7 @@
       <profiles>
         <profile id="91db-efbb-d248-3c20" name="Uncompromising Prosecution" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“When resolving an attack made with a hot-shot lasgun, hot-shot laspistol or hot-shot volley gun by a friendly 32ND THETOID EAGLESmodel whilst within 6&quot; of this Warlord, on an unmodified wound roll of 6 that weapon has an Armour Penetration characteristic of -4 for that attack.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“When resolving an attack made with a hot-shot lasgun, hot-shot laspistol or hot-shot volley gun by a friendly 32ND THETOID EAGLES model whilst within 6&quot; of this Warlord, on an unmodified wound roll of 6 that weapon has an Armour Penetration characteristic of -4 for that attack.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7443,7 +7443,7 @@
       <profiles>
         <profile id="234d-e7ff-165f-ab26" name="Master of Command" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Your Warlord gains the Voice of Command ability. If your Warlord already has the Voice of Command or Tank Orders ability, they may instead issue one additional order per turn. If your Warlord is a COMMISSAR, it can issue an order to any &lt; REGIMENT&gt; INFANTRY unit (irrespective of what regiment that unit is from – e.g. MIILITARUM TEMPESTUS, CADIAN, etc.)</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Your Warlord gains the Voice of Command ability. If your Warlord already has the Voice of Command or Tank Orders ability, they may instead issue one additional order per turn. If your Warlord is a COMMISSAR, it can issue an order to any &lt; REGIMENT&gt; INFANTRY unit (irrespective of what regiment that unit is from – e.g. MILITARUM TEMPESTUS, CADIAN, etc.)</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7489,13 +7489,13 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4935-363e-6a5d-adb7" name="WT: Draconian Disiplinarian" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="4935-363e-6a5d-adb7" name="WT: Draconian Disciplinarian" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3240-6a2f-a56d-1f72" type="max"/>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34e5-532e-f167-cee0" type="max"/>
       </constraints>
       <profiles>
-        <profile id="cd3c-5d13-88a9-3013" name="Draconian Disiplinarian" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+        <profile id="cd3c-5d13-88a9-3013" name="Draconian Disciplinarian" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You can re-roll failed Morale tests for friendly ASTRA MILITARUM INFANTRY units within 6&quot; of your Warlord in the Morale phase.</characteristic>
           </characteristics>
@@ -7553,7 +7553,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="-1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="98ef-33e0-c9ec-a8ac" name="Advanced Counter-measures" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="98ef-33e0-c9ec-a8ac" name="Advanced Countermeasures" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -7565,7 +7565,7 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15b4-dcb4-00d4-5cad" type="max"/>
       </constraints>
       <profiles>
-        <profile id="46ae-3908-447e-c758" name="Advanced Counter-measures" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+        <profile id="46ae-3908-447e-c758" name="Advanced Countermeasures" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“Use this Stratagem before the battle. Select one VALKYRIE model from your army. When you declare that model will hover, it does not lose the Hard to Hit ability.</characteristic>
           </characteristics>
@@ -8411,7 +8411,7 @@
               <characteristics>
                 <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">7</characteristic>
                 <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">18&quot;</characteristic>
-                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Select an enemy unit within 18&quot; of the psyker. Roll at D6. On a 2+, that unit suffers a mortal wound. Unless this mortal wound is negated, you can ten roll another die. On a 3+ that enemy unit suffers another mortal wound. Continue this process, adding 1 to the die roll required each time (so the next roll would need a 4+, than 5+, etc.) until you fail to cause a mortal wound, or the enemy unit is destroyed.</characteristic>
+                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Select an enemy unit within 18&quot; of the psyker. Roll a D6. On a 2+, that unit suffers a mortal wound. Unless this mortal wound is negated, you can ten roll another die. On a 3+ that enemy unit suffers another mortal wound. Continue this process, adding 1 to the die roll required each time (so the next roll would need a 4+, than 5+, etc.) until you fail to cause a mortal wound, or the enemy unit is destroyed.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -8657,7 +8657,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27cc-1afc-b3b6-8509" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="ada3-47da-f11c-9e57" name="WT (Armadeggon): Ex-gang Leader" hidden="false" collective="false" import="true" targetId="9428-029e-4bcd-939b" type="selectionEntry">
+            <entryLink id="ada3-47da-f11c-9e57" name="WT (Armageddon): Ex-gang Leader" hidden="false" collective="false" import="true" targetId="9428-029e-4bcd-939b" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditionGroups>
@@ -8713,7 +8713,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="291d-e257-0e95-3d42" name="WT (Millitarum Tempestus): Faithful Servant of the Throne" hidden="false" collective="false" import="true" targetId="ee13-f7d3-c9f0-85ba" type="selectionEntry">
+            <entryLink id="291d-e257-0e95-3d42" name="WT (Militarum Tempestus): Faithful Servant of the Throne" hidden="false" collective="false" import="true" targetId="ee13-f7d3-c9f0-85ba" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -8940,7 +8940,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="e4b8-f2eb-3b50-d513" name="WT: Draconian Disiplinarian" hidden="false" collective="false" import="true" targetId="4935-363e-6a5d-adb7" type="selectionEntry"/>
+            <entryLink id="e4b8-f2eb-3b50-d513" name="WT: Draconian Disciplinarian" hidden="false" collective="false" import="true" targetId="4935-363e-6a5d-adb7" type="selectionEntry"/>
             <entryLink id="a0de-19f3-5675-6257" name="WT: Grand Strategist" hidden="false" collective="false" import="true" targetId="9f7a-4c34-8d0c-e3c7" type="selectionEntry"/>
             <entryLink id="55e1-ce4a-202a-b8a0" name="WT: Implacable Determination" hidden="false" collective="false" import="true" targetId="75b8-5f2d-9f0c-fbb5" type="selectionEntry"/>
             <entryLink id="be2b-ae93-c886-91b4" name="WT: Master of Command" hidden="false" collective="false" import="true" targetId="4a25-7a1d-4442-3728" type="selectionEntry"/>
@@ -9077,13 +9077,13 @@
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68b3-fcaa-2f3f-a9f5" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="df5b-f9c6-5d13-5273" name="Diciplined Shooters" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="df5b-f9c6-5d13-5273" name="Disciplined Shooters" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a647-a9e2-ab11-63aa" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bf0-3991-b43c-e500" type="max"/>
           </constraints>
           <profiles>
-            <profile id="172b-9763-01ea-6231" name="Diciplined Shooters" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+            <profile id="172b-9763-01ea-6231" name="Disciplined Shooters" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
                 <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“When an INFANTRYmodel with this doctrine shoots with a Rapid Fire weapon against a unit that is within 18&quot;, double the number of attacks that weapon makes, rather than following the normal rules for Rapid Fire weapons.</characteristic>
               </characteristics>
@@ -10059,7 +10059,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8eec-af87-7364-6459" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="ed13-5ac3-a3c9-3e21" name="WT (Armadeggon): Ex-gang Leader" hidden="false" collective="false" import="true" targetId="9428-029e-4bcd-939b" type="selectionEntry">
+            <entryLink id="ed13-5ac3-a3c9-3e21" name="WT (Armageddon): Ex-gang Leader" hidden="false" collective="false" import="true" targetId="9428-029e-4bcd-939b" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditionGroups>
@@ -10115,7 +10115,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="92d0-a6d8-153b-79b3" name="WT (Millitarum Tempestus): Faithful Servant of the Throne" hidden="false" collective="false" import="true" targetId="ee13-f7d3-c9f0-85ba" type="selectionEntry">
+            <entryLink id="92d0-a6d8-153b-79b3" name="WT (Militarum Tempestus): Faithful Servant of the Throne" hidden="false" collective="false" import="true" targetId="ee13-f7d3-c9f0-85ba" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -10345,7 +10345,7 @@
             <entryLink id="dd04-6f38-3e22-6844" name="WT: Grand Strategist" hidden="false" collective="false" import="true" targetId="9f7a-4c34-8d0c-e3c7" type="selectionEntry"/>
             <entryLink id="3923-3cf0-3945-68fb" name="WT: Implacable Determination" hidden="false" collective="false" import="true" targetId="75b8-5f2d-9f0c-fbb5" type="selectionEntry"/>
             <entryLink id="0e4f-2060-a6c1-e185" name="WT: Master of Command" hidden="false" collective="false" import="true" targetId="4a25-7a1d-4442-3728" type="selectionEntry"/>
-            <entryLink id="4e79-37ad-cf0a-f866" name="WT: Draconian Disiplinarian" hidden="false" collective="false" import="true" targetId="4935-363e-6a5d-adb7" type="selectionEntry"/>
+            <entryLink id="4e79-37ad-cf0a-f866" name="WT: Draconian Disciplinarian" hidden="false" collective="false" import="true" targetId="4935-363e-6a5d-adb7" type="selectionEntry"/>
             <entryLink id="f52e-eaf7-b518-a427" name="WT: Old Grudges" hidden="false" collective="false" import="true" targetId="43d2-fba4-4e96-a8d3" type="selectionEntry"/>
             <entryLink id="27a4-fd77-5cd0-6233" name="WT: Bellowing Voice" hidden="false" collective="false" import="true" targetId="2b95-ca70-0ccd-7118" type="selectionEntry"/>
           </entryLinks>
@@ -10376,7 +10376,7 @@ Spirit of the Martyr: One model in the unit recovers D3 lost wounds, or you can 
       <description>When selecting this unit for your army, choose which forgeworld it will be from. This replaces the &lt;FORGEWORLD&gt; keyword in all instances on this datasheet.</description>
     </rule>
     <rule id="11ec-3914-8daa-53bb" name="Avalanche of Muscle" publicationId="53e9d88f--pubN88319" page="102" hidden="false">
-      <description>youcan add 1 to the Attacks characteristic of thie model in the Fight phase on any turn in which it made a successful charge. This ability may only be used the first time this model fights each turn.</description>
+      <description>You can add 1 to the Attacks characteristic of this model in the Fight phase on any turn in which it made a successful charge. This ability may only be used the first time this model fights each turn.</description>
     </rule>
     <rule id="e30b-1b04-2edf-2e9d" name="Crash and Burn" hidden="false">
       <description>If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield and before any embarked models disembark. On a 6 it crashes in a fiery explosion and each unit within 6&quot; suffers D3 mortal wounds.</description>
@@ -10385,7 +10385,7 @@ Spirit of the Martyr: One model in the unit recovers D3 lost wounds, or you can 
       <description>Models may disembark from this vehicle at any point during its move, but if the Valkyrie moves more than 20&quot;, you must roll a D6 for each model disembarking. On a 1, that model is slain.  Models that disembark in this manner must be set up more than 9&quot; from any enemy models.</description>
     </rule>
     <rule id="c46f-e0d9-1e78-b49c" name="Supersonic" hidden="false">
-      <description>Each time this model moves, first pivot it on the spot up to 90&quot; (this does not contribute to how far the model moves), and then move the model straight forwards. Note that it cannot pivot again after the initial pivot. When this model Advances,  increase it&apos;s Move characteristic by 20&quot; until the end of the phase - do not roll a dice.</description>
+      <description>Each time this model moves, first pivot it on the spot up to 90&quot; (this does not contribute to how far the model moves), and then move the model straight forwards. Note that it cannot pivot again after the initial pivot. When this model Advances,  increase its Move characteristic by 20&quot; until the end of the phase - do not roll a dice.</description>
     </rule>
     <rule id="7338-205d-7e1d-3795" name="Vehicle Squadron" hidden="false">
       <description>The first time this unit is set up, all models in this unit must be placed within 6&quot; of each other.  From that point onwards, each operates independently and is treated as a separate unit for all rules purposes.</description>
@@ -10394,10 +10394,10 @@ Spirit of the Martyr: One model in the unit recovers D3 lost wounds, or you can 
       <description>This model can transport 12 ASTRA MiLITARUM INFANTRY models. Each Heavy Weapons Team or Veteran Heavy Weapons Team takes the place of two other models and each OGRYN takes the space of three other models.</description>
     </rule>
     <rule id="873e-055d-949a-9751" name="Hard to Hit" hidden="false">
-      <description>Before this model moves in your Movement phase, you can declare it will hover. It&apos;s Move characteristic becomes 20&quot; until the end of the phase, and it loses the Airborne, Hard to Hit and Supersonic abilities until the beginntng of your next Movement phase.</description>
+      <description>Before this model moves in your Movement phase, you can declare it will hover. It&apos;s Move characteristic becomes 20&quot; until the end of the phase, and it loses the Airborne, Hard to Hit and Supersonic abilities until the beginning of your next Movement phase.</description>
     </rule>
     <rule id="a728-aac7-2070-f702" name="Hover Jet" hidden="false">
-      <description>Before this model moves in your Movement phase, you can declare it will hover. It&apos;s Move characteristic becomes 20&quot; until the end of the phase, and it loses the Airborne, Hard to Hit and Supersonic abilities until the beginntng of your next Movement phase.</description>
+      <description>Before this model moves in your Movement phase, you can declare it will hover. It&apos;s Move characteristic becomes 20&quot; until the end of the phase, and it loses the Airborne, Hard to Hit and Supersonic abilities until the beginning of your next Movement phase.</description>
     </rule>
     <rule id="681d-8707-d8ee-8034" name="Roving Gunship" hidden="false">
       <description>If this model hovers in its Movement phase, add 1 to all hit rolls made for it in the following Shooting phase.</description>
@@ -10572,7 +10572,7 @@ Spirit of the Martyr: One model in the unit recovers D3 lost wounds, or you can 
     </profile>
     <profile id="5c2d-ef21-5078-d479" name="Hover Jet" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Before this model moves in your Movement phase, you can declare it will hover. It&apos;s Move characteristic becomes 20&quot; until the end of the phase, and it loses the Airborne, Hard to Hit and Supersonic abilities until the beginntng of your next Movement phase.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Before this model moves in your Movement phase, you can declare it will hover. It&apos;s Move characteristic becomes 20&quot; until the end of the phase, and it loses the Airborne, Hard to Hit and Supersonic abilities until the beginning of your next Movement phase.</characteristic>
       </characteristics>
     </profile>
     <profile id="16e3-4e72-d831-8647" name="Strafing Run" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -10582,7 +10582,7 @@ Spirit of the Martyr: One model in the unit recovers D3 lost wounds, or you can 
     </profile>
     <profile id="2268-18ce-3bf2-b68d" name="Supersonic" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time this model moves, first pivot it on the spot up to 90&quot; (this does not contribute to how far the model moves), and then move the model straight forwards. Note that it cannot pivot again after the initial pivot. When this model Advances,  increase it&apos;s Move characteristic by 20&quot; until the end of the phase - do not roll a dice.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time this model moves, first pivot it on the spot up to 90&quot; (this does not contribute to how far the model moves), and then move the model straight forwards. Note that it cannot pivot again after the initial pivot. When this model Advances,  increase its Move characteristic by 20&quot; until the end of the phase - do not roll a dice.</characteristic>
       </characteristics>
     </profile>
     <profile id="390d-68dd-fa2b-5eb1" name="Hellstrike Missile" publicationId="53e9d88f--pubN88319" page="0" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -10684,7 +10684,7 @@ make attacks against eligible enemy units that are not within Engagement Range o
     </profile>
     <profile id="69cd-7f66-0f86-718b" name="Artillery Tractor" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model starts its move within 1&quot; of a friendly ASTRA MILITARUM ARTILLERY model, it can choose to tow it so long as neither this model nor the ARTILLERY model is within 1&quot; of an enemy model. If it does this, this model immediately makes a move of up to 12&quot; The ARTILLERY model is then placed anywhere withing 1&quot; of this model so that no part of the ARTILLERY model has moved more than 12&quot; from where it started. An ARTILLERY model that has been towed may not fire its weapons during the Shooting phase of the same turn.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model starts its move within 1&quot; of a friendly ASTRA MILITARUM ARTILLERY model, it can choose to tow it so long as neither this model nor the ARTILLERY model is within 1&quot; of an enemy model. If it does this, this model immediately makes a move of up to 12&quot; The ARTILLERY model is then placed anywhere within 1&quot; of this model so that no part of the ARTILLERY model has moved more than 12&quot; from where it started. An ARTILLERY model that has been towed may not fire its weapons during the Shooting phase of the same turn.</characteristic>
       </characteristics>
     </profile>
     <profile id="e519-9694-6fbe-2bab" name="Explodes (6+/2D6&quot;/D3)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -10694,7 +10694,7 @@ make attacks against eligible enemy units that are not within Engagement Range o
     </profile>
     <profile id="e807-fc4d-8f8a-81fe" name="Co-axial Weapon" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If during the same Shooting phase this model shoots it&apos;s Main gun at the same target as it&apos;s co-axial weapon, it may reroll any hit rolls with it&apos;s Main Gun.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If during the same Shooting phase this model shoots its Main gun at the same target as it&apos;s co-axial weapon, it may re-roll any hit rolls with its Main Gun.</characteristic>
       </characteristics>
     </profile>
     <profile id="6338-ae1c-93c9-2e89" name="Scout Vehicle" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -10729,7 +10729,7 @@ make attacks against eligible enemy units that are not within Engagement Range o
     </profile>
     <profile id="8235-431f-3816-c532" name="Artillery Battery (Sabre)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The first time this unit is set up, all moidels in this unit must be placed within 6&quot; of each other. From that point onwards, each operates independently and is treated as a separate unit for all rules purposes.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The first time this unit is set up, all models in this unit must be placed within 6&quot; of each other. From that point onwards, each operates independently and is treated as a separate unit for all rules purposes.</characteristic>
       </characteristics>
     </profile>
     <profile id="017f-29b9-fbf3-10e8" name="Zealot" publicationId="53e9d88f--pubN88319" page="99" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">

--- a/Imperium - Astra Militarum.cat
+++ b/Imperium - Astra Militarum.cat
@@ -740,7 +740,7 @@
         <categoryLink id="e92f-7b8e-b9cc-a8d2" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7ac3-b480-17d0-892e" name="Aquilla Lander" hidden="false" collective="false" import="true" targetId="c96d-e27b-69a5-e42b" type="selectionEntry">
+    <entryLink id="7ac3-b480-17d0-892e" name="Aquila Lander" hidden="false" collective="false" import="true" targetId="c96d-e27b-69a5-e42b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5b59-381e-c559-a6ee" name="New CategoryLink" hidden="false" targetId="2135-9abb-5c57-5391" primary="false"/>
         <categoryLink id="a783-c8fc-79f7-ffc9" name="New CategoryLink" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false"/>
@@ -1321,7 +1321,7 @@
         <categoryLink id="7a26-87ff-ea97-7859" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="bd61-4342-404e-f96a" name="Collossus Bombard" hidden="false" collective="false" import="true" targetId="05af-872f-e4ab-aba9" type="selectionEntry">
+    <entryLink id="bd61-4342-404e-f96a" name="Colossus Bombard" hidden="false" collective="false" import="true" targetId="05af-872f-e4ab-aba9" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -1734,7 +1734,7 @@
         <categoryLink id="467d-2223-6a99-351b" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5263-f558-d4a1-b271" name="Stygies Thunderer Seige Tank" hidden="false" collective="false" import="true" targetId="17b0-32eb-49b5-41c4" type="selectionEntry">
+    <entryLink id="5263-f558-d4a1-b271" name="Stygies Thunderer Siege Tank" hidden="false" collective="false" import="true" targetId="17b0-32eb-49b5-41c4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -2215,7 +2215,7 @@
         </profile>
         <profile id="3da9-3795-a0e7-6c37" name="Power Field" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Commisar Yarrick has a 4+ invulnerable save.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Commissar Yarrick has a 4+ invulnerable save.</characteristic>
           </characteristics>
         </profile>
         <profile id="7c0d-e994-6252-7d93" name="Hero of Hades Hive" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -3065,7 +3065,7 @@
         </profile>
         <profile id="15a5-a67e-f4d5-13f8" name="Supreme Commander" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Lord Castellan Creed&apos;s Voice of Command ability has a range of 12&quot;, and he may use this abililty three times in each of your turns. Resolve the effects of the first order before issuing the second order, and so on.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Lord Castellan Creed&apos;s Voice of Command ability has a range of 12&quot;, and he may use this ability three times in each of your turns. Resolve the effects of the first order before issuing the second order, and so on.</characteristic>
           </characteristics>
         </profile>
         <profile id="d20a-0e3f-32fe-9ab4" name="Tactical Genius" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -4932,7 +4932,7 @@
             </profile>
           </profiles>
           <selectionEntries>
-            <selectionEntry id="c532-019c-cbf0-3479" name="Wyven Quad Stormshard Mortar" page="0" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="c532-019c-cbf0-3479" name="Wyvern Quad Stormshard Mortar" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7e9e-5424-e8f9-c6d3" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e916-43d4-41fc-e17e" type="max"/>
@@ -9533,9 +9533,9 @@
             <characteristic name="Other" typeId="c2e2-f115-0003-5d7b"/>
           </characteristics>
         </profile>
-        <profile id="8687-a80d-ec29-9f1d" name="Astral Devination" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+        <profile id="8687-a80d-ec29-9f1d" name="Astral Divination" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the start of your Shooting phase, pick and enemy unit within 18&quot; of this model. For the duration of the phase, the unit you picked gains no bonus to ther saving throws for being in cover when it is targeted by attacks made by friendly ASTRA MILITARUM units within 6&quot; of this model.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the start of your Shooting phase, pick and enemy unit within 18&quot; of this model. For the duration of the phase, the unit you picked gains no bonus to their saving throws for being in cover when it is targeted by attacks made by friendly ASTRA MILITARUM units within 6&quot; of this model.</characteristic>
           </characteristics>
         </profile>
         <profile id="a84e-b874-ee16-cc43" name="Telepathic Assault" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -9720,7 +9720,7 @@
             <characteristic name="Cast" typeId="5afb-9914-904b-d3b3">1</characteristic>
             <characteristic name="Deny" typeId="b5ac-9c20-5d5a-6f9b">1</characteristic>
             <characteristic name="Powers Known" typeId="69d7-b45e-00a2-7e46">Smite &amp; 1 Psykana</characteristic>
-            <characteristic name="Other" typeId="c2e2-f115-0003-5d7b">When manifesting or denying a psychic power, first select a model in this unit -- measure range, visibility, etc. from this model. If this unit sufferes Perils of the Warp, it suffers D3 mortal wounds as described in the core rules, but units within 6&quot; will only suffer damage if the Perfils of the Warp causes the last model in the manifesting unit to be slain.</characteristic>
+            <characteristic name="Other" typeId="c2e2-f115-0003-5d7b">When manifesting or denying a psychic power, first select a model in this unit -- measure range, visibility, etc. from this model. If this unit suffers Perils of the Warp, it suffers D3 mortal wounds as described in the core rules, but units within 6&quot; will only suffer damage if the Perfils of the Warp causes the last model in the manifesting unit to be slain.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -10414,7 +10414,7 @@
         </profile>
         <profile id="14de-10a6-51ad-bbc0" name="Like Fighting a Shadow" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per battle, at the start of any of your Movement phases, Sly Marbo can disappear as long as there are no enemy models within 6&quot; of him. If he does, remove him from the battlefield. At the end of your next Movement phase he reappears using the Lethal Ambush abillty.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per battle, at the start of any of your Movement phases, Sly Marbo can disappear as long as there are no enemy models within 6&quot; of him. If he does, remove him from the battlefield. At the end of your next Movement phase he reappears using the Lethal Ambush ability.</characteristic>
           </characteristics>
         </profile>
         <profile id="3366-f424-ee27-1bd9" name="Sly Marbo" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -11523,7 +11523,7 @@ Use this Act of Faith at the start of the Morale phase. If successful, the selec
         </profile>
         <profile id="17c2-9359-31e8-2ca9" name="It&apos;s For Your Own Good" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If Aradia Madellan is slain as a result of Perials of the Warp whilst within 6&quot; of a friendly COMMISSAR, she is executed before anything untoward can happen - the power she was attempting to still fails, but units within 6&quot; of her do not suffer D3 mortal wounds as normal.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If Aradia Madellan is slain as a result of Perils of the Warp whilst within 6&quot; of a friendly COMMISSAR, she is executed before anything untoward can happen - the power she was attempting to still fails, but units within 6&quot; of her do not suffer D3 mortal wounds as normal.</characteristic>
           </characteristics>
         </profile>
         <profile id="6ba7-7f4f-9315-0f41" name="Aradia Madellan" hidden="false" typeId="bc97-dea9-9e88-bb7d" typeName="Psyker">

--- a/Imperium - Astra Militarum.cat
+++ b/Imperium - Astra Militarum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Astra Militarum" revision="288" battleScribeVersion="2.03" authorName="Jon K, Joe B" authorContact="Discord: @Alphalas, @CrusherJoe | Twitter: @_alphalas, @theawesomesauce" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="152" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Astra Militarum" revision="289" battleScribeVersion="2.03" authorName="Jon K, Joe B" authorContact="Discord: @Alphalas, @CrusherJoe | Twitter: @_alphalas, @theawesomesauce" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="152" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="99a162d9-4854-cc3b-c35e-b0c3a3cc77d6" name="Commissar Yarrick" hidden="false" collective="false" import="true" targetId="1fe0e11a-5174-b4e9-842e-b254870ae161" type="selectionEntry">
       <modifiers>


### PR DESCRIPTION
These typos broke before the guard did.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.