### PR TITLE
Fix: Typos - Raven Guard

### DIFF
--- a/Imperium - Raven Guard.cat
+++ b/Imperium - Raven Guard.cat
@@ -1823,7 +1823,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="24c1-7d78-2670-2b03" name="Opressor&apos;s End" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="24c1-7d78-2670-2b03" name="Oppressor&apos;s End" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditionGroups>
@@ -1840,7 +1840,7 @@
                 <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="23d8-2d24-bf60-3a0b" type="max"/>
               </constraints>
               <profiles>
-                <profile id="b469-1d2f-023b-0eeb" name="Opressor&apos;s End" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                <profile id="b469-1d2f-023b-0eeb" name="Oppressor&apos;s End" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">Melee</characteristic>
                     <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Melee</characteristic>

--- a/Imperium - Raven Guard.cat
+++ b/Imperium - Raven Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9503-9e14-1988-91a4" name="Imperium - Adeptus Astartes - Raven Guard" revision="22" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="146" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9503-9e14-1988-91a4" name="Imperium - Adeptus Astartes - Raven Guard" revision="23" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="146" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="cbd4-64ea-2787-3c13" name="Kayvaan Shrike [Legends]" hidden="false" collective="false" import="true" type="model">
       <modifiers>


### PR DESCRIPTION
It's not a phase, mom.

Typo fixes for our favourite sneaky marines.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.