### PR TITLE
Fix: Typos - Space Marines

### DIFF
--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="846d-3c14-21fc-369f" name="Imperium - Space Marines" revision="176" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="154" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="846d-3c14-21fc-369f" name="Imperium - Space Marines" revision="177" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="154" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="846d-3c14-pubN65537" name="Index: Imperium 1 &amp; Codex: Space Marines"/>
   </publications>

--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -60,7 +60,7 @@
     <categoryEntry id="13ac-0a73-2640-cc7a" name="Hellblaster Squad" hidden="false"/>
     <categoryEntry id="b294-9c6c-7cba-74b6" name="Thunderfire Cannon" hidden="false"/>
     <categoryEntry id="fe98-6796-1e9d-1d5a" name="Predator" hidden="false"/>
-    <categoryEntry id="63df-c0b5-9297-f3e3" name="Vinicator" hidden="false"/>
+    <categoryEntry id="63df-c0b5-9297-f3e3" name="Vindicator" hidden="false"/>
     <categoryEntry id="01a9-0c4e-1fb8-6686" name="Whirlwind" hidden="false"/>
     <categoryEntry id="1c7b-d16c-1891-1a16" name="Hunter" hidden="false"/>
     <categoryEntry id="a393-47f4-d068-f309" name="Stalker" hidden="false"/>
@@ -94,7 +94,7 @@
     <categoryEntry id="743d-5c90-e771-707f" name="Cassius" hidden="false"/>
     <categoryEntry id="f0cc-a26f-c8c5-9528" name="Telion" hidden="false"/>
     <categoryEntry id="f176-f861-6dfc-c362" name="Chronus" hidden="false"/>
-    <categoryEntry id="966d-a54b-00a2-7ed9" name="Tyrannic War Verterans" hidden="false"/>
+    <categoryEntry id="966d-a54b-00a2-7ed9" name="Tyrannic War Veterans" hidden="false"/>
     <categoryEntry id="9b86-c272-06ec-0894" name="Terminus Ultra" hidden="false"/>
     <categoryEntry id="c4e4-b28f-193a-8fc3" name="Lysander" hidden="false"/>
     <categoryEntry id="4a2f-f9cf-96e3-2671" name="Pedro Kantor" hidden="false"/>
@@ -172,7 +172,7 @@
         </profile>
         <profile id="4867-ad5b-70a4-f543" name="Astartes Banner" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">&lt;CHAPTER&gt; units within 6&quot; of any friendly &lt;CHAPTER&gt; ANCIENTS add 1 to their Leadership. In addition, roll a D6 each time a &lt;CHAPTER&gt; INFANTRY model is destroyed within 6&quot; of any friendly &lt;CHAPTER&gt; ANCIENTS, before removing the model as a casualty. On a 4+, that model musters one last surge of stregth before succumbing to its wounds; it can either shoot with one of its weapons as if it were the Shooting phase, or make a single attack as if it were the Fight phase.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">&lt;CHAPTER&gt; units within 6&quot; of any friendly &lt;CHAPTER&gt; ANCIENTS add 1 to their Leadership. In addition, roll a D6 each time a &lt;CHAPTER&gt; INFANTRY model is destroyed within 6&quot; of any friendly &lt;CHAPTER&gt; ANCIENTS, before removing the model as a casualty. On a 4+, that model musters one last surge of strength before succumbing to its wounds; it can either shoot with one of its weapons as if it were the Shooting phase, or make a single attack as if it were the Fight phase.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -934,7 +934,7 @@
         </profile>
         <profile id="526d-69c0-5d28-015e" name="Cataphractii Armor and Iron Halo" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model has a 3+ invulnerable save, but you must halve the result of the dice when determaining how far this model Advances.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model has a 3+ invulnerable save, but you must halve the result of the dice when determining how far this model Advances.</characteristic>
           </characteristics>
         </profile>
         <profile id="fbbf-6fa9-b3e4-d2e7" name="Chapter Master" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1753,7 +1753,7 @@
         </profile>
         <profile id="6a5c-6133-5c5e-5910" name="Transport" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
           <characteristics>
-            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can tranport 10 CHAPTER INFANTRY models. It cannot transport JUMP PACK, TERMINATOR, PRIMARIS, CENTURION models.</characteristic>
+            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 10 CHAPTER INFANTRY models. It cannot transport JUMP PACK, TERMINATOR, PRIMARIS, CENTURION models.</characteristic>
           </characteristics>
         </profile>
         <profile id="1c1e-1fb4-a774-87c3" name="Rhino 1" hidden="false" typeId="5f4f-ea74-0630-4afe" typeName="Wound Track">
@@ -5046,7 +5046,7 @@
       <entryLinks>
         <entryLink id="ad6e-4389-6ef2-7a49" name="Dreadnought Heavy Weapons" hidden="false" collective="false" import="true" targetId="345e-609b-29f8-73af" type="selectionEntryGroup"/>
         <entryLink id="cbac-2948-5657-1165" name="Dreadnought Arm Weapons" hidden="false" collective="false" import="true" targetId="0f5d-5463-7908-f599" type="selectionEntryGroup"/>
-        <entryLink id="2a2b-6938-ccd9-5e1b" name="Strategem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
+        <entryLink id="2a2b-6938-ccd9-5e1b" name="Stratagem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
@@ -5116,7 +5116,7 @@
       <entryLinks>
         <entryLink id="87a5-e822-c68e-c746" name="Dreadnought Heavy Weapons" hidden="false" collective="false" import="true" targetId="345e-609b-29f8-73af" type="selectionEntryGroup"/>
         <entryLink id="b163-0ea9-eecb-47b5" name="Dreadnought Arm Weapons" hidden="false" collective="false" import="true" targetId="0f5d-5463-7908-f599" type="selectionEntryGroup"/>
