### PR TITLE
Fix: Typos - Elucidian Starstriders

### DIFF
--- a/Imperium - Elucidian Starstriders.cat
+++ b/Imperium - Elucidian Starstriders.cat
@@ -396,7 +396,7 @@
         </profile>
         <profile id="1028-a692-e050-111d" name="Healing Serum" publicationId="b619-ccba-pubN66040" page="17" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of each Movemnt phase, this model can attempt to heal a single friendly ELUCIDIAN STARSTRIDERS INFANTRY unit within 3&quot;. If it does so, roll a D6; on a 4+ one model from the unit regains 1 lost wound. If the unit is NITSCH&apos;S SQUAD, one model slain earlier in the battle is returned to the unit instead.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of each Movement phase, this model can attempt to heal a single friendly ELUCIDIAN STARSTRIDERS INFANTRY unit within 3&quot;. If it does so, roll a D6; on a 4+ one model from the unit regains 1 lost wound. If the unit is NITSCH&apos;S SQUAD, one model slain earlier in the battle is returned to the unit instead.</characteristic>
           </characteristics>
         </profile>
       </profiles>


### PR DESCRIPTION
Single fixup for these sweet models.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.