### PR TITLE
Fix: Typos - Officio Assassinorum

### DIFF
--- a/Imperium - Officio Assassinorum.cat
+++ b/Imperium - Officio Assassinorum.cat
@@ -744,7 +744,7 @@ for each enemy unit that is within 6&quot; of this model. On a 4+ that enemy uni
   </sharedSelectionEntries>
   <sharedRules>
     <rule id="6fa7-7d69-7fce-f215" name="Independent Operative" publicationId="f731-6aa6-pubN66377" hidden="false">
-      <description>This Model can never have a Warlord Trait. During deployment, you can set this model up in concealment instead of placing it on the battlefield. At the end of any of your movement phases, this model can reveal it&apos;s position - set it up anywhere on the battlefield that is more then 9&quot; from any enemy model.</description>
+      <description>This Model can never have a Warlord Trait. During deployment, you can set this model up in concealment instead of placing it on the battlefield. At the end of any of your movement phases, this model can reveal it&apos;s position - set it up anywhere on the battlefield that is more than 9&quot; from any enemy model.</description>
     </rule>
     <rule id="62ec-db58-d522-deda" name="Lightning Reflexes" publicationId="f731-6aa6-pubN66377" hidden="false">
       <description>A model with this special rule has a 4+ invulnerable save.</description>


### PR DESCRIPTION
This single typo didn't even see the bullet.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.