### PR TITLE
Fix: Typos - Dark Angels

### DIFF
--- a/Imperium - Dark Angels.cat
+++ b/Imperium - Dark Angels.cat
@@ -3532,7 +3532,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
         </profile>
         <profile id="abb3-642e-d7ab-ad7f" name="Hover jet" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Before this model moves in your Movement phase, you can declare it will hover. It&apos;s Movement characteristic becomes 20&quot; until the end of the phase and it looses Airborne, Hard to Hit and Supersonic abilities until the beginning of your next Movement phase.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Before this model moves in your Movement phase, you can declare it will hover. It&apos;s Movement characteristic becomes 20&quot; until the end of the phase and it loses Airborne, Hard to Hit and Supersonic abilities until the beginning of your next Movement phase.</characteristic>
           </characteristics>
         </profile>
         <profile id="fd5e-15ef-eb1c-fd23" name="Stasis bomb" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -4928,7 +4928,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
         </profile>
         <profile id="f35d-e345-22df-6aac" name="The Spiritshield Helm" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When a model in a  friendly DARK ANGELS unit whithin 6&quot; of this model would lose a wound as a result of a mortal wound, roll one D6, adding 1 to the result if it is this model that would lose a wound; on a 5+ that wound is not lost.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When a model in a  friendly DARK ANGELS unit within 6&quot; of this model would lose a wound as a result of a mortal wound, roll one D6, adding 1 to the result if it is this model that would lose a wound; on a 5+ that wound is not lost.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5237,7 +5237,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
       <profiles>
         <profile id="7232-4d8e-1e33-6244" name="Digital Weapons" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When  a model with this Relic fights, it can make 1 additional attack using the close combat weapon profile. Wheln resolving that attack, if a hit is scored the target suffers 1 mortal wound and the attack sequence ends.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When  a model with this Relic fights, it can make 1 additional attack using the close combat weapon profile. When resolving that attack, if a hit is scored the target suffers 1 mortal wound and the attack sequence ends.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5284,7 +5284,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
       <profiles>
         <profile id="d91c-8426-3d59-4db7" name="Arbiter&apos;s Gaze" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When resolving an attack made by a model with this Relic, ignore negative hit roll modifiers and Ballistic Skill modifiers. When firing Overwatch, the bearer successfully hits using their Balliostic Skill, rather than on a 6.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When resolving an attack made by a model with this Relic, ignore negative hit roll modifiers and Ballistic Skill modifiers. When firing Overwatch, the bearer successfully hits using their Ballistic Skill, rather than on a 6.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5351,7 +5351,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
       <profiles>
         <profile id="3df0-9449-569c-bed3" name="Bolts of Judgement" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When you give a model this Relic, select one bolt weapon that model is equipped with. When that model shoots with that weapon, you can choose for it to fire a bolt of judgement. If you do, that model can only make on attack with that weapon, but the weapon has an Armour Penetration characteristic of -2 and a Damage of characteristic of 3 for that attack. When resolving that attack, a wound roll of 6+ is successful if the target is a VEHICLE unit or a MONSTER unit, otherwise a wound roll of 2+ is successful.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When you give a model this Relic, select one bolt weapon that model is equipped with. When that model shoots with that weapon, you can choose for it to fire a bolt of judgement. If you do, that model can only make one attack with that weapon, but the weapon has an Armour Penetration characteristic of -2 and a Damage of characteristic of 3 for that attack. When resolving that attack, a wound roll of 6+ is successful if the target is a VEHICLE unit or a MONSTER unit, otherwise a wound roll of 2+ is successful.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5397,7 +5397,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
         </profile>
         <profile id="a466-9d94-2107-2e5c" name="Sacred Standard" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">DARK ANGELS INFANTRY models that are destroyed within 6&quot; of any friendly DARK ANGELS CHAPTER ANCEINTS and subsequently musert one last surge of strength before succumbing to their wounds (see Astares Banner ability, above) always resolve their final attack as if they had a Ballistic Skill and a Weapon Skill characteristic of 2+.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">DARK ANGELS INFANTRY models that are destroyed within 6&quot; of any friendly DARK ANGELS CHAPTER ANCIENTS and subsequently musert one last surge of strength before succumbing to their wounds (see Astares Banner ability, above) always resolve their final attack as if they had a Ballistic Skill and a Weapon Skill characteristic of 2+.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -6161,7 +6161,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
       <profiles>
         <profile id="e668-0b35-a237-1894" name="Master-crafted weapon" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When you give a model this Relic, select one weapon that model is equipped with (this cannot be a weapon whose profile includes the word ‘master-crafted’). Add 1 to the Damage  haracteristic of that weapon. That weapon is considered to be a Chapter Relic.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When you give a model this Relic, select one weapon that model is equipped with (this cannot be a weapon whose profile includes the word ‘master-crafted’). Add 1 to the Damage characteristic of that weapon. That weapon is considered to be a Chapter Relic.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -6584,7 +6584,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
             <modifier type="set" field="points" value="40.0">
               <conditions>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef18-746a-369f-43a4" type="instanceOf">
-                  <comment>For some reason, the condition didnt trigger from the lib since it was loaded as PARENT instance of</comment>
+                  <comment>For some reason, the condition didn&apos;t trigger from the lib since it was loaded as PARENT instance of</comment>
                 </condition>
               </conditions>
             </modifier>