-        <entryLink id="2b67-3765-7889-2e23" name="Strategem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
+        <entryLink id="2b67-3765-7889-2e23" name="Stratagem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
@@ -5220,7 +5220,7 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="460d-0b9c-c414-b158" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="d479-f3c1-b122-6104" name="Strategem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
+        <entryLink id="d479-f3c1-b122-6104" name="Stratagem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
@@ -5334,7 +5334,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e4e1-b71b-ea7f-b83b" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="3c71-3344-65e8-4c1b" name="Strategem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
+        <entryLink id="3c71-3344-65e8-4c1b" name="Stratagem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
@@ -7326,7 +7326,7 @@
         </profile>
         <profile id="4b12-42ec-ae47-befa" name="Transport" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
           <characteristics>
-            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 6 CHAPTER INFANTRY model. It cannot transport JUMP PACK, PRIMARIS, TERMINATOR, or CENTRION models.</characteristic>
+            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 6 CHAPTER INFANTRY models. It cannot transport JUMP PACK, PRIMARIS, TERMINATOR, or CENTURION models.</characteristic>
           </characteristics>
         </profile>
         <profile id="dc16-cb33-aaa1-9816" name="Rhino Primaris 1" hidden="false" typeId="5f4f-ea74-0630-4afe" typeName="Wound Track">
@@ -7711,7 +7711,7 @@ Matched Play: Neither this model, nor any units embarked within it, are counted 
         <infoLink id="4464-8ae8-2452-493e" name="New InfoLink" hidden="false" targetId="94b4-a3ac-b2c9-df93" type="rule"/>
         <infoLink id="730b-7d10-924c-42d5" name="New InfoLink" hidden="false" targetId="9caa-ff00-a5bd-5f04" type="rule"/>
         <infoLink id="f2ce-a95c-055f-bf12" name="New InfoLink" hidden="false" targetId="ff68-151c-f4b2-1f97" type="profile"/>
-        <infoLink id="27b8-ea0d-70b7-4466" name="Straifing Run" hidden="false" targetId="93fd-f537-0273-01aa" type="profile"/>
+        <infoLink id="27b8-ea0d-70b7-4466" name="Strafing Run" hidden="false" targetId="93fd-f537-0273-01aa" type="profile"/>
         <infoLink id="ef13-21ef-6836-9fa8" name="Angels of Death" hidden="false" targetId="01a4-bec8-b573-fde7" type="rule"/>
       </infoLinks>
       <categoryLinks>
@@ -8842,7 +8842,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
         </profile>
         <profile id="91d1-f058-97e8-48c2" name="Transport" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
           <characteristics>
-            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 12 CHAPTER INFANTRY models and 1 CHAPTER DREADNOUGHT. Each JUMP PACK or TERMINATOR model takes the space of two other infantry models and each CENTURION takes space of 3 other infanty models. It cannot transport PRIMARIS models.</characteristic>
+            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 12 CHAPTER INFANTRY models and 1 CHAPTER DREADNOUGHT. Each JUMP PACK or TERMINATOR model takes the space of two other infantry models and each CENTURION takes space of 3 other infantry models. It cannot transport PRIMARIS models.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -9722,12 +9722,12 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="597a-bab2-6f1f-dd40" name="Tactical Withdrawl" hidden="false" collective="false" import="true" type="upgrade">
+                <selectionEntry id="597a-bab2-6f1f-dd40" name="Tactical Withdrawal" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8467-9d84-fb85-4d31" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile id="da2c-f51a-8de1-ad8b" name="Tactical Withdrawl" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+                    <profile id="da2c-f51a-8de1-ad8b" name="Tactical Withdrawal" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                       <characteristics>
                         <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Units with this tactic can charge in a turn in which they Fell Back.</characteristic>
                       </characteristics>
@@ -11517,7 +11517,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61d4-d5d0-d56b-7732" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="41f9-d9f1-d9e6-89fe" name="2x Fragstorm Granade Launchers" hidden="false" collective="false" import="true" targetId="fc75-e0cc-bdc8-858f" type="selectionEntry"/>
+            <entryLink id="41f9-d9f1-d9e6-89fe" name="2x Fragstorm Grenade Launchers" hidden="false" collective="false" import="true" targetId="fc75-e0cc-bdc8-858f" type="selectionEntry"/>
             <entryLink id="3345-4810-55e9-4c02" name="2x Storm Bolters" hidden="false" collective="false" import="true" targetId="391c-6e58-cc90-7442" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -11534,7 +11534,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f2c-1740-0c11-a680" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="6399-a257-b231-edc5" name="Strategem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
+        <entryLink id="6399-a257-b231-edc5" name="Stratagem: March of the Ancients" hidden="false" collective="false" import="true" targetId="46b3-cb0f-85c5-0e31" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="9.0"/>
@@ -11654,12 +11654,12 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
         </profile>
         <profile id="8f84-dcf4-11c7-2a41" name="Hover Tank" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Distanes and ranges are always measured to and from this model&apos;s hull even though it has a base.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Distances and ranges are always measured to and from this model&apos;s hull even though it has a base.</characteristic>
           </characteristics>
         </profile>
         <profile id="92a3-4a9e-8d4f-5837" name="Repulsor Field" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Your opponent must subtract 2 from any charge rolls made for units that declare a charge against a Repulor.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Your opponent must subtract 2 from any charge rolls made for units that declare a charge against a Repulsor.</characteristic>
           </characteristics>
         </profile>
         <profile id="b483-c643-ddb7-f1d3" name="Transport" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
