### PR TITLE
Fix: Typos - Orks

### DIFF
--- a/Orks.cat
+++ b/Orks.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="11b5-77b9-31bf-7b74" name="Orks" revision="89" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Tag8833" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="156" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="11b5-77b9-31bf-7b74" name="Orks" revision="90" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Tag8833" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="156" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="11b5-77b9-pubN65537" name="Codex: Orks"/>
     <publication id="7add-2f4d-3d89-78df" name="White Dwarf May 2020" shortName="WD520" publisher="White Dwarf" publisherUrl="May 2020"/>

--- a/Orks.cat
+++ b/Orks.cat
@@ -8801,7 +8801,7 @@ When rolling to wound this unit, use the Big Mek’s Toughness while it is on th
             <characteristic name="S" typeId="59b1-319e-ec13-d466">2D6</characteristic>
             <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
             <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">4</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Before firing this weapon, roll to determine the Strength of the shot.  If the result is 12, do not make a wound roll.  Instead, if the attack hits, each causes 3 mortal wounds.  Then the bearer suffers a mortal wound.</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Before firing this weapon, roll to determine the Strength of the shot.  If the result is 12, do not make a wound roll.  Instead, if the attack hits, each cause 3 mortal wounds.  Then the bearer suffers a mortal wound.</characteristic>
           </characteristics>
         </profile>
       </profiles>

--- a/Orks.cat
+++ b/Orks.cat
@@ -97,7 +97,7 @@
     <categoryEntry id="5ed3-1da6-32fe-c3a2" name="Battlewagon" hidden="false"/>
     <categoryEntry id="333e-4a17-5197-ddb3" name="Deff Dread" hidden="false"/>
     <categoryEntry id="06fd-96ed-49f8-8b07" name="Killa Kans" hidden="false"/>
-    <categoryEntry id="6562-99dc-d2f5-0863" name="Gorkanaunt" hidden="false"/>
+    <categoryEntry id="6562-99dc-d2f5-0863" name="Gorkanaut" hidden="false"/>
     <categoryEntry id="9052-f7b4-95fa-16f6" name="Lootas" hidden="false"/>
     <categoryEntry id="8253-2ac7-7fc4-8387" name="Morkanaut" hidden="false"/>
     <categoryEntry id="f76c-e1e9-4ded-f652" name="Stompa" hidden="false"/>
@@ -1841,7 +1841,7 @@ When rolling to wound this unit, use the Big Mek’s Toughness while it is on th
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4915-751e-0f0b-a656" type="max"/>
       </constraints>
       <profiles>
