### PR TITLE
Fix: Typos - FW Adeptus Astartes

### DIFF
--- a/Imperium - FW Adeptus Astartes.cat
+++ b/Imperium - FW Adeptus Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="dab7-e076-dd5e-d8aa" name="Imperium - FW Adeptus Astartes" revision="76" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="156" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="dab7-e076-dd5e-d8aa" name="Imperium - FW Adeptus Astartes" revision="77" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="156" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="dab7-e076-pubN133616" name="Codex: Space Wolves"/>
     <publication id="dab7-e076-pubN151451" name="Astraeus Super-heavy Tank PDF"/>

--- a/Imperium - FW Adeptus Astartes.cat
+++ b/Imperium - FW Adeptus Astartes.cat
@@ -2226,7 +2226,7 @@
         </profile>
         <profile id="59c2-4b7e-a39d-3b44" name="Transport" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <modifiers>
-            <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model can transport 6 &lt;CHAPTER&gt; INFANTRY models. Each TERMINATOR or JUMP PACK modeltakes up the space of two other models, and each CENTURION model takes up the space of three models. Itcannot transport PRIMARIS models.">
+            <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model can transport 6 &lt;CHAPTER&gt; INFANTRY models. Each TERMINATOR or JUMP PACK model takes up the space of two other models, and each CENTURION model takes up the space of three models. it cannot transport PRIMARIS models.">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
@@ -2238,7 +2238,7 @@
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model can transport 10 &lt;CHAPTER&gt; INFANTRY models. Each TERMINATOR or JUMP PACK modeltakes up the space of two other models, and each CENTURION model takes up the space of three models. Itcannot transport PRIMARIS models.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model can transport 10 &lt;CHAPTER&gt; INFANTRY models. Each TERMINATOR or JUMP PACK model takes up the space of two other models, and each CENTURION model takes up the space of three models. it cannot transport PRIMARIS models.</characteristic>
           </characteristics>
         </profile>
         <profile id="7fc0-861c-8d44-8a62" name="Relic Land Raider Proteus" hidden="false" typeId="5f4f-ea74-0630-4afe" typeName="Wound Track">
@@ -2813,7 +2813,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="be67-65b2-5472-8af0" name="Strategem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
+        <entryLink id="be67-65b2-5472-8af0" name="Stratagem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
@@ -2933,7 +2933,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="936c-f15f-3110-cb00" name="Strategem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
+        <entryLink id="936c-f15f-3110-cb00" name="Stratagem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
@@ -5850,7 +5850,7 @@
         </profile>
         <profile id="0cf5-7d39-1897-6631" name="Transport" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
           <characteristics>
-            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 40 &lt;CHAPTER&gt; INFANTRY mdels (each TERMINATOR and JUMP PACK model takes up the space of two other models, and each CENTURION takes up the space of three other models). It may also transport up to two DREADNOUGHTS, IRONCLAD DREADNOUGHTS, VENERABLE DREADNOUGHTS or CONTEMPTOR DREADNOUGHTS, each taking up the space of ten models. It cannot transport PRIMARIS models.</characteristic>
+            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 40 &lt;CHAPTER&gt; INFANTRY models (each TERMINATOR and JUMP PACK model takes up the space of two other models, and each CENTURION takes up the space of three other models). It may also transport up to two DREADNOUGHTS, IRONCLAD DREADNOUGHTS, VENERABLE DREADNOUGHTS or CONTEMPTOR DREADNOUGHTS, each taking up the space of ten models. It cannot transport PRIMARIS models.</characteristic>
           </characteristics>
         </profile>
         <profile id="5b6f-d4e4-feaf-928c" name="Relic Mastodon Super-heavy Siege Transport 1" hidden="false" typeId="8760-b4e3-100c-cd59" typeName="Void Shield Wound Track">
@@ -6138,7 +6138,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8cc-5068-5676-2692" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="3df7-83c6-3eb6-7dd4" name="Strategem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
+        <entryLink id="3df7-83c6-3eb6-7dd4" name="Stratagem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="9.0"/>
@@ -6281,7 +6281,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="b418-9905-242a-7fb0" name="Strategem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
+        <entryLink id="b418-9905-242a-7fb0" name="Stratagem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="13.0"/>
@@ -6436,7 +6436,7 @@
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed0e-f7e6-525e-2f8e" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="5dd7-0008-5d20-2f29" name="Strategem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
+        <entryLink id="5dd7-0008-5d20-2f29" name="Stratagem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="18.0"/>
@@ -6632,7 +6632,7 @@
         <infoLink id="bdd0-d12e-3027-e37d" name="Airborne" hidden="false" targetId="fd93-c4d6-1fc9-4962" type="profile"/>
         <infoLink id="73d6-4e8e-c93d-313e" name="Hard to Hit" hidden="false" targetId="7bd8-1f08-6aa1-e9b5" type="profile"/>
         <infoLink id="62c3-ddf0-673a-78ea" name="Supersonic" hidden="false" targetId="814d-7e63-7729-0951" type="profile"/>
