### PR TITLE
Fix: Typos - Deathwatch

### DIFF
--- a/Imperium - Deathwatch.cat
+++ b/Imperium - Deathwatch.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="203b-f8dd-2a64-2676" name="Imperium - Deathwatch" revision="100" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WindstormSCR" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="149" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="203b-f8dd-2a64-2676" name="Imperium - Deathwatch" revision="101" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WindstormSCR" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="149" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="203b-f8dd-pubN65537" name="Codex: Deathwatch"/>
     <publication id="203b-f8dd-pubN98915" name="Chapter Approved 2017"/>

--- a/Imperium - Deathwatch.cat
+++ b/Imperium - Deathwatch.cat
@@ -20,7 +20,7 @@
     <categoryEntry id="c82e-cd8d-e26d-a2c1" name="Faction: Deathwatch" hidden="false"/>
     <categoryEntry id="b86e-a36b-2bfb-9401" name="Terminator" hidden="false"/>
     <categoryEntry id="3a52-e075-4ce1-c3ae" name="Watch Master" hidden="false"/>
-    <categoryEntry id="0da7-4474-c112-ad2d" name="Captain Artimis" hidden="false"/>
+    <categoryEntry id="0da7-4474-c112-ad2d" name="Captain Artemis" hidden="false"/>
     <categoryEntry id="ae9f-868d-2286-91f6" name="Kill Team" hidden="false"/>
     <categoryEntry id="3266-4496-a016-a4c0" name="Vanguard Veterans" hidden="false"/>
     <categoryEntry id="40dc-74a1-5f7c-e292" name="Corvus Blackstar" hidden="false"/>
@@ -625,7 +625,7 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e7c-d4c7-5bfe-27cd" type="max"/>
       </constraints>
       <profiles>
-        <profile id="e3d5-d6f3-af66-0e53" name="Jump Pack Assult" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+        <profile id="e3d5-d6f3-af66-0e53" name="Jump Pack Assault" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During deployment, if this model has a jump pack, you can set it up high in the skies instead of placing it on the battlefield. At the end of any of your Movement phases this model can assault from above - set it up anywhere on the battlefield that is more than 9&quot; away from any enemy models.</characteristic>
           </characteristics>
@@ -1101,7 +1101,7 @@
       <profiles>
         <profile id="4a71-6edb-4974-3771" name="Drop Pod Assault" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During Deployment, you can set this model, along with any units embarked within it, in orbit instead of placing it on the battlefield. At the end of any of your Movement phases this model can perform a drop pod assault.  - set it up anywhere on the battlefield that is more that 9&quot; away from any enemy models. Any models embarked inside must immediately disembark, but they must be set up more than 9&quot; away from any enemy model. Any models that cannot be set up because there is not enough room are slain. Neither this model, nor any units embarked within it, are counted towards any limits that the mission you are playing places on the maximum number of Reinforcement units you can have in your army. This model can be set up in the Reinforcements step of your first, second or third Movement phase, regardless of any mission rules.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During Deployment, you can set this model, along with any units embarked within it, in orbit instead of placing it on the battlefield. At the end of any of your Movement phases this model can perform a drop pod assault.  - set it up anywhere on the battlefield that is more than 9&quot; away from any enemy models. Any models embarked inside must immediately disembark, but they must be set up more than 9&quot; away from any enemy model. Any models that cannot be set up because there is not enough room are slain. Neither this model, nor any units embarked within it, are counted towards any limits that the mission you are playing places on the maximum number of Reinforcement units you can have in your army. This model can be set up in the Reinforcements step of your first, second or third Movement phase, regardless of any mission rules.</characteristic>
           </characteristics>
         </profile>
         <profile id="d98d-7e56-4c84-5335" name="Transport" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
@@ -1462,7 +1462,7 @@
       <profiles>
         <profile id="42f5-c6d1-9e57-5971" name="Psyker" hidden="false" typeId="bc97-dea9-9e88-bb7d" typeName="Psyker">
           <characteristics>
