### PR TITLE
Fix: Typos - Death Korps

### DIFF
--- a/Imperium - FW Death Korps of Krieg.cat
+++ b/Imperium - FW Death Korps of Krieg.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="91ff-e116-e0a5-e883" name="Imperium - Death Korps of Krieg" revision="137" battleScribeVersion="2.03" authorName="Jon K, Joe B" authorContact="Discord: @Alphalas, @CrusherJoe | Twitter: @_alphalas, @theawesomesauce" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="155" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="91ff-e116-e0a5-e883" name="Imperium - Death Korps of Krieg" revision="138" battleScribeVersion="2.03" authorName="Jon K, Joe B" authorContact="Discord: @Alphalas, @CrusherJoe | Twitter: @_alphalas, @theawesomesauce" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="155" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="91ff-e116-pubN72301" name="Codex: Astra Militarum"/>
     <publication id="91ff-e116-pubN102593" name="War Zone Damocles: Mont&apos;ka"/>

--- a/Imperium - FW Death Korps of Krieg.cat
+++ b/Imperium - FW Death Korps of Krieg.cat
@@ -34,7 +34,7 @@
     </profileType>
   </profileTypes>
   <categoryEntries>
-    <categoryEntry id="94ba-b4f7-ef96-f4d3" name="Death Korps Marhsal Karis Venner" publicationId="53e9d88f-pubN134105" page="57" hidden="false"/>
+    <categoryEntry id="94ba-b4f7-ef96-f4d3" name="Death Korps Marshal Karis Venner" publicationId="53e9d88f-pubN134105" page="57" hidden="false"/>
     <categoryEntry id="6235-3bbb-25b4-3dc8" name="Death Korps Marshal" publicationId="53e9d88f-pubN134105" page="57" hidden="false"/>
     <categoryEntry id="cfb4-1566-762d-ea38" name="Death Korps Field Officer" publicationId="53e9d88f-pubN134105" page="58" hidden="false"/>
     <categoryEntry id="a56f-4b7c-5b7e-7cfa" name="Death Korps Death Rider Squadron Commander" publicationId="53e9d88f-pubN134105" page="58" hidden="false"/>
@@ -65,7 +65,7 @@
     <categoryEntry id="35e5-d612-a147-4c9c" name="Heavy Quad launcher Battery" hidden="false"/>
     <categoryEntry id="3d9c-9e4a-d73c-685f" name="Rapier Laser Destroyer battery" hidden="false"/>
     <categoryEntry id="c59c-be13-3335-ccb7" name="Salamander Scout Tank" hidden="false"/>
-    <categoryEntry id="3e6d-f4c0-bae2-83f3" name="Styges Thunderer Seige Tank" hidden="false"/>
+    <categoryEntry id="3e6d-f4c0-bae2-83f3" name="Styges Thunderer Siege Tank" hidden="false"/>
     <categoryEntry id="7486-a51c-c68c-1090" name="Medusa" hidden="false"/>
     <categoryEntry id="5120-68a7-27ad-7779" name="Basilisks" hidden="false"/>
     <categoryEntry id="8691-44a5-b7e2-145e" name="Veterans" hidden="false"/>
@@ -84,7 +84,7 @@
     <categoryEntry id="e917-4760-9b4b-08b4" name="Cyclops" hidden="false"/>
     <categoryEntry id="79d4-2a6a-be63-ae5f" name="Earthshaker" hidden="false"/>
     <categoryEntry id="a72d-5240-7f6f-bad3" name="Malcador" hidden="false"/>
-    <categoryEntry id="f44d-0b4c-cc20-59e1" name="Malcador Annihlator" hidden="false"/>
+    <categoryEntry id="f44d-0b4c-cc20-59e1" name="Malcador Annihilator" hidden="false"/>
     <categoryEntry id="cebd-62b7-7d99-a244" name="Malcador Defender" hidden="false"/>
     <categoryEntry id="923e-80a0-2539-3aa4" name="Malcador Heavy tank" hidden="false"/>
     <categoryEntry id="0ab2-5a41-9bf8-6f1f" name="Malcador Infernus" hidden="false"/>