-        <infoLink id="f563-f243-2a82-1d4d" name="Teminal targeting" hidden="false" targetId="6f45-8ece-1ff4-6a44" type="profile"/>
+        <infoLink id="f563-f243-2a82-1d4d" name="Terminal targeting" hidden="false" targetId="6f45-8ece-1ff4-6a44" type="profile"/>
         <infoLink id="bc9c-a9da-ddbf-2ebc" name="Skyborn Predator" hidden="false" targetId="8bfe-dcbd-8160-daa4" type="profile"/>
         <infoLink id="389f-5ced-4d9c-5b53" name="Angels of Death" hidden="false" targetId="01a4-bec8-b573-fde7" type="rule"/>
       </infoLinks>
@@ -9271,7 +9271,7 @@
               <profiles>
                 <profile id="350d-4611-abd2-fa46" name="The Armour Indomitus" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The wearer of the Armour Indomitus has a Save characteristic of 2+. In addition, once per battle, before making one of the wearer&apos;s saving throws, you can choose to activate the armour&apos;s force field. When you do so, the Armour Indomitus confers a 3+ invulverable save for the remainder of the turn.</characteristic>
+                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The wearer of the Armour Indomitus has a Save characteristic of 2+. In addition, once per battle, before making one of the wearer&apos;s saving throws, you can choose to activate the armour&apos;s force field. When you do so, the Armour Indomitus confers a 3+ invulnerable save for the remainder of the turn.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -9733,9 +9733,9 @@
           <selectionEntries>
             <selectionEntry id="677d-92c9-d341-ad3b" name="Brilliant Strategist" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
-                <profile id="eb12-8eec-9002-a62e" name="Brilliant Stragegist" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+                <profile id="eb12-8eec-9002-a62e" name="Brilliant Strategist" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per battle, if your Warlord is on the battlefie,d you can re-roll a single hit roll, wound roll, damage roll or saving throw. In addition, if your army is Battle-forged, roll a D6 each time you use a Stratagem; on a 5+ you gain 1 Command Point.</characteristic>
+                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per battle, if your Warlord is on the battlefield you can re-roll a single hit roll, wound roll, damage roll or saving throw. In addition, if your army is Battle-forged, roll a D6 each time you use a Stratagem; on a 5+ you gain 1 Command Point.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -9796,12 +9796,12 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="ceb6-9fc9-9c0c-d56e" name="Master of Maneuvre" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="ceb6-9fc9-9c0c-d56e" name="Master of Manoeuvre" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c5a-14ec-56d9-d4db" type="max"/>
               </constraints>
               <profiles>
-                <profile id="50b7-5a6a-5d12-dc3b" name="Master of Maneuvre" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+                <profile id="50b7-5a6a-5d12-dc3b" name="Master of Manoeuvre" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
                     <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You can re-roll the dice used to determine how far friendly DARK ANGELS units Advance or charge if they are within 6&quot; of your Warlord.</characteristic>
                   </characteristics>
@@ -9946,7 +9946,7 @@
               <profiles>
                 <profile id="9569-fee8-e9f3-a28c" name="Saga of the Warrior Born" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You can always choose for a unit affected by this saga in the Fight phase to fight first even if they didn&apos;t charge. If the enemy has units that have charged, or that have a similar ability, then alternate chooseing units to fight with, starting with the player whose turn is taking place.  Deed of Legend: Slay an enemy CHARACTER with your Warlord.</characteristic>
+                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You can always choose for a unit affected by this saga in the Fight phase to fight first even if they didn&apos;t charge. If the enemy has units that have charged, or that have a similar ability, then alternate choosing units to fight with, starting with the player whose turn is taking place.  Deed of Legend: Slay an enemy CHARACTER with your Warlord.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -9960,7 +9960,7 @@
               <profiles>
                 <profile id="9844-a744-6caf-1f6c" name="Saga of the Wolfkin" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If a unit is affectecd by this saga in the Fight phase, add 1 to the Attacks characteristic of all its models if it made a charge move, was charged, or performed a heroic intervention earlier in the same turn.  Deed of Legend: Slay a total of five models in the Fight phase with your Warlord (keep a tally from turn to turn). </characteristic>
