### PR TITLE
Fix: Typos - Imperial Knights

### DIFF
--- a/Imperium - Imperial Knights.cat
+++ b/Imperium - Imperial Knights.cat
@@ -1135,7 +1135,7 @@
             <characteristic name="S" typeId="59b1-319e-ec13-d466">+6</characteristic>
             <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
             <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">6</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When resolving an attack made with this weapon against a VEHICLE unit or MONSTER unit, you can reroll the wound roll.</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When resolving an attack made with this weapon against a VEHICLE unit or MONSTER unit, you can re-roll the wound roll.</characteristic>
           </characteristics>
         </profile>
         <profile id="3ee7-0b58-bf44-ec3e" name="Atrapos Lascutter (shooting)" publicationId="ddcc-9444-870e-9593" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -1145,7 +1145,7 @@
             <characteristic name="S" typeId="59b1-319e-ec13-d466">12</characteristic>
             <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
             <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">6</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When resolving an attack made with this weapon against a VEHICLE unit or MONSTER unit, you can reroll the wound roll.</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When resolving an attack made with this weapon against a VEHICLE unit or MONSTER unit, you can re-roll the wound roll.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -2782,7 +2782,7 @@ of 2. </characteristic>
           <entryLinks>
             <entryLink id="5738-3ac0-e204-7197" name="Questor Imperialis" hidden="false" collective="false" import="true" targetId="0331-f3d9-7e76-8298" type="selectionEntry"/>
             <entryLink id="2460-3c41-dcff-0fee" name="Questor Mechanicus" hidden="false" collective="false" import="true" targetId="05dc-b991-1a99-40e6" type="selectionEntry"/>
-            <entryLink id="c964-8f92-2d2d-57cf" name="Questor Allegiace &lt;Mixed&gt;" hidden="false" collective="false" import="true" targetId="c335-1f2a-e252-3ede" type="selectionEntry"/>
+            <entryLink id="c964-8f92-2d2d-57cf" name="Questor Allegiance &lt;Mixed&gt;" hidden="false" collective="false" import="true" targetId="c335-1f2a-e252-3ede" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="d4b4-0f03-05bb-daf8" name="Household Tradition" hidden="false" collective="false" import="true">
@@ -4803,7 +4803,7 @@ of 2. </characteristic>
       <profiles>
         <profile id="8183-c208-7e97-97ee" name="The Helm Dominatus" publicationId="82cd-d24f-pubN65537" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per battle round, at the start of either your Shooting phase or Fight phase, you can choose a unit from your opponent&apos;s army that is within 24&quot; of the bearer.  Until the end of the phase, add 1 to hit rolls for attacks made by &lt;HOUSEHOLD&gt; ARMIGER CLASS models against that enemy unit whist they are within 6&quot; of the bearer.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per battle round, at the start of either your Shooting phase or Fight phase, you can choose a unit from your opponent&apos;s army that is within 24&quot; of the bearer.  Until the end of the phase, add 1 to hit rolls for attacks made by &lt;HOUSEHOLD&gt; ARMIGER CLASS models against that enemy unit whilst they are within 6&quot; of the bearer.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5019,7 +5019,7 @@ of 2. </characteristic>
             <characteristic name="S" typeId="59b1-319e-ec13-d466">+6</characteristic>
             <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
             <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">6</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Replaces the bearer&apos;s Reaper Chainsword. Each wound roll of 6 made for this weapon inflicts D3 mortal wounds on the target in addition ot the normal damage.</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Replaces the bearer&apos;s Reaper Chainsword. Each wound roll of 6 made for this weapon inflicts D3 mortal wounds on the target in addition to the normal damage.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5170,7 +5170,7 @@ of 2. </characteristic>
       <profiles>
         <profile id="4810-4188-2548-dc0d" name="The Banner Inviolate" publicationId="82cd-d24f-pubN65537" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Re-roll hit rolls of 1 in the Fight phase for House Raven models whist they are within 6&quot; of the bearer.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Re-roll hit rolls of 1 in the Fight phase for House Raven models whilst they are within 6&quot; of the bearer.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -8107,7 +8107,7 @@ If a Freeblade from your army has any Burdens, roll 2D6 for them at the start of
     </profile>
     <profile id="96f0-a851-8433-76e1" name="Blessed by the Sacristans" publicationId="82cd-d24f-pubN65537" hidden="false" typeId="b2ac-1cb8-8f3c-8ded" typeName="Warlord Trait">
       <characteristics>
-        <characteristic name="Description" typeId="f9f0-1b0a-0e16-84b3">Chose one weapon (not an Heirloom of the Noble Houses) that your Warlord is equipped with.  Each time you make an unmodified wound roll of 6 for that weapon, the target suffers a mortal wound in addition to the normal damage.</characteristic>
+        <characteristic name="Description" typeId="f9f0-1b0a-0e16-84b3">Choose one weapon (not an Heirloom of the Noble Houses) that your Warlord is equipped with.  Each time you make an unmodified wound roll of 6 for that weapon, the target suffers a mortal wound in addition to the normal damage.</characteristic>
       </characteristics>
     </profile>
     <profile id="aede-42a1-aac1-d84e" name="Adamantium Knight" publicationId="82cd-d24f-pubN65537" hidden="false" typeId="b2ac-1cb8-8f3c-8ded" typeName="Warlord Trait">
@@ -8282,7 +8282,7 @@ If a Freeblade from your army has any Burdens, roll 2D6 for them at the start of
     </profile>
     <profile id="28a0-3aa5-799b-71b0" name="Vow of Honour" publicationId="ecea-8b62-fefb-9f8e" hidden="false" typeId="b797-3df8-cff8-b29f" typeName="Allegiance Oath">
       <characteristics>
-        <characteristic name="Description" typeId="01d0-a64f-195c-598f">Add 1 to Advance and Charge rolls made for a model with this Questor Allegiance Oath. This is not cumulative with any otehr modifiers (e.g. Landstrider)</characteristic>
+        <characteristic name="Description" typeId="01d0-a64f-195c-598f">Add 1 to Advance and Charge rolls made for a model with this Questor Allegiance Oath. This is not cumulative with any other modifiers (e.g. Landstrider)</characteristic>
       </characteristics>
     </profile>
     <profile id="f9b0-4028-7591-202d" name="Paragon of the Omnissiah" publicationId="ecea-8b62-fefb-9f8e" hidden="false" typeId="b2ac-1cb8-8f3c-8ded" typeName="Warlord Trait">

--- a/Imperium - Imperial Knights.cat
+++ b/Imperium - Imperial Knights.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="82cd-d24f-9f22-11f3" name="Imperium - Imperial Knights" revision="66" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Dr. Toboggan" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="153" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="82cd-d24f-9f22-11f3" name="Imperium - Imperial Knights" revision="67" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Dr. Toboggan" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="153" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="82cd-d24f-pubN65537" name="Codex: Imperial Knights" shortName="Codex" publisher="Codex: Imperial Knights"/>
     <publication id="ddcc-9444-870e-9593" name="Imperial Knights FW Army List" shortName="Forgeworld" publisher="Imperial Knights FW Army List"/>


### PR DESCRIPTION
Some typo fixes for the walking cathedrals.

![ndpb84bu7qj21](https://user-images.githubusercontent.com/3375026/93417906-6a714580-f8ec-11ea-8d67-9016e1f6eb15.jpg)

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.