@@ -11718,7 +11718,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04b9-61fb-3f61-bcda" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="3707-1037-c60c-4af3" name="2x Fragstorm Granade Launchers" hidden="false" collective="false" import="true" targetId="fc75-e0cc-bdc8-858f" type="selectionEntry"/>
+            <entryLink id="3707-1037-c60c-4af3" name="2x Fragstorm Grenade Launchers" hidden="false" collective="false" import="true" targetId="fc75-e0cc-bdc8-858f" type="selectionEntry"/>
             <entryLink id="e9f5-354f-49be-a8a5" name="2x Storm Bolters" hidden="false" collective="false" import="true" targetId="391c-6e58-cc90-7442" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -11740,7 +11740,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a44-7f3b-6480-2ec6" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="9d6d-c214-e60f-81d4" name="Auto Lanuchers" hidden="false" collective="false" import="true" targetId="8670-6bbb-f6c7-3e8a" type="selectionEntry"/>
+            <entryLink id="9d6d-c214-e60f-81d4" name="Auto Launchers" hidden="false" collective="false" import="true" targetId="8670-6bbb-f6c7-3e8a" type="selectionEntry"/>
             <entryLink id="6b43-e45e-7600-6db2" name="2x Fragstorm Grenade Launchers" hidden="false" collective="false" import="true" targetId="fc75-e0cc-bdc8-858f" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -11832,7 +11832,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
       <profiles>
         <profile id="cd75-1e6d-5f90-d70c" name="Grapnel Launcher" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When models with grapnel launchers move in the Movement phase, do not count any vertical distance they move against the total they can move (i.e. moving vertically is free for these models in the Movement phase). In addition, during deployment, you can set up this unit, if it is equipped with grapnel launchers, behing enemy lines instead of placing it on the battlefield. At the the end of your Movement phases this unit can join the battle - set it up within 6&quot; of a battlefield edge of your choice and more than 9&quot; away from any enemy models.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When models with grapnel launchers move in the Movement phase, do not count any vertical distance they move against the total they can move (i.e. moving vertically is free for these models in the Movement phase). In addition, during deployment, you can set up this unit, if it is equipped with grapnel launchers, behind enemy lines instead of placing it on the battlefield. At the end of your Movement phases this unit can join the battle - set it up within 6&quot; of a battlefield edge of your choice and more than 9&quot; away from any enemy models.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -12423,7 +12423,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
         </profile>
         <profile id="4f39-ff2f-98ef-b4e6" name="Duty&apos;s Burden" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">CRIMSONS FISTS model with a bolt rifle, mater-crafted auto bolt rifle or master crafted-stalker bolt rifle only. Duty&apos;s Burden replaces the bearer&apos;s bolt rifle, mater-crafted auto bolt rifle or master crafted-stalker bolt rifle.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">CRIMSONS FISTS model with a bolt rifle, master-crafted auto bolt rifle or master crafted-stalker bolt rifle only. Duty&apos;s Burden replaces the bearer&apos;s bolt rifle, master-crafted auto bolt rifle or master crafted-stalker bolt rifle.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -13105,7 +13105,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
             </profile>
             <profile id="814e-6373-01a0-e186" name="Helix Adept" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of your Movement phase, an Infiltrator Helix Adept can attempt to heal or revive 1 model from its unit. If the Infiltrator Helix Adept&apos;s unit contains a wounded model, that model regains 1 lost wound. If its unit contains no wounded models, bot one or more of its models have been slain during the battle, roll a D6. On a 5+ one slain model is returned to the unit with 1 would remaining. If the Infiltrator Helix Adept fails to revive a model, he cannot shoot in your next Shooting phase as he recovers the gene-seed of the fallen warrior.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of your Movement phase, an Infiltrator Helix Adept can attempt to heal or revive 1 model from its unit. If the Infiltrator Helix Adept&apos;s unit contains a wounded model, that model regains 1 lost wound. If its unit contains no wounded models, but one or more of its models have been slain during the battle, roll a D6. On a 5+ one slain model is returned to the unit with 1 wound remaining. If the Infiltrator Helix Adept fails to revive a model, he cannot shoot in your next Shooting phase as he recovers the gene-seed of the fallen warrior.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -13725,7 +13725,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
         </profile>
         <profile id="bfa7-c44f-8ab2-23ac" name="Repulsor Field" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Your opponent must subtract 2 from any charge rolls made for units that declare a charge against a Repulor.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Your opponent must subtract 2 from any charge rolls made for units that declare a charge against a Repulsor.</characteristic>
           </characteristics>
         </profile>
         <profile id="2989-c81c-fc05-0312" name="Transport" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
@@ -13735,7 +13735,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
         </profile>
         <profile id="c2a5-5ab9-d814-a747" name="Aquilon Optics" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model remains stationary or moves under half speed in its Movement phase (i.e. it moves a distance in inches less than half of its current Move characterisitc), it can shoot its heavy laser destroyer or macro plasma incinerator twice in the following Shooting phase (this weapon must target the same unit both times).</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model remains stationary or moves under half speed in its Movement phase (i.e. it moves a distance in inches less than half of its current Move characteristic), it can shoot its heavy laser destroyer or macro plasma incinerator twice in the following Shooting phase (this weapon must target the same unit both times).</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -14412,7 +14412,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2eb5-5d73-85e1-b9b9" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="73f3-ba0a-9ea7-80f9" name="2x Fragstorm Granade Launchers" hidden="false" collective="false" import="true" targetId="fc75-e0cc-bdc8-858f" type="selectionEntry"/>
+            <entryLink id="73f3-ba0a-9ea7-80f9" name="2x Fragstorm Grenade Launchers" hidden="false" collective="false" import="true" targetId="fc75-e0cc-bdc8-858f" type="selectionEntry"/>
             <entryLink id="aa6d-d708-3d11-5c2f" name="2x Storm Bolters" hidden="false" collective="false" import="true" targetId="391c-6e58-cc90-7442" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -15743,7 +15743,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
       <profiles>
         <profile id="1a7b-0e42-8159-d7fd" name="Stratagem: Master of Sanctity" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model knows one additional Litany from Litanies of Battle and can recite one additonal Litany at the start of the battle round. </characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model knows one additional Litany from Litanies of Battle and can recite one additional Litany at the start of the battle round. </characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -16157,7 +16157,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
         </modifier>
       </modifiers>
       <profiles>
