### PR TITLE
Fix: Typos - Blood Angels

### DIFF
--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Adeptus Astartes - Blood Angels" revision="172" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas | Twitter: @_alphalas" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="145" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Adeptus Astartes - Blood Angels" revision="173" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas | Twitter: @_alphalas" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="145" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="eb0f-c144-pubN65537" name="Codex: Blood Angels"/>
   </publications>

--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -104,7 +104,7 @@
     <categoryEntry id="8f14-0336-6baf-6caf" name="Incursor Squad" hidden="false"/>
     <categoryEntry id="1ea7-7a22-27b6-728e" name="Invictor Tactical Warsuit" hidden="false"/>
     <categoryEntry id="9b8a-b228-0dff-7a99" name="Impulsor" hidden="false"/>
-    <categoryEntry id="d3b9-ce80-f151-fa0c" name="Death Company Intersessors" hidden="false"/>
+    <categoryEntry id="d3b9-ce80-f151-fa0c" name="Death Company Intercessors" hidden="false"/>
   </categoryEntries>
   <selectionEntries>
     <selectionEntry id="c95a-52a8-aab7-ab34" name="Lieutenants" hidden="false" collective="false" import="true" type="upgrade">
@@ -5757,7 +5757,7 @@
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1278-58d0-b1cc-1e98" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="a50d-17ad-7f65-8177" name="Sanguinary Disipline" hidden="false" collective="false" import="true" targetId="4827-f579-85b6-064b" type="selectionEntryGroup">
+        <entryLink id="a50d-17ad-7f65-8177" name="Sanguinary Discipline" hidden="false" collective="false" import="true" targetId="4827-f579-85b6-064b" type="selectionEntryGroup">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f30-e191-f058-eb16" type="max"/>
           </constraints>
@@ -5799,7 +5799,7 @@
         <categoryLink id="553e-aec2-672d-65fe" name="New CategoryLink" hidden="false" targetId="df09-a39a-dd33-89f7" primary="false"/>
         <categoryLink id="5ebc-1db6-b038-e1eb" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
         <categoryLink id="670d-4807-3d06-a7b2" name="Faction: Death Company" hidden="false" targetId="b011-7906-1d21-91b1" primary="false"/>
-        <categoryLink id="eb38-d2bf-ff0f-fd88" name="Death Company Intersessors" hidden="false" targetId="d3b9-ce80-f151-fa0c" primary="false"/>
+        <categoryLink id="eb38-d2bf-ff0f-fd88" name="Death Company Intercessors" hidden="false" targetId="d3b9-ce80-f151-fa0c" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="f9c3-3fa5-fe70-b7ad" name="Intercessor" hidden="false" collective="false" import="true" type="model">
@@ -7236,7 +7236,7 @@
               <characteristics>
                 <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">6</characteristic>
                 <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">6&quot;</characteristic>
-                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Select a visible enemy unit within 6&quot; of the psyker and roll 2D6. If the total exceeds tbe highest Toughness characteristic in the target unit, the unit suffers D3 mortal wounds; if the total rolled is more than double that of the highest Toughness characteristic, the unit suffers 3 mortal wounds instead.</characteristic>
+                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Select a visible enemy unit within 6&quot; of the psyker and roll 2D6. If the total exceeds the highest Toughness characteristic in the target unit, the unit suffers D3 mortal wounds; if the total rolled is more than double that of the highest Toughness characteristic, the unit suffers 3 mortal wounds instead.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -7303,7 +7303,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="f1b0-4f0b-1370-3d1b" name="6. Wings of Sanguinus" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="f1b0-4f0b-1370-3d1b" name="6. Wings of Sanguinius" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9a4-126d-01eb-d5f7" type="max"/>
           </constraints>
@@ -9960,7 +9960,7 @@ units, subtract 1 from the Leadership characteristic of each of those enemy unit
     </profile>
     <profile id="4b4e-1b7c-7064-0661" name="Repulsor Field" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Your opponent mut subtract 2 from any charge rolls made for units taht declare a charge against a Repulsor.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Your opponent must subtract 2 from any charge rolls made for units that declare a charge against a Repulsor.</characteristic>
       </characteristics>
     </profile>
     <profile id="ee71-cd55-0219-fae9" name="Auto Launchers" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -10010,7 +10010,7 @@ units, subtract 1 from the Leadership characteristic of each of those enemy unit
     </profile>
     <profile id="c892-d4ec-19b0-7c7c" name="Lord of Death" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a D6 each time Chief Libraian Mephiston loses a wound. On a 5+ the wound is ignored and has no effect.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a D6 each time Chief Librarian Mephiston loses a wound. On a 5+ the wound is ignored and has no effect.</characteristic>
       </characteristics>
     </profile>
     <profile id="a67d-7d3e-07a2-fdd1" name="Redeemer of the Lost" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">


### PR DESCRIPTION
These typos are no match for the Fury of Baal.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.