### PR TITLE
Fix: Typos - Genestealer Cultists

### DIFF
--- a/Tyranids - Genestealer Cults.cat
+++ b/Tyranids - Genestealer Cults.cat
@@ -3988,7 +3988,7 @@
         </profile>
         <profile id="ce5b-1a80-987f-bbf1" name="Genomic Enhancement" publicationId="83b2-e602-pubN65537" page="93" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model can enhance one friendly &lt;CULT&gt; ABERRANT unit that is within 1&quot; of it at the end of each of your Movement phases. Roll a D6; on a 1, one model from the selected unit is slain. Then the roll a D3 and refer to the table below to see what bonus the survivors gain for the rest of the battle. A unit can only be the target of this ability once per battle.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model can enhance one friendly &lt;CULT&gt; ABERRANT unit that is within 1&quot; of it at the end of each of your Movement phases. Roll a D6; on a 1, one model from the selected unit is slain. Then roll a D3 and refer to the table below to see what bonus the survivors gain for the rest of the battle. A unit can only be the target of this ability once per battle.</characteristic>
           </characteristics>
         </profile>
         <profile id="a21a-b125-dfe0-19ab" name="1. Enhanced Musculature" hidden="false" typeId="d01c-5195-e332-7b24" typeName="Genomic Enhancement">
@@ -6320,7 +6320,7 @@ If your opponent has the first turn, then none of their units can be set up or e
               <characteristics>
                 <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">6</characteristic>
                 <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">18&quot;</characteristic>
-                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Select one eney unit within 18&quot; of an visible to this psyker. Roll a number of D6 equal the the number of HIVECULT models from your army within 3&quot; of that unit; for each roll of 6 that unit suffers 1 mortal wound.</characteristic>
+                <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Select one eney unit within 18&quot; of an visible to this psyker. Roll a number of D6 equal the number of HIVECULT models from your army within 3&quot; of that unit; for each roll of 6 that unit suffers 1 mortal wound.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -6468,9 +6468,9 @@ If your opponent has the first turn, then none of their units can be set up or e
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="729e-bfbe-3af1-b0fd" name="Twisted Helix: Muagenic Deviation" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="729e-bfbe-3af1-b0fd" name="Twisted Helix: Mutagenic Deviation" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" field="name" value="Power: Muagenic Deviation"/>
+            <modifier type="set" field="name" value="Power: Mutagenic Deviation"/>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
                 <conditionGroup type="or">
@@ -6500,7 +6500,7 @@ If your opponent has the first turn, then none of their units can be set up or e
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb21-8027-554b-5143" type="max"/>
           </constraints>
           <profiles>
-            <profile id="4b9f-615c-1ed3-5fb1" name="Muagenic Deviation" publicationId="4593-a2f0-546a-d6f2" page="78" hidden="false" typeId="ae70-4738-0161-bec0" typeName="Psychic Power">
+            <profile id="4b9f-615c-1ed3-5fb1" name="Mutagenic Deviation" publicationId="4593-a2f0-546a-d6f2" page="78" hidden="false" typeId="ae70-4738-0161-bec0" typeName="Psychic Power">
               <characteristics>
                 <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">6</characteristic>
                 <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">12&quot;</characteristic>
@@ -7689,9 +7689,9 @@ In addition, to represent Astra Militarum forces that have been subverted, you c
 
 If your army is Battle-forged, you can only include one ASTRA MILITARUM Detachment (one in which every unit has the ASTRA MILITARUM keyword) in your army for each GENESTEALER CULTS Detachment in that army. You cannot include ASTRA MILITARUM named characters in these Detachments, and these Detachments cannot be Specialist Detachments. These ASTRA MILITARUM Detachments are then known as BROOD BROTHERS Detachments, and every unit in them that has the &lt;REGIMENT&gt; or MILITARUM TEMPESTUS keyword must replace it in every instance on its datasheet with BROOD BROTHERS (if a unit does not have either of these keywords, it simply gains the BROOD BROTHERS keyword).
 