-        <profile id="0706-ba42-1454-5b1f" name="Prrimaris Captain" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="0706-ba42-1454-5b1f" name="Primaris Captain" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">2+</characteristic>
@@ -17754,7 +17754,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
               <characteristics>
                 <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">6</characteristic>
                 <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">18&quot;</characteristic>
-                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Veil of Timehas a warp charge value of 6. If manifested, select one friendly &lt;CHAPTER&gt; unit within 18&quot; of this psyker. Until the start of your next Psychic phase, when an Advance roll or charge roll is made for that unit, you can re-roll the dice. In addition, that unit always fights first in the Fight phase, even if it did not charge. If the enemy has units that have charged, or that have a similar ability, then alternate choosing units to fight with, starting with the player whose turn is taking place.</characteristic>
+                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Veil of Time has a warp charge value of 6. If manifested, select one friendly &lt;CHAPTER&gt; unit within 18&quot; of this psyker. Until the start of your next Psychic phase, when an Advance roll or charge roll is made for that unit, you can re-roll the dice. In addition, that unit always fights first in the Fight phase, even if it did not charge. If the enemy has units that have charged, or that have a similar ability, then alternate choosing units to fight with, starting with the player whose turn is taking place.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -17930,7 +17930,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
         <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0350-6271-81cb-c21c" type="max"/>
       </constraints>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5cce-4552-7b5e-adef" name="Relics of Mccragge" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="5cce-4552-7b5e-adef" name="Relics of Macragge" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -18598,7 +18598,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2b35-7b9f-3ed0-aae2" name="Opressor&apos;s End" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="2b35-7b9f-3ed0-aae2" name="Oppressor&apos;s End" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditionGroups>
@@ -18615,7 +18615,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
                 <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="44d5-4794-7d8f-4df5" type="max"/>
               </constraints>
               <profiles>
-                <profile id="5a6a-fb1f-9f4e-1e30" name="Opressor&apos;s End" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                <profile id="5a6a-fb1f-9f4e-1e30" name="Oppressor&apos;s End" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">Melee</characteristic>
                     <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Melee</characteristic>
@@ -19111,7 +19111,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
               <profiles>
                 <profile id="a9ff-b596-8f65-af02" name="The Aurillian Shroud" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per battle at the start of the battle round, a model with this relic can unveil the Aurillian Shroud. Until the end of the battle round friendly BLACK TEMPLARS units have a 4+ invulnerable save whilst thier unit is within 3&quot; of a model with this relic.</characteristic>
+                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per battle at the start of the battle round, a model with this relic can unveil the Aurillian Shroud. Until the end of the battle round friendly BLACK TEMPLARS units have a 4+ invulnerable save whilst their unit is within 3&quot; of a model with this relic.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -19171,7 +19171,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
               <profiles>
                 <profile id="b496-be57-7a3d-9818" name="Witchseeker Bolts" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Select one bolt weapon this model is equipped with. When the bearer shoots with that weapon, you can choose to fire a Witchseeker round. If you do, you can only make 1 attack with that weapon, but that attack can target an enemy PSYKER CHARACTER unit even if it is not the closest enemy unit. When resolving an attack made by with a witchseeker round against a PSYKER unit, if a hit is scored the target suffers D3 mortal wounds in addition to any other damage. </characteristic>
+                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Select one bolt weapon this model is equipped with. When the bearer shoots with that weapon, you can choose to fire a Witchseeker round. If you do, you can only make 1 attack with that weapon, but that attack can target an enemy PSYKER CHARACTER unit even if it is not the closest enemy unit. When resolving an attack made with a witchseeker round against a PSYKER unit, if a hit is scored the target suffers D3 mortal wounds in addition to any other damage. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -19183,7 +19183,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
               <profiles>
                 <profile id="da24-787f-99fb-e747" name="Skull of Cacodominus" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per battle after a psychic power has been manifested by an enemy PSKER model within 12&quot; inches of a model with this relic, one one D6. One a 2+ that model suffers D3 mortal wounds after that psyhic power has been resolved. </characteristic>
+                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per battle after a psychic power has been manifested by an enemy PSYKER model within 12&quot; inches of a model with this relic, one one D6. One a 2+ that model suffers D3 mortal wounds after that psychic power has been resolved. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -19453,12 +19453,12 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="46d1-cf91-b1e5-2eba" name="Warden of Mcragge" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="46d1-cf91-b1e5-2eba" name="Warden of Macragge" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5f5-ef17-725e-0986" type="max"/>
               </constraints>
               <profiles>
-                <profile id="8dd0-79be-d8da-318a" name="Warden of Mcragge" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+                <profile id="8dd0-79be-d8da-318a" name="Warden of Macragge" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
                     <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This Warlord can perform a Heroic Intervention if there are any enemy units within 6&quot; of them instead of 3&quot;, and when doing so can move up to 6&quot; instead of 3&quot;.</characteristic>
                   </characteristics>
@@ -20288,7 +20288,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
               <characteristics>
                 <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">6</characteristic>
                 <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">18&quot;</characteristic>
-                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">If manifested, select an enemy unit within 18&quot; of and visible to the psyker. Until the start of your next Psychic phase, subtract 1 from that unit&apos;s Leadership characteristic. In addition, your opponent must roll 2D6 - if the result is greate than that unit&apos;s Leadership characteristic, subtract 1 from hit rolls made for that unit until the start of your next Psychic phase.</characteristic>
+                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">If manifested, select an enemy unit within 18&quot; of and visible to the psyker. Until the start of your next Psychic phase, subtract 1 from that unit&apos;s Leadership characteristic. In addition, your opponent must roll 2D6 - if the result is greater than that unit&apos;s Leadership characteristic, subtract 1 from hit rolls made for that unit until the start of your next Psychic phase.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -21295,7 +21295,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
               <characteristics>
                 <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">6</characteristic>
                 <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">18&quot;</characteristic>
