### PR TITLE
Fix: Typos - Necrons

### DIFF
--- a/Necrons.cat
+++ b/Necrons.cat
@@ -128,7 +128,7 @@
     <categoryEntry id="c276-12d8-a188-16a2" name="Canoptek Scarab Swarms" hidden="false"/>
     <categoryEntry id="b606-2a05-51fe-7432" name="Canoptek Spyders" hidden="false"/>
     <categoryEntry id="c35b-bfb6-1254-19d5" name="Heavy Destroyers" hidden="false"/>
-    <categoryEntry id="f018-ec28-e87f-314d" name="Destoyers" hidden="false"/>
+    <categoryEntry id="f018-ec28-e87f-314d" name="Destroyers" hidden="false"/>
     <categoryEntry id="9536-4257-909e-fd69" name="Doomsday Ark" hidden="false"/>
     <categoryEntry id="5d3c-3efe-3c1d-4d6d" name="Monolith" hidden="false"/>
     <categoryEntry id="a78e-c548-f087-09f8" name="Annihilation Barge" hidden="false"/>
@@ -3862,7 +3862,7 @@
         </profile>
         <profile id="b1fe-66c4-b145-eb8d" name="Transient Madness" publicationId="61c6-c8c5-pubN65537" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a D3 at the beginning of your turn and consult the consult the following table.  Choose a friendly SAUTEKH INFANTRY unit within 6&quot; of Nemesor Zahndrekh to gain the relevant ability until the beginning of your next turn.    1) Avenge the Fallen: Add 1 to the Attacks characteristic of models in this unit.  2) Quell the Rebellion: Improve the Ballistic Skill of models in this unit by 1 (e.g. a Ballistic Skill of 3+ becomes 2+).  3) Solarmills? Charge!: Re-roll failed charge rolls for this unit.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a D3 at the beginning of your turn and consult the following table.  Choose a friendly SAUTEKH INFANTRY unit within 6&quot; of Nemesor Zahndrekh to gain the relevant ability until the beginning of your next turn.    1) Avenge the Fallen: Add 1 to the Attacks characteristic of models in this unit.  2) Quell the Rebellion: Improve the Ballistic Skill of models in this unit by 1 (e.g. a Ballistic Skill of 3+ becomes 2+).  3) Solarmills? Charge!: Re-roll failed charge rolls for this unit.</characteristic>
           </characteristics>
         </profile>
         <profile id="7fea-0337-b660-57b3" name="My Will Be Done (Zahndrekh)" publicationId="61c6-c8c5-pubN65537" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -5306,7 +5306,7 @@
             <characteristic name="S" typeId="59b1-319e-ec13-d466">*</characteristic>
             <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
             <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">This weapon automatically hits its target and wounds onf a 2+, unless it is targeting a VEHICLE, in which case it wounds on a 6+</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">This weapon automatically hits its target and wounds on a 2+, unless it is targeting a VEHICLE, in which case it wounds on a 6+</characteristic>
           </characteristics>
         </profile>
         <profile id="4df6-8a42-ac16-5796" name="Singularity Chamber (Solar Fire)" publicationId="03b4-8286-592c-c370" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -5521,7 +5521,7 @@
         </profile>
         <profile id="8727-c784-5acf-9200" name="Ziggurat Dock" publicationId="03b4-8286-592c-c370" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">A single friendly MONOLITH or SENTRY PYLON can dock with the Tomb Ziggurat during deployment.  Whilst upon the Tomb Ziggurat, all weapons on the docked model gain +1 to their Strength.  A MONOLITH cannot use its own eternity gate whist docked with a Tomb Ziggurat.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">A single friendly MONOLITH or SENTRY PYLON can dock with the Tomb Ziggurat during deployment.  Whilst upon the Tomb Ziggurat, all weapons on the docked model gain +1 to their Strength.  A MONOLITH cannot use its own eternity gate whilst docked with a Tomb Ziggurat.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -6283,7 +6283,7 @@
             <characteristic name="S" typeId="59b1-319e-ec13-d466">x2</characteristic>
             <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
             <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">3</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When attacking with this weapon, subract 1 from the hit roll.</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When attacking with this weapon, subtract 1 from the hit roll.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -8569,7 +8569,7 @@
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="cba7-3427-625e-eb99" name="Reanimation Protocols" publicationId="61c6-c8c5-pubN65537" hidden="false">
-      <description>Roll a D6 for each slain model from this unit (unless the whole unit has been completely destroyed) at the beginning of your turn.  Do not roll for models that have fled the unit.  On a 5+, the model&apos;s reanimation protocols activate and it is returned to this unit with its full compliment of wounds, otherwise it remains inactive (although you can roll again at the start of each of your subsequent turns). When a model’s reanimation protocols activate, set it up in unit coherency with any model from this unit that has not returned to the unit as a result of reanimation protocols this turn, and more than 1&quot; from enemy models.  If you cannot do this because there is no room to place the model, do not set it up (you can make Reanimation Protocols rolls for this model again in subsequent turns).</description>
+      <description>Roll a D6 for each slain model from this unit (unless the whole unit has been completely destroyed) at the beginning of your turn.  Do not roll for models that have fled the unit.  On a 5+, the model&apos;s reanimation protocols activate and it is returned to this unit with its full complement of wounds, otherwise it remains inactive (although you can roll again at the start of each of your subsequent turns). When a model’s reanimation protocols activate, set it up in unit coherency with any model from this unit that has not returned to the unit as a result of reanimation protocols this turn, and more than 1&quot; from enemy models.  If you cannot do this because there is no room to place the model, do not set it up (you can make Reanimation Protocols rolls for this model again in subsequent turns).</description>
     </rule>
     <rule id="601f-ad02-3e1f-fcc4" name="Living Metal" publicationId="61c6-c8c5-pubN65537" hidden="false">
       <description>At the beginning of your turn, this unit regains 1 lost wound.</description>