-            <characteristic name="Cast" typeId="5afb-9914-904b-d3b3">This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny one psychic power in each enemy Psychic phase. It knows the Smite power and two psychic powers from the Librarius disipline.</characteristic>
+            <characteristic name="Cast" typeId="5afb-9914-904b-d3b3">This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny one psychic power in each enemy Psychic phase. It knows the Smite power and two psychic powers from the Librarius discipline.</characteristic>
             <characteristic name="Deny" typeId="b5ac-9c20-5d5a-6f9b"/>
             <characteristic name="Powers Known" typeId="69d7-b45e-00a2-7e46"/>
             <characteristic name="Other" typeId="c2e2-f115-0003-5d7b"/>
@@ -1567,7 +1567,7 @@
       <profiles>
         <profile id="ba87-9bd7-afd4-3fb5" name="Psyker" hidden="false" typeId="bc97-dea9-9e88-bb7d" typeName="Psyker">
           <characteristics>
-            <characteristic name="Cast" typeId="5afb-9914-904b-d3b3">This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny one psychic power in each enemy Psychic phase. It knows the Smite power and two psychic powers from the Librarius disipline.</characteristic>
+            <characteristic name="Cast" typeId="5afb-9914-904b-d3b3">This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny one psychic power in each enemy Psychic phase. It knows the Smite power and two psychic powers from the Librarius discipline.</characteristic>
             <characteristic name="Deny" typeId="b5ac-9c20-5d5a-6f9b"/>
             <characteristic name="Powers Known" typeId="69d7-b45e-00a2-7e46"/>
             <characteristic name="Other" typeId="c2e2-f115-0003-5d7b"/>
@@ -1763,7 +1763,7 @@
       <profiles>
         <profile id="78c1-6fd7-dd9d-70a6" name="Transport" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
           <characteristics>
-            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can tranport 10 CHAPTER INFANTRY models. It cannot transport JUMP PACK, TERMINATOR, PRIMARIS, CENTURION models.</characteristic>
+            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 10 CHAPTER INFANTRY models. It cannot transport JUMP PACK, TERMINATOR, PRIMARIS, CENTURION models.</characteristic>
           </characteristics>
         </profile>
         <profile id="3286-704c-6d03-2ed9" name="Rhino" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -2918,7 +2918,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
       <profiles>
         <profile id="df28-59b1-95bc-89fb" name="Deathwatch Teleport Homer" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this unit has a Deathwatch teleport homer, place it anywhere in your deployment zone when your army deploys.  If an enemy model is ever within 9&quot; of the Deathwatch teleport homer, it is deactivated and removed from the battlefield.  Whilst there are any friendly Deathwatch teleport homers on the battlefield, a unit that contains one or more Deathwatch Terminators can perform an emergency teleport instead of moving in its Movement phase.  At the end fo the Movement phase, remove the unit and then set it up with all models within 6&quot; of a friendly Deathwatch teleport homer.  That Deathwatch teleport homer then shorts out and is removed from the battlefield.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this unit has a Deathwatch teleport homer, place it anywhere in your deployment zone when your army deploys.  If an enemy model is ever within 9&quot; of the Deathwatch teleport homer, it is deactivated and removed from the battlefield.  Whilst there are any friendly Deathwatch teleport homers on the battlefield, a unit that contains one or more Deathwatch Terminators can perform an emergency teleport instead of moving in its Movement phase.  At the end of the Movement phase, remove the unit and then set it up with all models within 6&quot; of a friendly Deathwatch teleport homer.  That Deathwatch teleport homer then shorts out and is removed from the battlefield.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -4736,7 +4736,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
       <profiles>
         <profile id="a2fb-15a3-d225-88df" name="Auxiliary Grenade Launcher" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If a model is armed with a auxiliary grenade launcher, increace the range of any Grenade weapons they have to 30&quot;</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If a model is armed with a auxiliary grenade launcher, increase the range of any Grenade weapons they have to 30&quot;</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5016,7 +5016,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2abb-8762-0bd7-7c76" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="a7ef-661b-8896-82f0" name="Heavy Onlsaught Gatling Cannon" hidden="false" collective="false" import="true" targetId="9f1b-e239-80b9-71c0" type="selectionEntry"/>