@@ -264,7 +264,7 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="1db7-9cb8-70a6-8e5b" name="Tainted Blade" hidden="false" collective="false" import="true" targetId="5e21-c1bd-7cc2-e2da" type="selectionEntry"/>
-    <entryLink id="e6ff-02ac-4a68-7e94" name="Collossus Bombard" hidden="false" collective="false" import="true" targetId="05af-872f-e4ab-aba9" type="selectionEntry">
+    <entryLink id="e6ff-02ac-4a68-7e94" name="Colossus Bombard" hidden="false" collective="false" import="true" targetId="05af-872f-e4ab-aba9" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7f05-e2de-86d2-b75f" name="Colossus Bombard" hidden="false" targetId="6ce3-2fc4-051c-cce1" primary="false"/>
         <categoryLink id="c4a1-f989-f5f6-8292" name="Death Korps of Krieg" hidden="false" targetId="9c0e-b999-8fcd-1e95" primary="false"/>
@@ -586,7 +586,7 @@
         <categoryLink id="0854-a2e4-e6e6-4c56" name="Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fbd7-37c5-902f-a08f" name="Stygies Thunderer Seige Tank" hidden="false" collective="false" import="true" targetId="17b0-32eb-49b5-41c4" type="selectionEntry">
+    <entryLink id="fbd7-37c5-902f-a08f" name="Stygies Thunderer Siege Tank" hidden="false" collective="false" import="true" targetId="17b0-32eb-49b5-41c4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="036c-2d8f-e87d-b7b0" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
         <categoryLink id="d05b-cb47-5eaf-94b6" name="New CategoryLink" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -1997,7 +1997,7 @@
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81a8-9b5f-18c3-7c92" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="6b30-f174-acdc-5a72" name="Kreig Combat Shotgun" hidden="false" collective="false" import="true" targetId="a4df-840e-0ad4-0bf4" type="selectionEntry">
+                <entryLink id="6b30-f174-acdc-5a72" name="Krieg Combat Shotgun" hidden="false" collective="false" import="true" targetId="a4df-840e-0ad4-0bf4" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14c5-9c94-31e8-2963" type="min"/>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6ea-d88a-4e39-fe68" type="max"/>
@@ -3501,7 +3501,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a4df-840e-0ad4-0bf4" name="Kreig Combat Shotgun" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="a4df-840e-0ad4-0bf4" name="Krieg Combat Shotgun" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="f3e6-2f60-1ae1-4b03" name="Krieg Combat Shotgun (carcass shot)" hidden="false" targetId="f985-58f8-3e74-48b7" type="profile"/>
         <infoLink id="575f-ea2b-3bd6-ff23" name="Krieg Combat Shotgun (solid shot)" hidden="false" targetId="a4e6-847f-0b8e-ef28" type="profile"/>
@@ -4148,13 +4148,13 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="4055-5377-6cd0-f7f1" name="Draconian Disiplinarian" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="4055-5377-6cd0-f7f1" name="Draconian Disciplinarian" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37db-a8d5-3bb3-63c5" type="max"/>
                 <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e12-04ce-d313-221a" type="max"/>
               </constraints>
               <profiles>
-                <profile id="5b3f-cfb6-fd41-2547" name="Draconian Disiplinarian" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+                <profile id="5b3f-cfb6-fd41-2547" name="Draconian Disciplinarian" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
                     <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You can re-roll failed Morale tests for friendly ASTRA MILITARUM INFANTRY units within 6&quot; of your Warlord in the Morale phase.</characteristic>
                   </characteristics>