-        <profile id="349e-8a45-502d-7fdb" name="Ghazghkul Thraka" publicationId="11b5-77b9-pubN65537" page="84" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="349e-8a45-502d-7fdb" name="Ghazghkull Thraka" publicationId="11b5-77b9-pubN65537" page="84" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">*</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">2+</characteristic>
@@ -3990,7 +3990,7 @@ When rolling to wound this unit, use the Big Mek’s Toughness while it is on th
       <profiles>
         <profile id="d652-d53c-bf8f-888d" name="Full Throttle" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When this unit advances you can add 6&quot; to it&apos;s movement rather than rolling a dice. But if you do so, you roll a D6 for each model in the unit at the end of the phase;  for each roll of 1, the unit suffers 1 mortal wound.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When this unit advances you can add 6&quot; to its movement rather than rolling a dice. But if you do so, you roll a D6 for each model in the unit at the end of the phase;  for each roll of 1, the unit suffers 1 mortal wound.</characteristic>
           </characteristics>
         </profile>
         <profile id="3a04-f936-098a-323b" name="Stormboyz Strike" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -5466,7 +5466,7 @@ When rolling to wound this unit, use the Big Mek’s Toughness while it is on th
         </profile>
         <profile id="7a01-5911-f421-1d43" name="Grot Krew" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each Mek Gun and its grot krew are treated as a single model for all rules purposes.  the Krew must remain within 1&quot; of their Mek Gun and cannot be targeted or attacked separately.  The range and visibility of all attacks made by a Mek Gun are measured from the Mek Gun, not the krew.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each Mek Gun and its grot krew are treated as a single model for all rules purposes.  The Krew must remain within 1&quot; of their Mek Gun and cannot be targeted or attacked separately.  The range and visibility of all attacks made by a Mek Gun are measured from the Mek Gun, not the krew.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5673,7 +5673,7 @@ When rolling to wound this unit, use the Big Mek’s Toughness while it is on th
           <profiles>
             <profile id="3035-54b5-7f4f-57f8" name="&apos;ard Case" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model is equipped with an &apos;ard case, it&apos;s Toughness characteristic is increased by 1 and it loses the Open-topped ability.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model is equipped with an &apos;ard case, its Toughness characteristic is increased by 1 and it loses the Open-topped ability.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -6709,7 +6709,7 @@ When rolling to wound this unit, use the Big Mek’s Toughness while it is on th
       <profiles>
         <profile id="7770-d670-a206-9cd0" name="Bigger &apos;n&apos; Stompier" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model is eligible to declare a charge in a turn in which it Fell Back. Each time this model makes a Normal Move, Advances or Falls Back, it can be moved across other models (exclud i ng Monster and Vehicle models) as if they were not there, and when it does it can be moved within Engagement Range of such models, but cannot finish its move within Engagement Range of any of them.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model is eligible to declare a charge in a turn in which it Fell Back. Each time this model makes a Normal Move, Advances or Falls Back, it can be moved across other models (excluding Monster and Vehicle models) as if they were not there, and when it does it can be moved within Engagement Range of such models, but cannot finish its move within Engagement Range of any of them.</characteristic>
           </characteristics>
         </profile>
         <profile id="b0fb-121e-923e-aea1" name="Stompa" publicationId="11b5-77b9-pubN65537" page="117" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -8159,7 +8159,7 @@ When rolling to wound this unit, use the Big Mek’s Toughness while it is on th
         </profile>
         <profile id="29fa-8952-1426-884e" name="Ramshackle Monster" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time a Meka-Dread loses a wound from any weapon, roll a D6 - on a roll of 4+, the wound is ignored.  The 1st time this roll is failed, the result needed is reduced to a 5+, and so on unti the roll fails on a 6+ and this ability may no longer be used.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time a Meka-Dread loses a wound from any weapon, roll a D6 - on a roll of 4+, the wound is ignored.  The 1st time this roll is failed, the result needed is reduced to a 5+, and so on until the roll fails on a 6+ and this ability may no longer be used.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -8801,7 +8801,7 @@ When rolling to wound this unit, use the Big Mek’s Toughness while it is on th
             <characteristic name="S" typeId="59b1-319e-ec13-d466">2D6</characteristic>
             <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
             <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">4</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Before firing this weapon, roll to determine the Strength of the shot.  If the result is 12, do not make a wound roll.  Instead, if the attack hits, each cause 3 mortal wounds.  Then the bearer suffers a mortal wound.</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Before firing this weapon, roll to determine the Strength of the shot.  If the result is 12, do not make a wound roll.  Instead, if the attack hits, each causes 3 mortal wounds.  Then the bearer suffers a mortal wound.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -11518,7 +11518,7 @@ When rolling to wound this unit, use the Big Mek’s Toughness while it is on th
         </profile>
         <profile id="1957-8c7a-159c-4f7e" name="Kustom Job" publicationId="11b5-77b9-pubN65537" page="118" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of your movement phase one ORK VEHICLE unit from your army that is within 1&quot; of this model can receive a Kustom Job.  If it does so, until the end of your turn, that unit cannot shoot or charge, and the attacks characteristic of models in that unit are reduced to 1, but you can choose and resolve one of the following effects.    More Speed - Until the end of your next Movement phase increase the move characteristic of models in the unit by 6&quot; In addition, roll a D6 to see if the unit receives something &apos;extra speshul&apos;; on a 6 Add 1&quot; to the unit&apos;s charge moves for the rest of the battle.    More Rivvets - That unit regains D3 wounds.  If there is a MEK or BIG MEK from your army within 1&quot; of this model that has not used it&apos;s mekaniak ability to repair a vehicle yet this turn it can oversee the kustom job; if it does so, the unit regains 3 lost wounds instead of D3, and the model that oversaw the Kustom Job cannot use it&apos;s big mekaniak or mekaniak this turn.  In addition, roll a D6 to see if the unit receives something &apos;extra speshul&apos;; on a 6 add 1 to the Toughness characteristic for models in that unit for the rest of the battle.   More Dakka - Chose one weapon (excluding a bubblechukka) that a model in that unit is equipped with.  The next time any models in the unit fire that weapon, the weapon makes the maximum number of attacks (e.g. a weapon with the Heavy 2D6 type will fire 12 shots). In addition, roll a D6 to see if the unit receives something &apos;extra speshul&apos;; on a 6 add 1 to the chosen weapon&apos;s Damage characteristic for the rest of the battle.    A unit can only receive a kustom job once per turn.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of your movement phase one ORK VEHICLE unit from your army that is within 1&quot; of this model can receive a Kustom Job.  If it does so, until the end of your turn, that unit cannot shoot or charge, and the attacks characteristic of models in that unit are reduced to 1, but you can choose and resolve one of the following effects.    More Speed - Until the end of your next Movement phase increase the move characteristic of models in the unit by 6&quot; In addition, roll a D6 to see if the unit receives something &apos;extra speshul&apos;; on a 6 Add 1&quot; to the unit&apos;s charge moves for the rest of the battle.    More Rivvets - That unit regains D3 wounds.  If there is a MEK or BIG MEK from your army within 1&quot; of this model that has not used it&apos;s mekaniak ability to repair a vehicle yet this turn it can oversee the kustom job; if it does so, the unit regains 3 lost wounds instead of D3, and the model that oversaw the Kustom Job cannot use it&apos;s big mekaniak or mekaniak this turn.  In addition, roll a D6 to see if the unit receives something &apos;extra speshul&apos;; on a 6 add 1 to the Toughness characteristic for models in that unit for the rest of the battle.   More Dakka - Choose one weapon (excluding a bubblechukka) that a model in that unit is equipped with.  The next time any models in the unit fire that weapon, the weapon makes the maximum number of attacks (e.g. a weapon with the Heavy 2D6 type will fire 12 shots). In addition, roll a D6 to see if the unit receives something &apos;extra speshul&apos;; on a 6 add 1 to the chosen weapon&apos;s Damage characteristic for the rest of the battle.    A unit can only receive a kustom job once per turn.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -11824,7 +11824,7 @@ hit roll. </characteristic>
               <profiles>
                 <profile id="cb81-4dcc-1a25-4fe3" name="Madboyz" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Frantic: INFANTRY and BIKER units only (excluding GRETCHIN). At the start of each battle round, roll one D3 and consult the table below to establish what effect applies to units with this Subkultur until the end of the battle round. This roll cannot be re-rolled. 