-BROOD BROTHERS Detachments do not gain any of the Detachment abilities listed in Codex: Astra Militarum, such as Regimental Doctrines, nor can they use any regiment-specific Stratagems, Orders etc. Furthermore, INFANTRY models in BROOD BROTHERS Detachments increase their Leadership characteristic by 1 and they gain the Unquestioning Loyalty ability. Units in BROOD BROTHERS Detachments do not gain the Cult Ambush ability. Your Warlord cannot be from a BROOD BROTHERS Detachment, and you cannot give any Relics to BROOD BROTHERS CHARACTERS. BROOD BROTHERS Detachments do not gain Command Benefits. This reflects that such Detachments are not a Genestealer Cult&apos;s primary fighting force, and the acquisition of such military assets is costly in terms of resource. The command benefits of Auxiliary Support Detachments are unaffected.
+BROOD BROTHERS Detachments do not gain any of the Detachment abilities listed in Codex: Astra Militarum, such as Regimental Doctrines, nor can they use any regiment-specific Stratagems, Orders etc. Furthermore, INFANTRY models in BROOD BROTHERS Detachments increase their Leadership characteristic by 1 and they gain the Unquestioning Loyalty ability. Units in BROOD BROTHERS Detachments do not gain the Cult Ambush ability. Your Warlord cannot be from a BROOD BROTHERS Detachment, and you cannot give any Relics to BROOD BROTHERS CHARACTERS. BROOD BROTHERS Detachments do not gain Command Benefits. This reflects that such Detachments are not a Genestealer Cult&apos;s primary fighting force, and the acquisition of such military assets is costly in terms of resources. The command benefits of Auxiliary Support Detachments are unaffected.
 
-BROOD BROTHERS units that have the Voice of Command or Tank Orders abilities (see Codex: Astra Militarum) cannot issue orders to any unit that has the GENSTEALER CULTS Faction keyword, nor can they issue orders to units that they would not have been able to issue orders to before they gained the BROOD BROTHERS keyword (e.g. a BROOD BROTHERS COMPANY COMMANDER cannot issue orders to a BROOD BROTHERS OGRYN unit or to a BROOD BROTHERS TEMPESTUS SCIONS unit).
+BROOD BROTHERS units that have the Voice of Command or Tank Orders abilities (see Codex: Astra Militarum) cannot issue orders to any unit that has the GENESTEALER CULTS Faction keyword, nor can they issue orders to units that they would not have been able to issue orders to before they gained the BROOD BROTHERS keyword (e.g. a BROOD BROTHERS COMPANY COMMANDER cannot issue orders to a BROOD BROTHERS OGRYN unit or to a BROOD BROTHERS TEMPESTUS SCIONS unit).
 
 BROOD BROTHERS TAUROX PRIMES can only transport 10 BROOD BROTHERS OFFICIO PREFECTUS INFANTRY models or 10 INFANTRY models that replaced their MILITARUM TEMPESTUS keyword with BROOD BROTHERS.</description>
     </rule>
@@ -7714,7 +7714,7 @@ BROOD BROTHERS TAUROX PRIMES can only transport 10 BROOD BROTHERS OFFICIO PREFEC
         <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
         <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
         <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
-        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">This weapon can only be fired if a model (excluding models with a Balistic Skill characteristic of &apos;-&apos;) is embarked upon the vehicle equipped with it. Blast</characteristic>
+        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">This weapon can only be fired if a model (excluding models with a Ballistic Skill characteristic of &apos;-&apos;) is embarked upon the vehicle equipped with it. Blast</characteristic>
       </characteristics>
     </profile>
     <profile id="7e36-8493-f7bf-c9e2" name="Clearance Incinerator" publicationId="83b2-e602-pubN65537" page="102" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -8114,7 +8114,7 @@ BROOD BROTHERS TAUROX PRIMES can only transport 10 BROOD BROTHERS OFFICIO PREFEC
     </profile>
     <profile id="eb65-363e-41a8-5cf5" name="Smoke Launchers" publicationId="83b2-e602-pubN65537" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per game, instead of shooting its weapons in the Shooting phase, this models can use its smoke launchers. If it does so, subtract 1 from hit rolls for attacks made with ranged weapons that target it until your next Shooting phase.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per game, instead of shooting its weapons in the Shooting phase, this model can use its smoke launchers. If it does so, subtract 1 from hit rolls for attacks made with ranged weapons that target it until your next Shooting phase.</characteristic>
       </characteristics>
     </profile>
     <profile id="85e0-86c8-dc67-9be5" name="Open-topped" publicationId="83b2-e602-pubN65537" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">


### PR DESCRIPTION
Praise the 4 typoed Emperor!

Original PR: https://github.com/BSData/wh40k/pull/8124, split to make review easier.