+            <entryLink id="a7ef-661b-8896-82f0" name="Heavy Onslaught Gatling Cannon" hidden="false" collective="false" import="true" targetId="9f1b-e239-80b9-71c0" type="selectionEntry"/>
             <entryLink id="a95e-5781-f57a-ba7b" name="Macro Plasma Incinerator" hidden="false" collective="false" import="true" targetId="5230-16cd-9cac-89ef" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -5072,7 +5072,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9f1b-e239-80b9-71c0" name="Heavy Onlsaught Gatling Cannon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="9f1b-e239-80b9-71c0" name="Heavy Onslaught Gatling Cannon" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="69bd-0165-5b12-198b" name="Heavy Onslaught Gatling Cannon" hidden="false" targetId="ac67-1fe2-ecff-e890" type="profile"/>
       </infoLinks>
@@ -5107,7 +5107,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
       <profiles>
         <profile id="ad6b-57b3-7d69-48ed" name="Grapnel Launcher" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When models with grapnel launchers move in the Movement phase, do not count any vertical distance they move against the total they can move (i.e. moving vertically is free for these models in the Movement phase). In addition, during deployment you can set up this unit if it is equipped with grapnel launchers behing enemy lines instead of placing it on the battlefield. At the the end of your movement phase this unit can join the battle. Set it up within 6&quot; of a battlefield edge of your choice and more than 9&quot; away from any enemy models.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When models with grapnel launchers move in the Movement phase, do not count any vertical distance they move against the total they can move (i.e. moving vertically is free for these models in the Movement phase). In addition, during deployment you can set up this unit if it is equipped with grapnel launchers behind enemy lines instead of placing it on the battlefield. At the end of your movement phase this unit can join the battle. Set it up within 6&quot; of a battlefield edge of your choice and more than 9&quot; away from any enemy models.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5285,7 +5285,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
             <characteristic name="S" typeId="59b1-319e-ec13-d466">0</characteristic>
             <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
             <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">0</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">A shock greande doesn&apos;t inflict any damage. Instead, each time a shock grenade hits an enemy INFANTRY unit, it is stunned until the end of the turn - it cannot fire Overwatch and your opponent must subtract 1 from any hit rolls made for the unit. Second and subsequent hits from a shock grenade have no additional effect.</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">A shock grenade doesn&apos;t inflict any damage. Instead, each time a shock grenade hits an enemy INFANTRY unit, it is stunned until the end of the turn - it cannot fire Overwatch and your opponent must subtract 1 from any hit rolls made for the unit. Second and subsequent hits from a shock grenade have no additional effect.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5319,12 +5319,12 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
       <profiles>
         <profile id="d3f8-b8d3-482d-c0b9" name="Hover Tank" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Distanes and ranges are always measured to and from this model&apos;s hull even though it has a base.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Distances and ranges are always measured to and from this model&apos;s hull even though it has a base.</characteristic>
           </characteristics>
         </profile>
         <profile id="9410-9a95-9653-8305" name="Repulsor Field" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Your opponent must subtract 2 from any charge rolls made for units that declare a charge against a Repulor.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Your opponent must subtract 2 from any charge rolls made for units that declare a charge against a Repulsor.</characteristic>
           </characteristics>
         </profile>
         <profile id="cec0-82c6-603a-5c26" name="Transport" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