-                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Storm of the Emperor’s Wrathhas a warp charge value of 6. If manifested, select the nearest enemy unit that is within 18&quot; of and visible to this psyker. Roll one D6 for each model in that unit; for each 6 that unit suffers 1 mortal wound.</characteristic>
+                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Storm of the Emperor’s Wrath has a warp charge value of 6. If manifested, select the nearest enemy unit that is within 18&quot; of and visible to this psyker. Roll one D6 for each model in that unit; for each 6 that unit suffers 1 mortal wound.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -21314,7 +21314,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
               <characteristics>
                 <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">6</characteristic>
                 <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">18&quot;</characteristic>
-                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Psychic Shackleshas a warp charge value of 6. If manifested, select one enemy unit within 18&quot; of and visible to this psyker. Until the start of your next Psychic phase, halve the Move characteristic (rounding up) of models in that unit, and when a charge roll or Advance roll is made for that unit, subtract 1 from that roll. A unit cannot be affected by both this psychic power and the Tenebrous Curse psychic power at the same time.</characteristic>
+                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Psychic Shackles has a warp charge value of 6. If manifested, select one enemy unit within 18&quot; of and visible to this psyker. Until the start of your next Psychic phase, halve the Move characteristic (rounding up) of models in that unit, and when a charge roll or Advance roll is made for that unit, subtract 1 from that roll. A unit cannot be affected by both this psychic power and the Tenebrous Curse psychic power at the same time.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -21345,7 +21345,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="b77a-0596-4c4d-9ebe" name="Stormspeaking Discpline" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="b77a-0596-4c4d-9ebe" name="Stormspeaking Discipline" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -21425,7 +21425,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
               <characteristics>
                 <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">6</characteristic>
                 <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">12&quot;</characteristic>
-                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Ride the Windshas a warp charge value of 6. If manifested, select one friendly WHITE SCARSunit within 12&quot; of this psyker. Until the start of your next Psychic phase, when an Advance roll or charge roll is made for that unit, add 2 to the result.</characteristic>
+                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Ride the Winds has a warp charge value of 6. If manifested, select one friendly WHITE SCARSunit within 12&quot; of this psyker. Until the start of your next Psychic phase, when an Advance roll or charge roll is made for that unit, add 2 to the result.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -21463,7 +21463,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
               <characteristics>
                 <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">7</characteristic>
                 <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">18&quot;</characteristic>
-                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Blasting Galehas a warp charge value of 7. If manifested, select one enemy unit within 18&quot; of and visible to this psyker. Until the start of your next Psychic phase, that unit cannot Advance, and when a charge roll is made for it, roll one fewer D6, to a minimum of one D6 (typically, this will mean one D6 is rolled instead of 2D6).</characteristic>
+                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Blasting Gale has a warp charge value of 7. If manifested, select one enemy unit within 18&quot; of and visible to this psyker. Until the start of your next Psychic phase, that unit cannot Advance, and when a charge roll is made for it, roll one fewer D6, to a minimum of one D6 (typically, this will mean one D6 is rolled instead of 2D6).</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -21805,7 +21805,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
             <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b7f-d641-9465-30bd" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="4621-29cc-7a8e-be9f" name="Stormspeaking Discpline" hidden="false" collective="false" import="true" targetId="b77a-0596-4c4d-9ebe" type="selectionEntryGroup">
+        <entryLink id="4621-29cc-7a8e-be9f" name="Stormspeaking Discipline" hidden="false" collective="false" import="true" targetId="b77a-0596-4c4d-9ebe" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="dbc5-d5e3-4087-2ec2" value="0.0">
               <conditionGroups>
@@ -21977,7 +21977,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
           <profiles>
             <profile id="540d-6129-2dc8-cd4c" name="1) Flaming Blast" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Flaming Blasthas a warp charge value of 6. If manifested, select one point on the battlefield within 24&quot; of and visible to this psyker. Roll one D6 for each enemy unit within 3&quot; of that point; on a 4+ that unit suffers 1 mortal wound.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Flaming Blast has a warp charge value of 6. If manifested, select one point on the battlefield within 24&quot; of and visible to this psyker. Roll one D6 for each enemy unit within 3&quot; of that point; on a 4+ that unit suffers 1 mortal wound.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -21994,7 +21994,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
           <profiles>
             <profile id="8c3a-8180-b148-df8e" name="2) Fire Shield" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Fire Shieldhas a warp charge value of 6. If manifested, select one friendly SALAMANDERSunit within 18&quot; of this psyker. Until the start of your next Psychic phase, when resolving an attack made with a ranged weapon against that unit, subtract 1 from the hit roll. In addition, when a charge roll is made for a charge that unit is a target of, subtract 1 from the result.
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Fire Shield has a warp charge value of 6. If manifested, select one friendly SALAMANDERSunit within 18&quot; of this psyker. Until the start of your next Psychic phase, when resolving an attack made with a ranged weapon against that unit, subtract 1 from the hit roll. In addition, when a charge roll is made for a charge that unit is a target of, subtract 1 from the result.
 </characteristic>
               </characteristics>
             </profile>