+                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If a unit is affected by this saga in the Fight phase, add 1 to the Attacks characteristic of all its models if it made a charge move, was charged, or performed a heroic intervention earlier in the same turn.  Deed of Legend: Slay a total of five models in the Fight phase with your Warlord (keep a tally from turn to turn). </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -10360,7 +10360,7 @@ In addition, when a Psychic test or Deny the Witch test is taken for a PSYKER mo
         <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
         <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
         <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
-        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">This weapon may not be fiired on any turn in which the model carrying it has moved. In addition, for each 24&quot; between the bearer and the target, increase the Strength by +2 and the Damage by +D3. If a model is ramoved from play as a casualty due to wouds caused by this weapon, then the target unit suffers 2D6 additional hits at Strength 6, AP 0, causing 1 Damage. These additional hits do not trigger further hits themselves.</characteristic>
+        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">This weapon may not be fired on any turn in which the model carrying it has moved. In addition, for each 24&quot; between the bearer and the target, increase the Strength by +2 and the Damage by +D3. If a model is removed from play as a casualty due to wounds caused by this weapon, then the target unit suffers 2D6 additional hits at Strength 6, AP 0, causing 1 Damage. These additional hits do not trigger further hits themselves.</characteristic>
       </characteristics>
     </profile>
     <profile id="1e79-bbf5-79e9-73e3" name="Castellum air defence missiles" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -11784,7 +11784,7 @@ In addition, when a Psychic test or Deny the Witch test is taken for a PSYKER mo
     </profile>
     <profile id="ec07-50ef-7c00-b5cb" name="Fragstorm Launchers" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model finishes acharge move within 1&quot; of an enemy unit, roll a D6. On a 4+, that unit suffers D3 mortal wounds.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model finishes a charge move within 1&quot; of an enemy unit, roll a D6. On a 4+, that unit suffers D3 mortal wounds.</characteristic>
       </characteristics>
     </profile>
     <profile id="b81a-7ad7-6a5d-7d81" name="Contemptor Mortis" page="26" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -12098,7 +12098,7 @@ In addition, when a Psychic test or Deny the Witch test is taken for a PSYKER mo
         <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time this model moves, first pivot it on the spot up to 90° (this does not contribute to how far the model moves) and then move the model straight forwards. Not that it cannot pivot again after the initial pivot. When this model Advances, increase its Move characteristic by 20&quot; until the end of the phase - do not roll a dice.</characteristic>
       </characteristics>
     </profile>
-    <profile id="6f45-8ece-1ff4-6a44" name="Teminal Targeting" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+    <profile id="6f45-8ece-1ff4-6a44" name="Terminal Targeting" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
         <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model does not suffer the penalty to hit rolls for moving and firing Heavy weapons.</characteristic>
       </characteristics>