@@ -8618,7 +8618,7 @@
     </profile>
     <profile id="a977-75d0-a5ce-8e6c" name="Quantum Shielding" publicationId="61c6-c8c5-pubN65537" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time this model fails a saving throw, roll a D6.  If the result is less than the damage inflicted by that attack, the damage is ignored (e.g. if this model suffers 4 damage, if you then roll a 3 or less the damage is ignored).  Quantium Shielding cannot prevent damage caused by mortal wounds.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time this model fails a saving throw, roll a D6.  If the result is less than the damage inflicted by that attack, the damage is ignored (e.g. if this model suffers 4 damage, if you then roll a 3 or less the damage is ignored).  Quantum Shielding cannot prevent damage caused by mortal wounds.</characteristic>
       </characteristics>
     </profile>
     <profile id="e837-8e96-6423-5d20" name="Gauss Blaster" publicationId="61c6-c8c5-pubN65537" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">

--- a/Necrons.cat
+++ b/Necrons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="61c6-c8c5-a304-ff5f" name="Necrons" revision="75" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Dr. Toboggan" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="153" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="61c6-c8c5-a304-ff5f" name="Necrons" revision="76" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Dr. Toboggan" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="153" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="61c6-c8c5-pubN65537" name="Codex: Necrons" shortName="Necrons" publisher="Codex: Necrons" publicationDate="March 2018" publisherUrl="https://www.games-workshop.com/en-US/Codex-Necrons-2018-ENG"/>
     <publication id="61c6-c8c5-pubN106894" name="Seraptek Construct Datasheet" shortName="FW Datasheet" publisher="Forgeworld Website" publisherUrl="https://www.forgeworld.co.uk/resources/PDF/Downloads/Forgeworld_Necron_Seraptek_Datasheet.pdf"/>


### PR DESCRIPTION
Typo fixes for these robo skellies who use their gods like Pokemon.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.