+                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Frantic: INFANTRY and BIKER units only (excluding GRETCHIN). At the start of each battle round, roll one D3 and consult the table below to establish what effect applies to units with this Subkultur until the end of the battle round. This roll cannot be re-rolled.
 1. Moroniks : When resolving an attack that targets a unit with this Subkultur, add 1 to the saving throw (invulnerable saving throws are unaffected).
 2. Nuttaz : Units with this Subkultur automatically pass Morale tests.
 3. Frenzies: Add 1 to the Strength characteristic of models in a unit with this Subkultur</characteristic>
@@ -13907,7 +13907,7 @@ hit roll. </characteristic>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac42-1428-c2ed-cb47" type="max"/>
       </constraints>
       <profiles>
-        <profile id="6663-fb08-6655-a481" name="Ghazghkul Thraka" publicationId="11b5-77b9-pubN65537" page="84" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="6663-fb08-6655-a481" name="Ghazghkull Thraka" publicationId="11b5-77b9-pubN65537" page="84" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">5&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">2+</characteristic>
@@ -14299,7 +14299,7 @@ Detachment also includes Ghazghkull Thraka. Note, however, that this model does 
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">While this Warlord has fewer wounds remaining than it&apos;s Wounds characteristic, add 3 to its Attacks characteristic.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">While this Warlord has fewer wounds remaining than its Wounds characteristic, add 3 to its Attacks characteristic.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -16365,7 +16365,7 @@ more). Until the start of your next Psychic phase, when resolving an attack made
 In addition, immediately make an additional hit roll against the same target using the same weapon. These additional hit rolls cannot themselves generate extra hit rolls. When firing a weapon with randomly determined characteristics (ie. Bubblechukka), any additional hit rolls use the same characteristics as the hit roll that generated the additional hit roll.  This ability does not affect weapons that automatically hit their target.</description>
     </rule>
     <rule id="0b6c-1bcf-a37e-9f0c" name="Speed Mob" publicationId="11b5-77b9-pubN65537" page="82" hidden="false">
-      <description>The first time this unit sets up on the battlefield, all of its models must be placed within 6&quot; of at least one other  model from the unit.  From that point onwards each model operates independently and is treated as a seperate unit for all rules purposes.</description>
+      <description>The first time this unit sets up on the battlefield, all of its models must be placed within 6&quot; of at least one other  model from the unit.  From that point onwards each model operates independently and is treated as a separate unit for all rules purposes.</description>
     </rule>
     <rule id="3f88-a717-6763-c8f5" name="Grots" hidden="false">
       <description>Units comprised entirely of GRETCHIN cannot benefit from any Clan Kultur.  In addition, Ork Stratagems can only be used on these units if the Stratagem explicitly states so (e.g. the &apos;Grot Shields&apos; Stratagem)</description>
@@ -16483,7 +16483,7 @@ In addition, immediately make an additional hit roll against the same target usi
     </profile>
     <profile id="c284-5882-8566-317a" name="Open-Topped" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Models embarked on this model can attack in their Shooting phase. Measure the range and draw line of sight from any point on this model.  When they do so, any restrictions or modifiers that apply to this model also apply to its passengers. for example, the passengers cannot shoot if this model has Fallen Back in the same turn.
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Models embarked on this model can attack in their Shooting phase. Measure the range and draw line of sight from any point on this model.  When they do so, any restrictions or modifiers that apply to this model also apply to its passengers. For example, the passengers cannot shoot if this model has Fallen Back in the same turn.
 While this transport is within Engagement Range of any enemy units, embarked units cannot shoot, except with any Pistols they are equipped with.</characteristic>
       </characteristics>
     </profile>


### PR DESCRIPTION
Someone paint these typos red so they get out of here faster.

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.