@@ -5400,7 +5400,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0765-e3f4-f816-00ea" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="3a4c-9454-ca49-35a5" name="Heavy Onlsaught Gatling Cannon" hidden="false" collective="false" import="true" targetId="9f1b-e239-80b9-71c0" type="selectionEntry"/>
+            <entryLink id="3a4c-9454-ca49-35a5" name="Heavy Onslaught Gatling Cannon" hidden="false" collective="false" import="true" targetId="9f1b-e239-80b9-71c0" type="selectionEntry"/>
             <entryLink id="efb4-9aec-a79d-068f" name="Las-talon" hidden="false" collective="false" import="true" targetId="5ca6-11eb-52e7-aad9" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -5568,7 +5568,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
       <profiles>
         <profile id="0533-547c-dc3c-2087" name="Psyker" hidden="false" typeId="bc97-dea9-9e88-bb7d" typeName="Psyker">
           <characteristics>
-            <characteristic name="Cast" typeId="5afb-9914-904b-d3b3">This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny one psychic power in each enemy Psychic phase. It knows the Smite power and two psychic powers from the Librarius disipline.</characteristic>
+            <characteristic name="Cast" typeId="5afb-9914-904b-d3b3">This model can attempt to manifest two psychic powers in each friendly Psychic phase, and attempt to deny one psychic power in each enemy Psychic phase. It knows the Smite power and two psychic powers from the Librarius discipline.</characteristic>
             <characteristic name="Deny" typeId="b5ac-9c20-5d5a-6f9b"/>
             <characteristic name="Powers Known" typeId="69d7-b45e-00a2-7e46"/>
             <characteristic name="Other" typeId="c2e2-f115-0003-5d7b"/>
@@ -5787,7 +5787,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
             <characteristic name="S" typeId="59b1-319e-ec13-d466">0</characteristic>
             <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
             <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">0</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">A shock greande doesn&apos;t inflict any damage. Instead, each time a shock grenade hits an enemy INFANTRY unit, it is stunned until the end of the turn - it cannot fire Overwatch and your opponent must subtract 1 from any hit rolls made for the unit. Second and subsequent hits from a shock grenade have no additional effect.</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">A shock grenade doesn&apos;t inflict any damage. Instead, each time a shock grenade hits an enemy INFANTRY unit, it is stunned until the end of the turn - it cannot fire Overwatch and your opponent must subtract 1 from any hit rolls made for the unit. Second and subsequent hits from a shock grenade have no additional effect.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7363,7 +7363,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
         </profile>
         <profile id="25b6-6fbd-6b27-cd9b" name="Repulsor Field" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Your opponent must subtract 2 from any charge rolls made for units that declare a charge against a Repulor.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Your opponent must subtract 2 from any charge rolls made for units that declare a charge against a Repulsor.</characteristic>
           </characteristics>
         </profile>
         <profile id="ec0e-5fab-ce79-1aa0" name="Transport" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
@@ -7373,7 +7373,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
         </profile>
         <profile id="bc07-0f9f-e730-163c" name="Aquilon Optics" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model remains stationary or moves under half speed in its Movement phase (i.e. it moves a distance in inches less than half of its current Move characterisitc), it can shoot its heavy laser destroyer or macro plasma incinerator twice in the following Shooting phase (this weapon must target the same unit both times).</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model remains stationary or moves under half speed in its Movement phase (i.e. it moves a distance in inches less than half of its current Move characteristic), it can shoot its heavy laser destroyer or macro plasma incinerator twice in the following Shooting phase (this weapon must target the same unit both times).</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7442,7 +7442,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7227-ca2b-e8dd-9ad9" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="3b0e-eff8-6f79-3f08" name="Heavy Onlsaught Gatling Cannon" hidden="false" collective="false" import="true" targetId="9f1b-e239-80b9-71c0" type="selectionEntry">
+        <entryLink id="3b0e-eff8-6f79-3f08" name="Heavy Onslaught Gatling Cannon" hidden="false" collective="false" import="true" targetId="9f1b-e239-80b9-71c0" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75a1-f7e2-b802-c8d1" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8c0-e7f3-75be-1b67" type="max"/>
@@ -7578,7 +7578,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="11b2-7567-324f-3cee" name="Meltagun, Cyclone Missle Launcher and Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="11b2-7567-324f-3cee" name="Meltagun, Cyclone Missile Launcher and Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
         <entryLink id="783f-404e-4b74-ec4e" name="Meltagun" hidden="false" collective="false" import="true" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
           <constraints>