@@ -6634,7 +6634,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e408-e55b-6ee2-1211" type="max"/>
           </constraints>
           <profiles>
-            <profile id="a434-116b-985b-eef0" name="Veteran Sergreant" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+            <profile id="a434-116b-985b-eef0" name="Veteran Sergeant" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
               <characteristics>
                 <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
                 <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
@@ -7107,7 +7107,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="35eb-9927-127e-7fca" name="5. Master of Maneuvre" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="35eb-9927-127e-7fca" name="5. Master of Manoeuvre" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="1d32-797f-fb88-b35c" value="1">
                   <conditionGroups>
@@ -7136,7 +7136,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
                 <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="48dc-af70-a1cc-60e5" type="max"/>
               </constraints>
               <profiles>
-                <profile id="bbc1-3ba1-9035-826a" name="Master of Maneuvre" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+                <profile id="bbc1-3ba1-9035-826a" name="Master of Manoeuvre" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
                     <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You can re-roll the dice used to determine how far friendly DARK ANGELS units Advance or charge if they are within 6&quot; of your Warlord.</characteristic>
                   </characteristics>
@@ -7252,7 +7252,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
               <profiles>
                 <profile id="aed4-e5b9-54e9-0db4" name="Stealth Adept" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Substract 1 from hit rolls that target your Warlord.</characteristic>
+                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Subtract 1 from hit rolls that target your Warlord.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -7322,7 +7322,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
               <profiles>
                 <profile id="f8c5-ca1a-a057-958c" name="1. Lay Low The Mighty" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You can re-roll wound rolls for attacks made with melee weapons against CHARACTER units, or units with a Wounds charateristic of 8 or more, by models in friendly DEATHWING units whilst their unit is within 6&quot; of this Warlord.</characteristic>
+                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You can re-roll wound rolls for attacks made with melee weapons against CHARACTER units, or units with a Wounds characteristic of 8 or more, by models in friendly DEATHWING units whilst their unit is within 6&quot; of this Warlord.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -7756,7 +7756,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
           <profiles>
             <profile id="a263-7c52-6927-cdfe" name="Recitation of Focus" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Iff this litany is inspiring, select one friendly DARK ANGELS unit within 6&quot; of the model. When resolving an attack made with a ranged weapon by a model in that unit, add 1 to the hit roll.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this litany is inspiring, select one friendly DARK ANGELS unit within 6&quot; of the model. When resolving an attack made with a ranged weapon by a model in that unit, add 1 to the hit roll.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -7773,7 +7773,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
           <profiles>
             <profile id="57d4-467d-489a-c649" name="Canticle of Hate" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this litany is inspiring, add 2 to the charge rolls made for friendly DARL ANGELS units whilst they are within 6&quot; of this model. When a friendly DARK ANGELS unit makes a pile-in or consolidate move within 6&quot; of this model, models in that unit can move up to an additional 3&quot;. This is not cumulative with any other ability that adds to a unit&apos;s charge roll or increases the distance it can pile-in or consolidate.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this litany is inspiring, add 2 to the charge rolls made for friendly DARK ANGELS units whilst they are within 6&quot; of this model. When a friendly DARK ANGELS unit makes a pile-in or consolidate move within 6&quot; of this model, models in that unit can move up to an additional 3&quot;. This is not cumulative with any other ability that adds to a unit&apos;s charge roll or increases the distance it can pile-in or consolidate.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -7832,7 +7832,7 @@ Assault and Pistol weapons equipped on DARK ANGELS units with this ability is in
       <description>You can re-roll all hit rolls of 1 for this unit whenever it shoots (including when firing Overwatch) so long as it did not move in its prior Movement phase. Each time a Combat Attrition test is taken for this unit, it is automatically passed.’</description>
     </rule>
     <rule id="9ee9-a3a2-9d63-b93f" name="Combat Doctrines" hidden="false">
-      <description>If your army is Battle-forged and if every unit from your army has this ability (excluding Servitor and Unaligned units), this unit gains a bonus (see below) depending on which combat doctrine is active for your army, as follows: 
+      <description>If your army is Battle-forged and if every unit from your army has this ability (excluding Servitor and Unaligned units), this unit gains a bonus (see below) depending on which combat doctrine is active for your army, as follows:
 • During the first battle round, the Devastator Doctrine is active for your army.
 • During the second battle round, the Tactical Doctrine is active for your army.
 • At the start of the third battle round, select either the Tactical Doctrine or Assault Doctrine: until the end of that battle round, the doctrine you selected is active for your army.

--- a/Imperium - Dark Angels.cat
+++ b/Imperium - Dark Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b8fe-8d38-37ec-90e8" name="Imperium - Adeptus Astartes - Dark Angels" revision="165" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Thairne" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="156" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="b8fe-8d38-37ec-90e8" name="Imperium - Adeptus Astartes - Dark Angels" revision="166" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Thairne" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="156" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="b8fe-8d38-pubN65537" name="Codex: Dark Angels"/>
   </publications>


### PR DESCRIPTION
These typos are Unforgivable. The Fallen must have placed them there.

For the Lion!

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.