@@ -22012,7 +22012,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
           <profiles>
             <profile id="b342-61af-6e2c-e416" name="3) Burning Hands" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Burning Handshas a warp charge value of 6. If manifested, then until the start of your next Psychic phase, when resolving an attack made with a close combat weapon (the profile for which can be found in the Warhammer 40,000 core rules) by this psyker, if a hit is scoredthe target suffers 1 mortal wound and the attack sequence ends.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Burning Hands has a warp charge value of 6. If manifested, then until the start of your next Psychic phase, when resolving an attack made with a close combat weapon (the profile for which can be found in the Warhammer 40,000 core rules) by this psyker, if a hit is scored the target suffers 1 mortal wound and the attack sequence ends.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -22046,7 +22046,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
           <profiles>
             <profile id="863c-e537-169b-38c4" name="5) Fury of Nocturne" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Fury of Nocturnehas a warp charge value of 6. If manifested, select one enemy unit within 18&quot; of and visible to this psyker. Roll 2D6; if the result is greater than the highest Toughness characteristic of models in that unit, that unit suffers D3 mortal wounds.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Fury of Nocturne has a warp charge value of 6. If manifested, select one enemy unit within 18&quot; of and visible to this psyker. Roll 2D6; if the result is greater than the highest Toughness characteristic of models in that unit, that unit suffers D3 mortal wounds.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -22063,7 +22063,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
           <profiles>
             <profile id="d26d-05de-4875-45a0" name="6) Draconic Aspect" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Draconic Aspecthas a warp charge value of 6. If manifested, then until the start of your next Psychic phase, subtract 2 from the Leadership characteristic of models in enemy units whilst their unit is within 12&quot; of this psyker.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Draconic Aspect has a warp charge value of 6. If manifested, then until the start of your next Psychic phase, subtract 2 from the Leadership characteristic of models in enemy units whilst their unit is within 12&quot; of this psyker.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -22096,7 +22096,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
           <profiles>
             <profile id="0e4b-f768-7e97-7e76" name="1) Tectonic Purge" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Tectonic Purgehas a warp charge value of 6. If manifested, then until the start of your next Psychic phase, when a charge roll is made for an enemy unit within 12&quot; of this psyker, subtract 2 from the result. </characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Tectonic Purge has a warp charge value of 6. If manifested, then until the start of your next Psychic phase, when a charge roll is made for an enemy unit within 12&quot; of this psyker, subtract 2 from the result. </characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -22113,7 +22113,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
           <profiles>
             <profile id="e4c1-19b0-8784-b3a6" name="2) Wrack and Ruin" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Wrack and Ruinhas a warp charge value of 6. If manifested, select one BUILDINGunit within 18&quot; of and visible to this psyker, or select one enemy unit that is wholly within or on a terrain feature and is within 18&quot; of and visible to this psyker. Roll nine D6, adding 1 to the result if the unit you selected was a BUILDING; for each roll of 5+ that unit suffers 1 mortal wound.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Wrack and Ruin has a warp charge value of 6. If manifested, select one BUILDINGunit within 18&quot; of and visible to this psyker, or select one enemy unit that is wholly within or on a terrain feature and is within 18&quot; of and visible to this psyker. Roll nine D6, adding 1 to the result if the unit you selected was a BUILDING; for each roll of 5+ that unit suffers 1 mortal wound.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -22130,7 +22130,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
           <profiles>
             <profile id="45c0-276a-5802-3a37" name="3) Iron Inferno" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Iron Infernohas a warp charge value of 6. If manifested, select one point on the battlefield within 18&quot; of and visible to this psyker. Roll one D6 for each enemy unit within 6&quot; of that point; on a 4+ that unit suffers 1 mortal wound.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Iron Inferno has a warp charge value of 6. If manifested, select one point on the battlefield within 18&quot; of and visible to this psyker. Roll one D6 for each enemy unit within 6&quot; of that point; on a 4+ that unit suffers 1 mortal wound.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -22164,7 +22164,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
           <profiles>
             <profile id="a7cc-c7d4-7a8d-1d2c" name="5) Aspect of Stone" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Aspect of Stonehas a warp charge value of 5. If manifested, then until the start of your next Psychic phase, add 2 to this psyker’s Strength and Toughness characteristics. 
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Aspect of Stone has a warp charge value of 5. If manifested, then until the start of your next Psychic phase, add 2 to this psyker’s Strength and Toughness characteristics.
 </characteristic>
               </characteristics>
             </profile>
@@ -22237,7 +22237,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
           <profiles>
             <profile id="ebd3-0d66-8c05-8a73" name="Singular Presence" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Friendly &lt;CHAPTER&gt; INFANTRY, BIKER and DREADNOUGHT units within 3&quot; of this Warlord can perfrom Heroic Interventions as if they were CHARACTERS</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Friendly &lt;CHAPTER&gt; INFANTRY, BIKER and DREADNOUGHT units within 3&quot; of this Warlord can perform Heroic Interventions as if they were CHARACTERS</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -22480,7 +22480,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
           <profiles>
             <profile id="6705-b35b-58dc-bcb9" name="Wise Orator" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When you roll to determine if a llitany recited by this Warlord is inspiring, you can re-roll the dice</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When you roll to determine if a litany recited by this Warlord is inspiring, you can re-roll the dice</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -22833,7 +22833,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
           <profiles>
             <profile id="3612-13c4-e7c4-7627" name="Pennant of the Fallen" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">&lt;CHAPTER&gt; models that attack with one of thier melee weapons as  a result of this model&apos;s Astartes Banner ability can make two attacks instead of one</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">&lt;CHAPTER&gt; models that attack with one of their melee weapons as  a result of this model&apos;s Astartes Banner ability can make two attacks instead of one</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -23028,7 +23028,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
           <profiles>
             <profile id="835a-e26a-8aa8-8d9e" name="The Armour Indomitus" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The wearer of the Armour Indomitus has a Save characteristic of 2+. In addition, once per battle, before making one of the wearer&apos;s saving throws, you can choose to activate the armour&apos;s force field. When you do so, the Armour Indomitus confers a 3+ invulverable save for the remainder of the turn.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The wearer of the Armour Indomitus has a Save characteristic of 2+. In addition, once per battle, before making one of the wearer&apos;s saving throws, you can choose to activate the armour&apos;s force field. When you do so, the Armour Indomitus confers a 3+ invulnerable save for the remainder of the turn.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -23298,7 +23298,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
           <profiles>
             <profile id="34ae-30b0-71a8-4ad6" name="The Emperor&apos;s Judgement" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When resolving an attack made agaisnt this model with this relic, your opponent cannot re-roll the hit roll, wound roll, or damage roll. In addition, when a Morale test is taken for an enemy unit within 6&quot; of this model, roll two dice and discard the lowest(or either if they are the same)</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When resolving an attack made against this model with this relic, your opponent cannot re-roll the hit roll, wound roll, or damage roll. In addition, when a Morale test is taken for an enemy unit within 6&quot; of this model, roll two dice and discard the lowest(or either if they are the same)</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -23693,7 +23693,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
       <description>If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield and before any embarked models disembark. On a 6 it explodes, and each unit within 6&quot; suffers D6 mortal wounds.</description>
     </rule>
     <rule id="60e6-2b02-c072-469e" name="Defenders of Humanity" hidden="false">