@@ -7747,7 +7747,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
               <characteristics>
                 <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">8</characteristic>
                 <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">Self</characteristic>
-                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">If manifested, then until the start of your next Psychic phase, while they are within 6&quot; of the psyker, enemy models cannot take invulnerabe saves and must halve the results of any Psychic tests (rounding up) that they take.</characteristic>
+                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">If manifested, then until the start of your next Psychic phase, while they are within 6&quot; of the psyker, enemy models cannot take invulnerable saves and must halve the results of any Psychic tests (rounding up) that they take.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -7804,7 +7804,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
               <characteristics>
                 <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">6</characteristic>
                 <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">18&quot;</characteristic>
-                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">If manifested, select a visible enemy unit within 18&quot;. Then, roll a D6 and add the psyker&apos;s Leadership to the result. Your opponent then rolls a D6 and adds the Leadership of their unit to the result. If the psyker&apos;s total score is greater than the enemy&apos;s score, the enemy unit suffers D3 mortal wounds; if it is equal to the enemy&apos;s score, the enemy unit suffers one mortal wound; it if is less than the enemy&apos;s score, nothing happens.</characteristic>
+                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">If manifested, select a visible enemy unit within 18&quot;. Then, roll a D6 and add the psyker&apos;s Leadership to the result. Your opponent then rolls a D6 and adds the Leadership of their unit to the result. If the psyker&apos;s total score is greater than the enemy&apos;s score, the enemy unit suffers D3 mortal wounds; if it is equal to the enemy&apos;s score, the enemy unit suffers one mortal wound; if it is less than the enemy&apos;s score, nothing happens.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -7917,7 +7917,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
         </entryLink>
         <entryLink id="87cf-5e55-e371-99c8" name="Cyclone Missile Launcher and Thunder Hammer/Stormshield" hidden="false" collective="false" import="true" targetId="2c57-923c-9e52-6af9" type="selectionEntry"/>
         <entryLink id="33c3-fb2c-2824-6e78" name="Cyclone Missile Launcher and Storm Bolter" hidden="false" collective="false" import="true" targetId="365b-3b47-ad82-667e" type="selectionEntry"/>
-        <entryLink id="f86e-40c9-dc6f-323f" name="Meltagun, Cyclone Missle Launcher and Storm Bolter" hidden="false" collective="false" import="true" targetId="11b2-7567-324f-3cee" type="selectionEntry"/>
+        <entryLink id="f86e-40c9-dc6f-323f" name="Meltagun, Cyclone Missile Launcher and Storm Bolter" hidden="false" collective="false" import="true" targetId="11b2-7567-324f-3cee" type="selectionEntry"/>
         <entryLink id="4a9f-75f5-8360-0a02" name="Meltagun, Thunder Hammer and Storm Shield" hidden="false" collective="false" import="true" targetId="577b-009a-fb9e-7ea3" type="selectionEntry"/>
         <entryLink id="4b50-c722-07b0-9fe0" name="Cyclone Missile Launcher, Meltagun, Thunder Hammer and Storm Shield" hidden="false" collective="false" import="true" targetId="b5d7-318b-56fc-eaec" type="selectionEntry"/>
       </entryLinks>
@@ -8521,7 +8521,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
                 <characteristic name="S" typeId="59b1-319e-ec13-d466">User</characteristic>
                 <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
                 <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