@@ -4519,7 +4519,7 @@
     </profile>
     <profile id="f884-552c-9917-3f45" name="Implacable Officer" publicationId="53e9d88f-pubN134105" page="57" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model may use the Voice of Command (DKOK) abillty three times in each of your turns. Resolve the effects of the first order before attempting the second order, and so on.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model may use the Voice of Command (DKOK) ability three times in each of your turns. Resolve the effects of the first order before attempting the second order, and so on.</characteristic>
       </characteristics>
     </profile>
     <profile id="f2af-a2c9-3275-3016" name="Commander-in-Chief" publicationId="53e9d88f-pubN134105" page="57" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -4601,12 +4601,12 @@
     </profile>
     <profile id="1217-56ef-432f-3cc6" name="Death Korps Vox-caster" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If a friendly DEATH KORPS OF KRIEG OFFICER is within 3&quot; of a unit with a vox-caster when using thier Voice of Command ability, you may extend the range of the order to 18&quot; if the target unit also contains a vox-caster.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If a friendly DEATH KORPS OF KRIEG OFFICER is within 3&quot; of a unit with a vox-caster when using their Voice of Command ability, you may extend the range of the order to 18&quot; if the target unit also contains a vox-caster.</characteristic>
       </characteristics>
     </profile>
     <profile id="37d1-c17b-6b45-492b" name="Death Korps Platoon Standard" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">All friendsly DEATH KORPS OF KRIEG units within 6&quot; of one or more units with a Death Korps Platoon Standard may add 1 to their Leadership when taking Morale Tests.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">All friendly DEATH KORPS OF KRIEG units within 6&quot; of one or more units with a Death Korps Platoon Standard may add 1 to their Leadership when taking Morale Tests.</characteristic>
       </characteristics>
     </profile>
     <profile id="39b8-17e5-93e8-001b" name="Death Korps Death Rider" publicationId="53e9d88f-pubN134105" page="67" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -4629,7 +4629,7 @@
         <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
         <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
         <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">After a model on this mount makes its close sombat attacks, you can attack with its mount. Make two additional attacks using this weapon&apos;s profile.</characteristic>
+        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">After a model on this mount makes its close combat attacks, you can attack with its mount. Make two additional attacks using this weapon&apos;s profile.</characteristic>
       </characteristics>
     </profile>
     <profile id="a26e-ee3b-8a60-52e7" name="Death Korps Hunting Lance" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -4841,7 +4841,7 @@
     </profile>
     <profile id="4b83-a75f-32f7-2941" name="Explodes (Centaur)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield, and before any embarked models disembark. On a 6+ is explodes, and each unit iwthin 6&quot; suffers 1 mortal wound.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield, and before any embarked models disembark. On a 6+ is explodes, and each unit within 6&quot; suffers 1 mortal wound.</characteristic>
       </characteristics>
     </profile>
     <profile id="4e80-6921-23dc-7d67" name="Assault Team Transport" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -4876,7 +4876,7 @@
     </profile>
     <profile id="4769-7136-e407-4743" name="Transport (Storm Chimera)" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
       <characteristics>
-        <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 12 ASTRA MILITARUM INFANTRY models. Each heavy Weapon Team or Veteran Heavy Weapon Team takes the space fo two other models, and each OGRYN takes the spaces of three other models.</characteristic>
+        <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 12 ASTRA MILITARUM INFANTRY models. Each heavy Weapon Team or Veteran Heavy Weapon Team takes the space of two other models, and each OGRYN takes the spaces of three other models.</characteristic>
       </characteristics>
     </profile>
     <profile id="9d20-fbec-6208-a911" name="Medi-pack" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -4894,7 +4894,7 @@
         <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time a friendly DEATH KORPS OF KRIEG INFANTRY or DEATH KORPS OF KRIEG CAVALRY unit within 6&quot; suffers a wound, roll a D6. On a 6, it ignores the injury and the wound is not lost. A unit cannot use both this and the Augmented Mount ability to prevent the same wound.</characteristic>
       </characteristics>
     </profile>
-    <profile id="fa86-a9cd-ac7d-3adf" name="Death Korps Quartermaster Revanant" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+    <profile id="fa86-a9cd-ac7d-3adf" name="Death Korps Quartermaster Revenant" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
       <characteristics>
         <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
         <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>


### PR DESCRIPTION
Mask wearing, shovel wielding, typo busting warriors.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.