-      <description>If your army os battle-forged, all Troops units in Space Marine Detachments gain this ability. Such a unit thst is within range of an objective marker controls the objective market even if there are more enemy models within range of that objective marker. If an enemy unit within range of the same objective marker </description>
+      <description>If your army is battle-forged, all Troops units in Space Marine Detachments gain this ability. Such a unit that is within range of an objective marker controls the objective market even if there are more enemy models within range of that objective marker. If an enemy unit within range of the same objective marker </description>
     </rule>
   </sharedRules>
   <sharedProfiles>
@@ -23759,12 +23759,12 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
     </profile>
     <profile id="b6ba-39af-6402-3665" name="Company Heroes" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During deployment, all models in this unit must be set up at the same time, though they do not need to be set up in unit coherency. From that point onwards, each Primaris Lieutenant is treated as a seperate unit.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During deployment, all models in this unit must be set up at the same time, though they do not need to be set up in unit coherency. From that point onwards, each Primaris Lieutenant is treated as a separate unit.</characteristic>
       </characteristics>
     </profile>
     <profile id="6586-5d43-b320-83cf" name="Astartes Banner" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">&lt;CHAPTER&gt; units within 6&quot;of any friendly &lt;CHAPTER&gt; ANCIENTS add 1 to their Leadership. In addition, roll a D6 each time a &lt;CHAPTER&gt; INFANTRY model is destroyed within 6&quot; of any friendly &lt;CHAPTER&gt; ANCIENTS, before removing the model as a casualty. On a 4+ that model musters one last surge of strength before succuming to its wounds; it can either shoot with one of its weapons as if it were the Shooting phase, or make a single attack as if it were the Fight phase.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">&lt;CHAPTER&gt; units within 6&quot;of any friendly &lt;CHAPTER&gt; ANCIENTS add 1 to their Leadership. In addition, roll a D6 each time a &lt;CHAPTER&gt; INFANTRY model is destroyed within 6&quot; of any friendly &lt;CHAPTER&gt; ANCIENTS, before removing the model as a casualty. On a 4+ that model musters one last surge of strength before succumbing to its wounds; it can either shoot with one of its weapons as if it were the Shooting phase, or make a single attack as if it were the Fight phase.</characteristic>
       </characteristics>
     </profile>
     <profile id="9a48-b883-2c2b-71cb" name="Combat Shield" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -23779,12 +23779,12 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
     </profile>
     <profile id="d488-59b5-28cb-96fd" name="Command Squad Bodyguard" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a dice each time a friendly &lt;CHAPTER&gt; CHARACTER loses a wound whilst they are within 3&quot; of this unit; on a 2+ a model from this squad can intercept that hit - the charater does not lose a wound but this unt suffers a mortal wound.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a dice each time a friendly &lt;CHAPTER&gt; CHARACTER loses a wound whilst they are within 3&quot; of this unit; on a 2+ a model from this squad can intercept that hit - the character does not lose a wound but this unt suffers a mortal wound.</characteristic>
       </characteristics>
     </profile>
     <profile id="bde4-2791-d683-a7ed" name="Biker Bodyguard" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a dice each time a friendly &lt;CHAPTER&gt; BIKER CHARACTER loses a wound whilst they are within 3&quot; of this unit; on a 2+ a model from this squad can intercept that hit - the charater does not lose a wound but this unt suffers a mortal wound.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a dice each time a friendly &lt;CHAPTER&gt; BIKER CHARACTER loses a wound whilst they are within 3&quot; of this unit; on a 2+ a model from this squad can intercept that hit - the character does not lose a wound but this unt suffers a mortal wound.</characteristic>
       </characteristics>
     </profile>
     <profile id="3e31-4e4b-6ab6-d90b" name="Combat Squads" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -23835,12 +23835,12 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
     </profile>
     <profile id="4354-1572-8be0-2ea3" name="Centurion Assault Launchers" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If a model with Centurian Assault Launchers finishes a charge move within 1&quot; of an enemy unit, roll a D6 - on a 4+ that unit suffers a mortal wound.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If a model with Centurion Assault Launchers finishes a charge move within 1&quot; of an enemy unit, roll a D6 - on a 4+ that unit suffers a mortal wound.</characteristic>
       </characteristics>
     </profile>
     <profile id="66eb-ddf5-9810-3026" name="Omniscope" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Enemy units do not receive the benefit to their saving throws for being in cover against attacks made by a unit that includes a Centurian Sergeant.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Enemy units do not receive the benefit to their saving throws for being in cover against attacks made by a unit that includes a Centurion Sergeant.</characteristic>
       </characteristics>
     </profile>
     <profile id="cdb4-e266-8c8b-b51c" name="Space Marine Sergeant" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -23943,7 +23943,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
     </profile>
     <profile id="1da0-3127-d978-6dc2" name="Cataphractii Armour" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Models in this unit have a 4+ invulnerable save but you must halve the result of the dice rolled when dertermaining har far this model advances.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Models in this unit have a 4+ invulnerable save but you must halve the result of the dice rolled when determining har far this model advances.</characteristic>
       </characteristics>
     </profile>
     <profile id="dc14-c594-6abc-3e0a" name="Tartaros Armour" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -23976,7 +23976,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
     </profile>
     <profile id="d094-0d22-e764-18dc" name="Open Topped" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Models embarked on this vehicle can shoot in their Shooting phase. They measure ranged and draw line of sight from any point on the vehicle. When they do so, any restrictions or modifiers that apply to this model also apply to its passengers. Note that the passangers cannot shoot if this model Falls Back, even those this model itself can.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Models embarked on this vehicle can shoot in their Shooting phase. They measure range and draw line of sight from any point on the vehicle. When they do so, any restrictions or modifiers that apply to this model also apply to its passengers. Note that the passengers cannot shoot if this model Falls Back, even those this model itself can.</characteristic>
       </characteristics>
     </profile>
     <profile id="3f33-636e-17fd-9a79" name="Anti-grav Upwash" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -23991,7 +23991,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
     </profile>
     <profile id="7472-621a-b7e6-1819" name="Servo-skull Hub" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">In each of youe shooting phases, choose one of the following effects:  Targeting Data Skull: Add 1 to hit rolls made for a single friendly CHAPTER unit within 12&quot; of this model until the end of the phase.  Repair Skull: Choose a single CHAPTER VEHICLE within 12&quot; of this model. That model regains 1 lost wound.  Vox Skull: Subtract 1 from Morale tests taken for friendly CHAPTER units within 12&quot; of this model until your next shooting phase.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">In each of your shooting phases, choose one of the following effects:  Targeting Data Skull: Add 1 to hit rolls made for a single friendly CHAPTER unit within 12&quot; of this model until the end of the phase.  Repair Skull: Choose a single CHAPTER VEHICLE within 12&quot; of this model. That model regains 1 lost wound.  Vox Skull: Subtract 1 from Morale tests taken for friendly CHAPTER units within 12&quot; of this model until your next shooting phase.</characteristic>
       </characteristics>
     </profile>
     <profile id="fc27-b833-f689-e835" name="Infernum Halo-launcher" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -24006,7 +24006,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
     </profile>
     <profile id="ff68-151c-f4b2-1f97" name="Hover Jet" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Before this model moves in your Movement phase, you can declare it will hover. Its Move characteristic becomes 20&quot; until the end of the phase, and it loses Aireborne, Hard to Hit, and Supersonic abilitied until beginning of your next Movement Phase.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Before this model moves in your Movement phase, you can declare it will hover. Its Move characteristic becomes 20&quot; until the end of the phase, and it loses Airborne, Hard to Hit, and Supersonic abilities until beginning of your next Movement Phase.</characteristic>
       </characteristics>
     </profile>
     <profile id="06e9-cf5a-6396-b114" name="Signum" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -24021,12 +24021,12 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
     </profile>
     <profile id="4b31-7acf-0d2a-4973" name="Power of the Machine Spirit" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model does not suffer he penalty to hit rolls for moving and firing Heavy Weapons.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model does not suffer the penalty to hit rolls for moving and firing Heavy Weapons.</characteristic>
       </characteristics>
     </profile>
     <profile id="26a1-7cd2-c9e6-d6ab" name="Frag Assault Launchers" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a D6 each time this models finishes a charge move within 1&quot; of an emeny unit; on a 4+ that unit suffers D3 motal wounds.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a D6 each time this models finishes a charge move within 1&quot; of an enemy unit; on a 4+ that unit suffers D3 mortal wounds.</characteristic>
       </characteristics>
     </profile>
     <profile id="f049-4a94-49b9-7f14" name="Infiltrator" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -24360,7 +24360,7 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
     </profile>
     <profile id="eb6d-5525-bbe8-6d0a" name="Company Heroes" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During deployment, all models in this unit must be set up at the same time, though they do not need to be set up in unit coherency. From that point onwards, each Lieutenant is treated as a seperate unit.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During deployment, all models in this unit must be set up at the same time, though they do not need to be set up in unit coherency. From that point onwards, each Lieutenant is treated as a separate unit.</characteristic>
       </characteristics>
     </profile>
     <profile id="05cc-be62-d02a-ff67" name="Anvil of Strength" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -24493,12 +24493,12 @@ Crewed Artillery:After this unit is set up on the battlefield for the first time
     </profile>
     <profile id="7cbf-7a62-18e3-6b18" name="Superlative Duellist" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When resolving an attack made with a melee weapon by this model against a CHARACTER unit, you can re-roll the hit roll and you can reroll the wound roll. </characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When resolving an attack made with a melee weapon by this model against a CHARACTER unit, you can re-roll the hit roll and you can re-roll the wound roll. </characteristic>
       </characteristics>
     </profile>
     <profile id="c1ae-78d7-31b4-55ea" name="Martial Superiority" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model is within 1&quot; of any enemy CHARACTER models at the start of the fight phase, it can fight first in the fight phase, even if it did not charge.  If the enemy has units that have charged, or that have a similar ability, then alternate choosing units to fight with, starting with the player who&apos;s turn is taking place. </characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model is within 1&quot; of any enemy CHARACTER models at the start of the fight phase, it can fight first in the fight phase, even if it did not charge.  If the enemy has units that have charged, or that have a similar ability, then alternate choosing units to fight with, starting with the player whose turn is taking place. </characteristic>
       </characteristics>
     </profile>
     <profile id="0e8b-44ab-6b00-31ae" name="Orbital Comms Array" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">


### PR DESCRIPTION
Typo fixes for OldMarines and ChadMarines alike.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.