-                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When setting up the bearer, pick one of the following keywords: ORK, TYRANID, T’AU EMPIRE, AELDARIor NECRONS. You can re-roll failed wound rolls for this weapon when attacking enemy units with that keyword</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When setting up the bearer, pick one of the following keywords: ORK, TYRANID, T’AU EMPIRE, AELDARI or NECRONS. You can re-roll failed wound rolls for this weapon when attacking enemy units with that keyword</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -8748,7 +8748,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
     </profile>
     <profile id="b7b9-274a-1b87-3b67" name="Litanies of Hate" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You can re-roll failed hit rolls in the Fight phase for friendly &lt;CHPATER&gt; units within 6&quot; of this model.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You can re-roll failed hit rolls in the Fight phase for friendly &lt;CHAPTER&gt; units within 6&quot; of this model.</characteristic>
       </characteristics>
     </profile>
     <profile id="83c5-c731-4688-c8eb" name="Iron Halo" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -8763,7 +8763,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
     </profile>
     <profile id="1baf-0fae-82e1-da51" name="Combat Squads" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Before deployment at the start of the game, a unit with this ability containing 10 models may be split into two units, each containing 5 models. Units of Agressors, Bikers or Inceptors containing 6 models can also be split into two units, each containing 3 models.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Before deployment at the start of the game, a unit with this ability containing 10 models may be split into two units, each containing 5 models. Units of Aggressors, Bikers or Inceptors containing 6 models can also be split into two units, each containing 3 models.</characteristic>
       </characteristics>
     </profile>
     <profile id="d4ca-64f8-7af9-1503" name="Self-repair" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -8773,7 +8773,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
     </profile>
     <profile id="9e55-78af-ff73-24d6" name="Power of the Machine Spirit" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model does not suffer he penalty to hit rolls for moving and firing Heavy Weapons.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model does not suffer the penalty to hit rolls for moving and firing Heavy Weapons.</characteristic>
       </characteristics>
     </profile>
     <profile id="0cd3-5fb0-83ba-2475" name="Teleport Strike" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -8783,7 +8783,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
     </profile>
     <profile id="a3b8-74b3-06b9-db2c" name="Frag Assault Launchers" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a D6 each time this models finishes a charge move within 1&quot; of an emeny unit; on a 4+ that unit suffers D3 motal wounds.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a D6 each time this models finishes a charge move within 1&quot; of an enemy unit; on a 4+ that unit suffers D3 mortal wounds.</characteristic>
       </characteristics>
     </profile>
     <profile id="3311-4a28-ced2-0d5b" name="Unyielding Ancient" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -8923,7 +8923,7 @@ For the purposes of setting up on or moving through Battlefield Terrain, this un
     </profile>
     <profile id="0f8d-0c8e-c28b-a2b1" name="Narthecium" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of any of your Movement phases, the Apothecary can attempt to heal or revive a singel model. Select a friendly &lt;CHAPTER&gt; INFANTRY or BIKER unit within 3&quot; of the Apothecary. If that unit contains a wounded model, it immediately regains D3 lost wounds. If the chosen unit contains no wounded models but one or more of its models have been slain during the battle, roll a D6. On a 4+ a single slain model is returned to the unit with 1 wound remaining. I fthe Apothecary fails to revive a model he can do nothing else for the remainder of the turn (shoot, charge, fight, ect.) as he recovers gene-seed of the fallen warrior. A unit can only be the target of the Narthecium ability once in each turn.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of any of your Movement phases, the Apothecary can attempt to heal or revive a single model. Select a friendly &lt;CHAPTER&gt; INFANTRY or BIKER unit within 3&quot; of the Apothecary. If that unit contains a wounded model, it immediately regains D3 lost wounds. If the chosen unit contains no wounded models but one or more of its models have been slain during the battle, roll a D6. On a 4+ a single slain model is returned to the unit with 1 wound remaining. If the Apothecary fails to revive a model he can do nothing else for the remainder of the turn (shoot, charge, fight, ect.) as he recovers the gene-seed of the fallen warrior. A unit can only be the target of the Narthecium ability once in each turn.</characteristic>
       </characteristics>
     </profile>
     <profile id="ac67-1fe2-ecff-e890" name="Heavy Onslaught Gatling Cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">


### PR DESCRIPTION
The best of the best just got better with these typo fixups.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.