@@ -12326,7 +12326,7 @@ In addition, when a Psychic test or Deny the Witch test is taken for a PSYKER mo
     </profile>
     <profile id="813c-413f-ff72-bf1c" name="Artillery" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The Rapier Carrier can only fire its weapon if at least one of the Space Marine Gunners it was deployed with is within 3&quot;. If both of the Space Marine Gunners the Rapier Carrier was depolyed with are slain, the Rapier Carrier is also removed as slain.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The Rapier Carrier can only fire its weapon if at least one of the Space Marine Gunners it was deployed with is within 3&quot;. If both of the Space Marine Gunners the Rapier Carrier was deployed with are slain, the Rapier Carrier is also removed as slain.</characteristic>
       </characteristics>
     </profile>
     <profile id="b548-09b5-d576-4528" name="Tarantula Sentry Gun" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -12448,7 +12448,7 @@ In addition, when a Psychic test or Deny the Witch test is taken for a PSYKER mo
     </profile>
     <profile id="b74a-0617-cf66-8c5e" name="Shield Gate Barriers" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Unless the Tacticus Bunker has been destroyed, all INFANTRY, DREADOUGHT or BIKE units on the Castellum Stronghold tile have a 4+ invulnerable save against Shooting attacks.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Unless the Tacticus Bunker has been destroyed, all INFANTRY, DREADNOUGHT or BIKE units on the Castellum Stronghold tile have a 4+ invulnerable save against Shooting attacks.</characteristic>
       </characteristics>
     </profile>
     <profile id="11a3-5870-dd26-3ff5" name="Command Relay" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -12519,7 +12519,7 @@ In addition, when a Psychic test or Deny the Witch test is taken for a PSYKER mo
     </profile>
     <profile id="cda4-bdb3-deb1-6af8" name="Blessing of the Omnissiah (Astral Claws)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of your Movement phase. this model can repair a single ASTRAL CLAWS VEHICLE whithin 1&quot;. That model regains D3 lost wounds. A model can only be repaired once per turn.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of your Movement phase. This model can repair a single ASTRAL CLAWS VEHICLE within 1&quot;. That model regains D3 lost wounds. A model can only be repaired once per turn.</characteristic>
       </characteristics>
     </profile>
     <profile id="ee21-612c-b9ab-b823" name="Rites of Battle (Astral Claws/Tiger Claws)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -12554,7 +12554,7 @@ In addition, when a Psychic test or Deny the Witch test is taken for a PSYKER mo
     </profile>
     <profile id="4aa0-1d4c-2350-59af" name="Undying Spite" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If Lord Asterion Molo is slain in the figh phase before he has fought, he immediatelly piles in and makes his attacks before being removed.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If Lord Asterion Molo is slain in the fight phase before he has fought, he immediately piles in and makes his attacks before being removed.</characteristic>
       </characteristics>
     </profile>
     <profile id="11f2-dee3-b6b4-90ac" name="Chapter Master (Minotaurs)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -12569,7 +12569,7 @@ In addition, when a Psychic test or Deny the Witch test is taken for a PSYKER mo
     </profile>
     <profile id="85e9-3339-a07b-6c2e" name="Bane of the Damned" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Friendly RED SCORPIONS INFANTRY units within 6&quot; of Magister Sevrin Loth canre-roll failed wound rolls against PSYKERS.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Friendly RED SCORPIONS INFANTRY units within 6&quot; of Magister Sevrin Loth can re-roll failed wound rolls against PSYKERS.</characteristic>
       </characteristics>
     </profile>
     <profile id="30fe-5fc2-410b-94e8" name="The Armour of Selket" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -12619,7 +12619,7 @@ In addition, when a Psychic test or Deny the Witch test is taken for a PSYKER mo
     </profile>
     <profile id="3b4a-f36a-64d0-8da9" name="Grim Hunter" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Afte falling back, Lias Issodon may still shoot or Advance in the same turn, but may not charge.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">After falling back, Lias Issodon may still shoot or Advance in the same turn, but may not charge.</characteristic>
       </characteristics>
     </profile>
     <profile id="87e5-e096-8317-a4d9" name="Infiltrate, Isolate, Destroy" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -12629,7 +12629,7 @@ In addition, when a Psychic test or Deny the Witch test is taken for a PSYKER mo
     </profile>
     <profile id="f262-b76f-a579-a878" name="Master of Ambush" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During deployment, you can set up Lias Issodon and up to three friendly RAPTORS INFANTRY units (not including TERMINATORS, CENTURIONS or PRIMARIS units) in the shadows instead of placing them on the battlefield. At the end of any of your movement phases, Lias Issodon and any accompanying units can reveal themselves on the battlefield - set them up anywhwere on the battlefield that is more than 9&quot; away from enemy models.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During deployment, you can set up Lias Issodon and up to three friendly RAPTORS INFANTRY units (not including TERMINATORS, CENTURIONS or PRIMARIS units) in the shadows instead of placing them on the battlefield. At the end of any of your movement phases, Lias Issodon and any accompanying units can reveal themselves on the battlefield - set them up anywhere on the battlefield that is more than 9&quot; away from enemy models.</characteristic>
       </characteristics>
     </profile>
     <profile id="4d6d-94bb-b2b9-e64f" name="Stealth Modified Armour" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -12839,7 +12839,7 @@ In addition, when a Psychic test or Deny the Witch test is taken for a PSYKER mo
         <characteristic name="S" typeId="59b1-319e-ec13-d466">x2</characteristic>
         <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
         <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">3</characteristic>
-        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When resolving an attack made with this porfile, subtract 1 from the hit roll, and a wound roll of 6+ inflicts 1 mortal wound on the target in addition to any other damage.</characteristic>
+        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When resolving an attack made with this profile, subtract 1 from the hit roll, and a wound roll of 6+ inflicts 1 mortal wound on the target in addition to any other damage.</characteristic>
       </characteristics>
     </profile>
     <profile id="eb63-fe95-cee1-5b8a" name="God-splitter, Sweeping Blows" publicationId="eaff-9d37-65fa-35a2" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">


### PR DESCRIPTION
Typos for the FW line of Space Marines. Purge the Resin.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.