### PR TITLE
Further validation work

### DIFF
--- a/Aeldari - Craftworlds.cat
+++ b/Aeldari - Craftworlds.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="30b2-6f64-b85e-b4dc" name="Aeldari - Craftworlds" revision="106" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@FarseerV @WindstormSCR" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="159" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="30b2-6f64-b85e-b4dc" name="Aeldari - Craftworlds" revision="108" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@FarseerV @WindstormSCR" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="159" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="30b2-6f64-pubN137513" name="Codex: Craftworlds"/>
   </publications>
@@ -341,7 +341,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="7f58-11af-d17f-2e32" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="9d57-b32e-13bd-d85b" type="selectionEntry">
+        <entryLink id="7f58-11af-d17f-2e32" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e06-4ac5-f17a-ef59" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="424b-9272-89c1-3cd0" type="min"/>
@@ -377,16 +377,6 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
         <cost name="pts" typeId="points" value="155.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="9d57-b32e-13bd-d85b" name="Shuriken Pistol" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="661c-11df-fd15-ce9e" name="" hidden="false" targetId="56bb-69aa-22ea-acb9" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -712,7 +702,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="3fe8-403b-7f74-ac50" name="" hidden="false" collective="false" import="true" targetId="9d57-b32e-13bd-d85b" type="selectionEntry">
+        <entryLink id="3fe8-403b-7f74-ac50" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc41-ad37-9d8f-1097" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acfe-0d5d-7c8d-fe22" type="min"/>
@@ -1843,6 +1833,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="5a71-7827-b512-b168" name="Autarch (Legends)" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="074a-9a69-e93f-6c0c" name="Autarch" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -1902,7 +1904,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ba-8a6e-128a-0148" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="df26-10af-09f8-6c67" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="9d57-b32e-13bd-d85b" type="selectionEntry"/>
+            <entryLink id="df26-10af-09f8-6c67" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry"/>
             <entryLink id="597a-6d95-7542-5728" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="ea36-2191-cc7a-d06e" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -1937,6 +1939,15 @@
         <entryLink id="b1a3-f6f4-7c62-db0b" name="Is A Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
         <entryLink id="1924-1275-0902-0e35" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
         <entryLink id="c887-fbe9-d41f-a632" name="Relics of Ynnead" hidden="false" collective="false" import="true" targetId="9b35-7aef-974a-5b0f" type="selectionEntryGroup"/>
+        <entryLink id="62d2-37b9-f048-ed17" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
@@ -1945,6 +1956,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="2989-8d08-72fc-9556" name="Autarch with Swooping Hawk Wings (Legends)" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="7bbb-b20e-6ffe-a021" name="Autarch with Swooping Hawk Wings" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -2042,7 +2065,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="daba-a5a2-a70c-f13b" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="7b3a-7791-7880-1516" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="9d57-b32e-13bd-d85b" type="selectionEntry"/>
+            <entryLink id="7b3a-7791-7880-1516" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry"/>
             <entryLink id="4d3b-facd-a676-b181" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="ea36-2191-cc7a-d06e" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -2077,6 +2100,15 @@
         <entryLink id="fc5a-4199-00aa-d523" name="Is A Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
         <entryLink id="9380-595b-aedd-186b" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
         <entryLink id="b0f5-eaef-619c-5f80" name="Relics of Ynnead" hidden="false" collective="false" import="true" targetId="9b35-7aef-974a-5b0f" type="selectionEntryGroup"/>
+        <entryLink id="4829-4700-ab27-b2f3" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
@@ -2085,6 +2117,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="df35-8ec6-91e0-ae46" name="Autarch with Warp Jump Generator (Legends)" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="76d0-5daa-07d1-eec4" name="Autarch with Warp Jump Generator" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -2167,7 +2211,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c04-ea27-f591-18e2" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="980f-bf93-04db-753d" name="" hidden="false" collective="false" import="true" targetId="9d57-b32e-13bd-d85b" type="selectionEntry"/>
+            <entryLink id="980f-bf93-04db-753d" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry"/>
             <entryLink id="657b-19b9-f2a1-4758" name="" hidden="false" collective="false" import="true" targetId="ea36-2191-cc7a-d06e" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -2202,6 +2246,15 @@
         <entryLink id="5419-7279-37cf-487d" name="Is A Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
         <entryLink id="e697-df9e-f2c8-4289" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
         <entryLink id="7a1f-008e-b6b5-af22" name="Relics of Ynnead" hidden="false" collective="false" import="true" targetId="9b35-7aef-974a-5b0f" type="selectionEntryGroup"/>
+        <entryLink id="e801-60c3-5ffb-3977" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
@@ -2210,6 +2263,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="7a74-f56b-28ad-cd55" name="Autarch Skyrunner (Legends)" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="5f0f-e105-44e1-f47f" name="Autarch Skyrunner" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -2288,7 +2353,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4367-2797-9567-42d6" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="aab4-5361-9399-1733" name="" hidden="false" collective="false" import="true" targetId="9d57-b32e-13bd-d85b" type="selectionEntry"/>
+            <entryLink id="aab4-5361-9399-1733" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry"/>
             <entryLink id="0c75-3e27-d973-2f0a" name="" hidden="false" collective="false" import="true" targetId="ea36-2191-cc7a-d06e" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -2387,6 +2452,15 @@
           </modifiers>
         </entryLink>
         <entryLink id="8e9a-d6e1-648f-1790" name="Relics of Ynnead" hidden="false" collective="false" import="true" targetId="9b35-7aef-974a-5b0f" type="selectionEntryGroup"/>
+        <entryLink id="654c-5135-fedc-db3f" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
@@ -2530,6 +2604,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="85ec-b193-d2df-32cc" name="Farseer" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="5523-58be-820b-db47" name="Farseer" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -2565,7 +2651,7 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5682-e0cd-21ee-cce6" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="d3cf-65f1-7ba3-ac37" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="9d57-b32e-13bd-d85b" type="selectionEntry">
+        <entryLink id="d3cf-65f1-7ba3-ac37" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="9af3-0291-3858-c8ae" value="0.0">
               <conditions>
@@ -2600,6 +2686,15 @@
           </constraints>
         </entryLink>
         <entryLink id="b988-1f54-4c51-f14c" name="Runes of Fortune" hidden="false" collective="false" import="true" targetId="2811-a32c-6768-4a0d" type="selectionEntryGroup"/>
+        <entryLink id="a495-0a39-5e9c-98e0" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
@@ -2608,6 +2703,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="6084-315e-0c6c-6548" name="Farseer Skyrunner" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="3a90-6c65-5e48-634e" name="Farseer Skyrunner" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -2651,7 +2758,7 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9075-2052-ca69-6632" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="86e5-b67e-7954-8e39" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="9d57-b32e-13bd-d85b" type="selectionEntry">
+        <entryLink id="86e5-b67e-7954-8e39" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="0464-98ac-2e38-8f67" value="0.0">
               <conditions>
@@ -2695,6 +2802,15 @@
           </constraints>
         </entryLink>
         <entryLink id="42ee-31ac-2241-64cb" name="Runes of Fortune" hidden="false" collective="false" import="true" targetId="2811-a32c-6768-4a0d" type="selectionEntryGroup"/>
+        <entryLink id="139a-7728-090b-4c8a" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
@@ -2703,6 +2819,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="c9fe-debd-d9f2-9274" name="Warlock Conclave" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="ee41-8383-765f-5685" name="Warlock" hidden="false" targetId="1b0a-49d4-c8f5-a018" type="profile"/>
         <infoLink id="f3e9-2700-dcc5-6a1c" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
@@ -2736,7 +2864,7 @@
           </categoryLinks>
           <entryLinks>
             <entryLink id="5b26-2418-c0cc-88a0" name="Rune Armour" hidden="false" collective="false" import="true" targetId="afbb-a355-ff30-9cd6" type="selectionEntry"/>
-            <entryLink id="56e7-d03d-d270-7f76" name="" hidden="false" collective="false" import="true" targetId="9d57-b32e-13bd-d85b" type="selectionEntry">
+            <entryLink id="56e7-d03d-d270-7f76" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9097-7887-9b96-6144" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b62b-cc00-0dc4-e234" type="min"/>
@@ -2760,7 +2888,7 @@
           </constraints>
         </entryLink>
         <entryLink id="705f-3882-1671-b87f" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="84ac-6246-0f73-79f1" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="84ac-6246-0f73-79f1" name="Battle Honours (Chapter Approved)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
         <entryLink id="16bc-364e-713f-1a76" name="Revenant Discipline" hidden="false" collective="false" import="true" targetId="7f93-a621-fdeb-0426" type="selectionEntryGroup">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fab-a5eb-5080-fa95" type="max"/>
@@ -2776,6 +2904,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="1262-6fb1-b88d-e00e" name="Warlock" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="9bec-3d40-71b2-1813" name="Warlock" hidden="false" targetId="1b0a-49d4-c8f5-a018" type="profile"/>
         <infoLink id="8e58-8a55-99e7-a450" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
@@ -2795,7 +2935,7 @@
       </categoryLinks>
       <entryLinks>
         <entryLink id="7858-696c-5e9e-c623" name="" hidden="false" collective="false" import="true" targetId="afbb-a355-ff30-9cd6" type="selectionEntry"/>
-        <entryLink id="8fd8-72d8-de2b-ffd6" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="9d57-b32e-13bd-d85b" type="selectionEntry">
+        <entryLink id="8fd8-72d8-de2b-ffd6" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="558f-f3bb-37ab-fcc5" value="0.0">
               <conditions>
@@ -2832,6 +2972,15 @@
           </constraints>
         </entryLink>
         <entryLink id="0d35-b09f-4081-c3b9" name="Runes of Fortune" hidden="false" collective="false" import="true" targetId="2811-a32c-6768-4a0d" type="selectionEntryGroup"/>
+        <entryLink id="f25f-5527-55fc-7117" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
@@ -2840,6 +2989,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="9316-eafd-ca2e-50f3" name="Warlock Skyrunner Conclave" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="b880-0f3d-1802-7672" name="Warlock Skyrunner" hidden="false" targetId="dbc7-cea4-af84-b8ef" type="profile"/>
         <infoLink id="f3bb-ecb9-d375-aada" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
@@ -2881,7 +3042,7 @@
               </constraints>
             </entryLink>
             <entryLink id="44d0-9a97-e2f5-5da3" name="Rune Armour" hidden="false" collective="false" import="true" targetId="afbb-a355-ff30-9cd6" type="selectionEntry"/>
-            <entryLink id="a8d7-fa7c-9984-82fe" name="" hidden="false" collective="false" import="true" targetId="9d57-b32e-13bd-d85b" type="selectionEntry">
+            <entryLink id="a8d7-fa7c-9984-82fe" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23bb-851a-c63f-c566" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="086f-00f0-bb4b-9852" type="min"/>
@@ -2897,7 +3058,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="54e3-eea2-9522-0eac" name="" hidden="false" collective="false" import="true" targetId="08da-47e9-744b-f7d4" type="selectionEntry"/>
+        <entryLink id="54e3-eea2-9522-0eac" name="Ride the Wind" hidden="false" collective="false" import="true" targetId="08da-47e9-744b-f7d4" type="selectionEntry"/>
         <entryLink id="2e69-0737-7760-547f" name="" hidden="false" collective="false" import="true" targetId="8537-bbde-aa0f-bf4d" type="selectionEntry"/>
         <entryLink id="a738-0b1f-3fd6-dd3b" name="Runes of Battle" hidden="false" collective="false" import="true" targetId="f801-39da-ca0a-33b8" type="selectionEntryGroup">
           <constraints>
@@ -2906,7 +3067,7 @@
           </constraints>
         </entryLink>
         <entryLink id="780b-122d-0455-2549" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="995e-6df4-30d1-6663" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="995e-6df4-30d1-6663" name="Battle Honours (Chapter Approved)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
         <entryLink id="db87-5620-d2c8-2360" name="Revenant Discipline" hidden="false" collective="false" import="true" targetId="7f93-a621-fdeb-0426" type="selectionEntryGroup">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6849-1419-519d-9d53" type="max"/>
@@ -2922,6 +3083,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="7271-6bae-b95f-af49" name="Warlock Skyrunner" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="1758-d71d-97ca-62fa" name="Warlock Skyrunner" hidden="false" targetId="dbc7-cea4-af84-b8ef" type="profile"/>
         <infoLink id="89ea-e423-5116-165f" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
@@ -2949,7 +3122,7 @@
         </entryLink>
         <entryLink id="0ca8-31a3-0e4a-e12f" name="" hidden="false" collective="false" import="true" targetId="08da-47e9-744b-f7d4" type="selectionEntry"/>
         <entryLink id="4a39-b1f4-9592-1313" name="" hidden="false" collective="false" import="true" targetId="afbb-a355-ff30-9cd6" type="selectionEntry"/>
-        <entryLink id="78c0-2b52-c168-5f41" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="9d57-b32e-13bd-d85b" type="selectionEntry">
+        <entryLink id="78c0-2b52-c168-5f41" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="d571-43d1-00d3-1ec6" value="0.0">
               <conditions>
@@ -2995,6 +3168,15 @@
           </constraints>
         </entryLink>
         <entryLink id="b4ba-8aa6-17cc-0995" name="Runes of Fortune" hidden="false" collective="false" import="true" targetId="2811-a32c-6768-4a0d" type="selectionEntryGroup"/>
+        <entryLink id="77c9-a5fe-8a1b-dc53" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
@@ -3003,6 +3185,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="20a6-e29d-7a34-ddc4" name="Spiritseer" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="7cf3-feaf-532a-70a3" name="Spiritseer" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -3056,7 +3250,7 @@
       </selectionEntries>
       <entryLinks>
         <entryLink id="d478-f244-11b5-352e" name="" hidden="false" collective="false" import="true" targetId="afbb-a355-ff30-9cd6" type="selectionEntry"/>
-        <entryLink id="bf34-9b0b-c403-0250" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="9d57-b32e-13bd-d85b" type="selectionEntry">
+        <entryLink id="bf34-9b0b-c403-0250" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="210b-d974-14f0-d192" value="0.0">
               <conditions>
@@ -3102,6 +3296,15 @@
         </entryLink>
         <entryLink id="500c-0376-d9ca-9080" name="Relics of Ynnead" hidden="false" collective="false" import="true" targetId="9b35-7aef-974a-5b0f" type="selectionEntryGroup"/>
         <entryLink id="2ff6-5c24-1e4f-5037" name="Runes of Fortune" hidden="false" collective="false" import="true" targetId="2811-a32c-6768-4a0d" type="selectionEntryGroup"/>
+        <entryLink id="aa00-8d74-9384-d644" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
@@ -3117,6 +3320,18 @@
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="e336-16ea-3426-4865" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
         <infoLink id="e26c-f5d4-3840-38ee" name="Battle Focus" hidden="false" targetId="56e7-c06e-e0f4-ee45" type="profile"/>
@@ -3259,6 +3474,18 @@
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="37bc-f45a-e5d7-75db" name="Storm Guardian" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -3430,6 +3657,18 @@
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="e3d9-ffa8-bb25-1e28" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
         <infoLink id="a3ee-c812-98c5-4517" name="Battle Focus" hidden="false" targetId="56e7-c06e-e0f4-ee45" type="profile"/>
@@ -3558,6 +3797,18 @@
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="9444-7e7c-10b2-cf59" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
         <infoLink id="7438-1c6d-7983-d0b7" name="Battle Focus" hidden="false" targetId="56e7-c06e-e0f4-ee45" type="profile"/>
@@ -3658,6 +3909,18 @@
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="4e42-5c62-ac94-22f1" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
         <infoLink id="3239-cb8a-8793-38d2" name="Battle Focus" hidden="false" targetId="56e7-c06e-e0f4-ee45" type="profile"/>
@@ -4017,6 +4280,18 @@
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="2098-8532-7ccc-45e2" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
         <infoLink id="79fa-2beb-7064-5bed" name="Battle Focus" hidden="false" targetId="56e7-c06e-e0f4-ee45" type="profile"/>
@@ -4370,6 +4645,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="281e-56da-5e6b-6e9e" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
         <infoLink id="0f8f-a531-dce3-f8f5" name="Battle Focus" hidden="false" targetId="56e7-c06e-e0f4-ee45" type="profile"/>
@@ -4665,7 +4952,7 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acee-9346-f046-bd14" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="c431-caab-8f13-9200" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="9d57-b32e-13bd-d85b" type="selectionEntry">
+                    <entryLink id="c431-caab-8f13-9200" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed52-906d-638d-8eb9" type="max"/>
                       </constraints>
@@ -4751,6 +5038,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="5a0a-add9-867c-6b5f" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
         <infoLink id="8c2c-bd8f-6a93-6677" name="Battle Focus" hidden="false" targetId="56e7-c06e-e0f4-ee45" type="profile"/>
@@ -5056,6 +5355,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="38ea-34ad-029b-5948" name="Strength from Death" hidden="false" targetId="3362-e057-11e7-3e13" type="rule"/>
       </infoLinks>
@@ -5170,16 +5481,23 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="cf45-60c0-2eeb-2fba" name="Strength from Death" hidden="false" targetId="3362-e057-11e7-3e13" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="f52d-d0f0-2520-3c32" name="New CategoryLink" hidden="false" targetId="fb5a-2f35-6253-b891" primary="false"/>
-        <categoryLink id="b6b6-e588-acf9-85bc" name="New CategoryLink" hidden="false" targetId="05e9-e880-b1fb-ce90" primary="false"/>
-        <categoryLink id="19e8-66c0-d90d-6e02" name="New CategoryLink" hidden="false" targetId="f406-94c7-4d73-4784" primary="false"/>
         <categoryLink id="facc-5744-dbed-3cd4" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
-        <categoryLink id="c775-779e-e0e8-f80e" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-        <categoryLink id="1876-fcfb-9cac-4444" name="New CategoryLink" hidden="false" targetId="9a3e-947f-26da-d343" primary="false"/>
         <categoryLink id="06eb-6a1b-0153-f634" name="New CategoryLink" hidden="false" targetId="9cdb-59a0-c8cb-911e" primary="false"/>
         <categoryLink id="0559-c97d-6e3e-af0c" name="New CategoryLink" hidden="false" targetId="fb5a-2f35-6253-b891" primary="false"/>
         <categoryLink id="7359-06de-dc19-9e5d" name="New CategoryLink" hidden="false" targetId="05e9-e880-b1fb-ce90" primary="false"/>
@@ -5288,6 +5606,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="66d3-17ef-c15b-39f8" name="Wave Serpent" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="e266-7c2d-1779-2fc5" name="Wave Serpent 1." hidden="false" typeId="5f4f-ea74-0630-4afe" typeName="Wound Track">
           <characteristics>
@@ -5331,22 +5661,15 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
         <infoLink id="c5fd-b223-bbee-954e" name="Strength from Death" hidden="false" targetId="3362-e057-11e7-3e13" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="e675-24a6-abcd-4028" name="New CategoryLink" hidden="false" targetId="fb5a-2f35-6253-b891" primary="false"/>
-        <categoryLink id="8e5b-7c19-5120-75a9" name="New CategoryLink" hidden="false" targetId="05e9-e880-b1fb-ce90" primary="false"/>
-        <categoryLink id="8a27-6924-9e0b-710c" name="New CategoryLink" hidden="false" targetId="f406-94c7-4d73-4784" primary="false"/>
         <categoryLink id="4bc6-38eb-9b62-1b48" name="New CategoryLink" hidden="false" targetId="1b66-3f5f-6705-079a" primary="true"/>
-        <categoryLink id="e88d-bebc-f243-c884" name="New CategoryLink" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false"/>
-        <categoryLink id="5daa-0be8-f44d-3dc9" name="New CategoryLink" hidden="false" targetId="6cc4-1b62-8e8a-05cd" primary="false"/>
-        <categoryLink id="a84b-bf16-1c5f-2625" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
-        <categoryLink id="b4fa-078b-2d79-782f" name="New CategoryLink" hidden="false" targetId="663e-2a3e-e3a4-f250" primary="false"/>
         <categoryLink id="c04f-ae18-1548-387c" name="New CategoryLink" hidden="false" targetId="ab1c-3e0d-9e37-95f7" primary="false"/>
-        <categoryLink id="6fc3-d59e-748c-a9b2" name="New CategoryLink" hidden="false" targetId="fb5a-2f35-6253-b891" primary="false"/>
-        <categoryLink id="6fa1-23ca-707f-32cc" name="New CategoryLink" hidden="false" targetId="05e9-e880-b1fb-ce90" primary="false"/>
-        <categoryLink id="433c-57a2-3243-935a" name="New CategoryLink" hidden="false" targetId="f406-94c7-4d73-4784" primary="false"/>
         <categoryLink id="9bc9-3477-7428-04e4" name="New CategoryLink" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false"/>
         <categoryLink id="87f5-4e9f-f097-954b" name="New CategoryLink" hidden="false" targetId="6cc4-1b62-8e8a-05cd" primary="false"/>
         <categoryLink id="bf1f-bb55-82dc-a72e" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
-        <categoryLink id="82fc-9799-bb5d-a66f" name="New CategoryLink" hidden="false" targetId="663e-2a3e-e3a4-f250" primary="false"/>
+        <categoryLink id="4d41-fdcb-cbcb-3f8d" name="Faction: &lt;Craftworld&gt;" hidden="false" targetId="fb5a-2f35-6253-b891" primary="false"/>
+        <categoryLink id="630c-b6ab-2275-5e6c" name="Faction: Aeldari" hidden="false" targetId="05e9-e880-b1fb-ce90" primary="false"/>
+        <categoryLink id="937b-2e50-9645-8993" name="Faction: Asuryani" hidden="false" targetId="f406-94c7-4d73-4784" primary="false"/>
+        <categoryLink id="cfc6-b0e5-b3ea-af95" name="Faction: Warhost" hidden="false" targetId="663e-2a3e-e3a4-f250" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ebcb-34d7-383f-c23e" name="Serpent Shield" hidden="false" collective="false" import="true" type="upgrade">
@@ -5432,6 +5755,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="c0e1-75e0-05a2-3a12" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
         <infoLink id="ff3f-c6c6-3476-4e0c" name="Battle Focus" hidden="false" targetId="56e7-c06e-e0f4-ee45" type="profile"/>
@@ -5785,6 +6120,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="ad18-cd61-69c0-e342" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
         <infoLink id="07bf-c895-03b7-d3ea" name="Battle Focus" hidden="false" targetId="56e7-c06e-e0f4-ee45" type="profile"/>
@@ -6185,6 +6532,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="9edf-fd56-93d1-6bcf" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
         <infoLink id="7587-e38f-f6f3-5dfd" name="Battle Focus" hidden="false" targetId="56e7-c06e-e0f4-ee45" type="profile"/>
@@ -6525,6 +6884,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="7505-4db5-8bd4-2871" name="Crimson Hunter" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="dc8c-3fdd-46cc-3b85" name="Crimson Hunter" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -6604,6 +6975,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="5c1d-49fc-e16b-8cc9" name="Crimson Hunter Exarch" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="5eaf-6a28-7f14-0dfa" name="Crimson Hunter Exarch" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -6881,6 +7264,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="aa83-612d-5933-1f68" name="Vypers" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="7817-9f29-5b05-7e95" name="Strength from Death" hidden="false" targetId="3362-e057-11e7-3e13" type="rule"/>
       </infoLinks>
@@ -6990,6 +7385,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="c537-8d87-968f-5355" name="Hemlock Wraithfighter" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="c0c8-b529-56d3-9138" name="Hemlock Wraithfighter" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -7140,6 +7547,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="f15c-4143-3375-08bb" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
         <infoLink id="4bf5-6970-054d-e967" name="Strength from Death" hidden="false" targetId="3362-e057-11e7-3e13" type="rule"/>
@@ -7458,6 +7877,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="4f55-4d68-96b3-2fec" name="Support Weapons" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="0ddf-41d2-03f8-f265" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
         <infoLink id="79bd-a0c8-3c47-38e6" name="Battle Focus" hidden="false" targetId="56e7-c06e-e0f4-ee45" type="profile"/>
@@ -7582,6 +8013,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="6307-5f9d-2ddb-68e6" name="Falcon" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="a8a2-b829-ea4f-d83c" name="Falcon" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -7691,6 +8134,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="4af8-033e-2933-ec79" name="Fire Prism" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="7521-7b50-16a1-6cc6" name="Fire Prism" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -7892,6 +8347,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="261a-f362-1a45-03c8" name="War Walkers" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="5068-e04d-4ace-4f7b" name="Strength from Death" hidden="false" targetId="3362-e057-11e7-3e13" type="rule"/>
       </infoLinks>
@@ -8015,6 +8482,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="816d-cdb2-dfea-5422" name="Wraithlord" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="df74-6b88-32b9-2678" name="Wraithlord" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -8118,6 +8597,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="c400-a060-dd8f-0df3" name="Wraithknight" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="37d2-e9cb-0f4d-35c1" name="Wraithknight" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -9431,6 +9922,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="1900-b48b-d576-b739" name="Phantom Titan" publicationId="03b4-8286-592c-c370" page="77" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="0ca4-8cc4-2dcd-3180" name="Phantom Titan" publicationId="03b4-8286-592c-c370" page="77" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -9908,6 +10411,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="2ac7-a3d4-852e-127c" name="Revenant Titan" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="be72-ffe1-fb52-ed3a" name="Revenant Titan" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -10146,6 +10661,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="72f1-877f-b201-c21f" name="Skathach Wraithknight" publicationId="03b4-8286-592c-c370" page="73" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="0411-0165-db4b-d029" name="Skathach Wraithknight" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -10390,6 +10917,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="2e35-dd46-cbe3-c0cb" name="Vampire Hunter" publicationId="03b4-8286-592c-c370" page="72" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="5ac1-26d6-4200-ddcf" name="Vampire Hunter" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -10542,6 +11081,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="08ca-9708-d94c-60cc" name="Vampire Raider" publicationId="03b4-8286-592c-c370" page="71" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="2576-cb82-8c5c-dddf" name="Vampire Raider" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -10651,6 +11202,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="0296-0f1b-7ff5-3ef0" name="Phoenix" publicationId="03b4-8286-592c-c370" page="70" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="2b01-722d-5ca9-a57e" name="Phoenix" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -10863,6 +11426,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="2734-1029-3121-a8f3" name="Nightwing" publicationId="03b4-8286-592c-c370" page="69" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="6d37-0c26-22dd-4dda" name="Nightwing" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -10974,6 +11549,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="622d-5ec9-bea6-bd2a" name="Cobra" publicationId="03b4-8286-592c-c370" page="68" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="e6ce-c4c4-dcc3-8eed" name="Cobra" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -11153,6 +11740,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="3640-64e3-3cef-88de" name="Scorpion" publicationId="03b4-8286-592c-c370" page="67" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="b5b4-237f-305d-272a" name="Scorpion" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -11334,6 +11933,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="918c-a048-cbd0-057c" name="Lynx" publicationId="03b4-8286-592c-c370" page="66" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="759a-b518-642e-0b9c" name="Lynx" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -11544,6 +12155,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="0253-5808-e354-33dc" name="Warp Hunter" publicationId="03b4-8286-592c-c370" page="65" hidden="false" collective="false" import="true" type="upgrade">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="5a48-3791-d955-6d7f" name="Warp Hunter" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -11666,6 +12289,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="ae08-dbdb-00a4-91c3" name="Hornets" publicationId="03b4-8286-592c-c370" page="65" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="0570-e4da-807e-c28c" name="Strength from Death" hidden="false" targetId="3362-e057-11e7-3e13" type="rule"/>
       </infoLinks>
@@ -11824,6 +12459,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="e554-ea88-ace6-b9ee" name="Wraithseer" publicationId="03b4-8286-592c-c370" page="64" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="6039-e2c5-2f0d-cc33" name="Wraithseer" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -12025,6 +12672,15 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
           </modifiers>
         </entryLink>
         <entryLink id="6a34-e49b-75bb-4297" name="Relics of Ynnead" hidden="false" collective="false" import="true" targetId="9b35-7aef-974a-5b0f" type="selectionEntryGroup"/>
+        <entryLink id="7ca6-32e8-3baf-bdb7" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
@@ -12033,6 +12689,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
       </costs>
     </selectionEntry>
     <selectionEntry id="689e-d4fa-fd7a-3034" name="Wasp Assault Walkers" publicationId="03b4-8286-592c-c370" page="63" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="79b3-4f0f-1a33-3055" name="Strength from Death" hidden="false" targetId="3362-e057-11e7-3e13" type="rule"/>
       </infoLinks>
@@ -12169,6 +12837,18 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="2560-c613-0c37-10e3" name="Ancient Doom" hidden="false" targetId="0717-5e61-82ac-ab50" type="profile"/>
         <infoLink id="c935-a8d1-1501-aa4d" name="Battle Focus" hidden="false" targetId="56e7-c06e-e0f4-ee45" type="profile"/>
@@ -12458,16 +13138,6 @@ that Howling Banshee Exarch, and that executioner has a Damage characteristic of
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="053c-d658-4f19-a234" name="Star Glaive" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="328a-32e6-4ac1-8fad" name="Star Glaive" hidden="false" targetId="ec5f-2e84-a0f0-e8be" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b7fa-f88c-305c-534f" name="Plasma Grenades" hidden="false" collective="true" import="true" type="upgrade">
@@ -12997,6 +13667,18 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
       </costs>
     </selectionEntry>
     <selectionEntry id="9d2f-3d02-5734-6cec" name="Autarch" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="d9d2-9ec4-c294-10b1" name="Autarch" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -13043,7 +13725,7 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
       </selectionEntries>
       <entryLinks>
         <entryLink id="feac-cd9a-7dcf-6745" name="Forceshield" hidden="false" collective="false" import="true" targetId="d607-4875-b868-1932" type="selectionEntry"/>
-        <entryLink id="3dba-3860-25f3-3387" name="Star Glaive" hidden="false" collective="false" import="true" targetId="053c-d658-4f19-a234" type="selectionEntry">
+        <entryLink id="3dba-3860-25f3-3387" name="Star Glaive" hidden="false" collective="false" import="true" targetId="1279-9620-9b6d-88ae" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7147-16ec-45aa-84ac" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dee-cd70-4053-3f11" type="max"/>
@@ -13061,6 +13743,15 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
         <entryLink id="8b7c-4c71-9e81-bed9" name="Relics of Ynnead" hidden="false" collective="false" import="true" targetId="9b35-7aef-974a-5b0f" type="selectionEntryGroup"/>
         <entryLink id="d4f3-8539-86de-6ae2" name="Warlord" hidden="false" collective="false" import="true" targetId="2ce0-03a1-ec03-76aa" type="selectionEntry"/>
         <entryLink id="c1bc-6a92-dd7b-f3f3" name="Warlord Trait" hidden="false" collective="false" import="true" targetId="64ad-12e1-bca2-9894" type="selectionEntryGroup"/>
+        <entryLink id="81aa-e01c-200f-78c9" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
@@ -13069,6 +13760,18 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
       </costs>
     </selectionEntry>
     <selectionEntry id="5b10-d99d-d2fa-27ad" name="Autarch with Swooping Hawk Wings" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="1663-9ecf-f1fe-752c" name="Autarch with Swooping Hawk Wings" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -13208,6 +13911,15 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d40d-20b5-76f7-9a5a" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="5631-cc00-2070-e0be" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
@@ -13216,6 +13928,18 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
       </costs>
     </selectionEntry>
     <selectionEntry id="efe1-2d6f-8511-2507" name="Autarch Skyrunner" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="85a4-070d-d3c6-dc3b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="b0d4-bc08-6a62-df32" name="Autarch Skyrunner" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -13363,6 +14087,15 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
           </modifiers>
         </entryLink>
         <entryLink id="821c-78fa-4889-4ea9" name="Relics of Ynnead" hidden="false" collective="false" import="true" targetId="9b35-7aef-974a-5b0f" type="selectionEntryGroup"/>
+        <entryLink id="afcc-b4d4-e3c4-37e3" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
@@ -13874,6 +14607,7 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
                 <conditionGroup type="or">
                   <conditions>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e554-ea88-ace6-b9ee" type="instanceOf"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="00b1-e9ab-61a3-292e" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -13934,7 +14668,7 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6f3a-0e93-5211-1a55" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -14000,7 +14734,7 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6f3a-0e93-5211-1a55" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -14106,8 +14840,8 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6f3a-0e93-5211-1a55" type="instanceOf"/>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8ca5-d893-a551-ac06" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -14139,8 +14873,8 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
           </entryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" typeId="points" value="4.0"/>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ca9c-8467-adaa-1931" name="Psytronome of Iyanden" hidden="true" collective="false" import="true" type="upgrade">
@@ -14184,6 +14918,7 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
                   <conditions>
                     <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="99e9-e617-958e-1a73" type="instanceOf"/>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="867d-ef6e-0469-e0d3" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="74a1-2d9c-f3b5-52b2" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -14269,6 +15004,8 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
                 <conditionGroup type="or">
                   <conditions>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e554-ea88-ace6-b9ee" type="instanceOf"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7eb5-cf45-cc95-cffb" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="00b1-e9ab-61a3-292e" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -15548,16 +16285,6 @@ As soon as any unit is destroyed, All units from your army benefit from Soulburs
         <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
         <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
         <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="ec5f-2e84-a0f0-e8be" name="Star Glaive" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">Melee</characteristic>
-        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Melee</characteristic>
-        <characteristic name="S" typeId="59b1-319e-ec13-d466">x2</characteristic>
-        <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
-        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
-        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When attacking with this weapon, you must subtract 1 from the hit roll.</characteristic>
       </characteristics>
     </profile>
     <profile id="3bb5-a77b-67c5-aa61" name="Executioner" publicationId="30b2-6f64-pubN137513" page="125" hidden="false" typeId="ae70-4738-0161-bec0" typeName="Psychic Power">

--- a/Aeldari - Drukhari.cat
+++ b/Aeldari - Drukhari.cat
@@ -600,6 +600,15 @@
         <entryLink id="ea85-5755-02a5-3f2f" name="Relics of Ynnead" hidden="false" collective="false" import="true" targetId="9b35-7aef-974a-5b0f" type="selectionEntryGroup"/>
         <entryLink id="1f47-1968-4a41-6949" name="Warlord Trait" hidden="false" collective="false" import="true" targetId="64ad-12e1-bca2-9894" type="selectionEntryGroup"/>
         <entryLink id="20b1-0d09-1bb2-73e8" name="Phantasm Grenade Launcher" hidden="false" collective="false" import="true" targetId="4448-243b-2379-2c73" type="selectionEntry"/>
+        <entryLink id="f15d-191f-7225-91fe" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
@@ -2011,6 +2020,15 @@
           <constraints>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0054-7e0e-1891-5921" type="max"/>
           </constraints>
+        </entryLink>
+        <entryLink id="9717-cfee-6de7-0e2a" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </entryLink>
       </entryLinks>
       <costs>

--- a/Aeldari - Drukhari.cat
+++ b/Aeldari - Drukhari.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e0a4-2172-4397-e39a" name="Aeldari - Drukhari" revision="79" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WindstormSCR @FarseerV" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="159" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e0a4-2172-4397-e39a" name="Aeldari - Drukhari" revision="80" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WindstormSCR @FarseerV" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="159" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="e0a4-2172-pubN65537" name="Codex: Drukhari"/>
     <publication id="d36f-0c87-284a-7055" name="Warhammer Legends - Drukhari"/>
@@ -40,7 +40,6 @@
     <categoryEntry id="db6a-df50-9c8f-2c52" name="Tantalus" hidden="false"/>
     <categoryEntry id="1018-59aa-c195-3ed9" name="Ravager" hidden="false"/>
     <categoryEntry id="a028-67e7-ffca-214b" name="Voidraven Bomber" hidden="false"/>
-    <categoryEntry id="dbdf-5a53-d746-429d" name="Faction: Reborn Drukhari" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="9cf3-09b4-05fe-4ec9" name="Archon" hidden="false" collective="false" import="true" targetId="3ea9-f42c-d816-b91a" type="selectionEntry">
@@ -264,10 +263,10 @@
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebb3-4f37-6e57-7a8e" type="atLeast"/>
               </conditions>
               <conditionGroups>
-                <conditionGroup type="and">
+                <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6dc4-d2cd-0f45-5586" type="equalTo"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="105d-2b08-1dc3-2f69" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6dc4-d2cd-0f45-5586" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="105d-2b08-1dc3-2f69" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -382,10 +381,10 @@
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebb3-4f37-6e57-7a8e" type="atLeast"/>
               </conditions>
               <conditionGroups>
-                <conditionGroup type="and">
+                <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce1e-8a0d-dae0-8bd3" type="equalTo"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="105d-2b08-1dc3-2f69" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce1e-8a0d-dae0-8bd3" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="105d-2b08-1dc3-2f69" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -495,7 +494,7 @@
       <modifiers>
         <modifier type="append" field="name" value="[Legends]">
           <conditions>
-            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="973d-fda7-9ba7-a05d" type="equalTo"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="20b1-0d09-1bb2-73e8" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -505,9 +504,9 @@
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
           </conditions>
           <modifiers>
-            <modifier type="remove" field="category" value="53ad-d29f-5f37-2a82"/>
+            <modifier type="remove" field="category" value="105d-2b08-1dc3-2f69"/>
             <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
-            <modifier type="add" field="category" value="dbdf-5a53-d746-429d"/>
+            <modifier type="add" field="category" value="e95e-5a32-aa75-4fc7"/>
           </modifiers>
         </modifierGroup>
       </modifierGroups>
@@ -563,19 +562,6 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="973d-fda7-9ba7-a05d" name="Phantasm Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b279-7816-6dfa-6d4f" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="8ee8-d9a6-b5c2-7620" name="Phantasm Grenade Launcher" hidden="false" targetId="f952-96a8-8586-f910" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="bb4c-1edf-f2f8-b3db" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="c190-1fce-e872-e039">
@@ -585,7 +571,7 @@
           </constraints>
           <entryLinks>
             <entryLink id="48c3-13f0-f4c5-02cc" name="New EntryLink" hidden="false" collective="false" import="true" targetId="277e-79e0-b605-ca05" type="selectionEntry"/>
-            <entryLink id="c190-1fce-e872-e039" name="Huskblade" hidden="false" collective="false" import="true" targetId="b1f7-b1c1-5b1d-d499" type="selectionEntry"/>
+            <entryLink id="c190-1fce-e872-e039" name="Huskblade" hidden="false" collective="false" import="true" targetId="124a-de32-6682-0bd7" type="selectionEntry"/>
             <entryLink id="1a97-ec85-4266-148e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="bc9e-551d-9afb-78d5" type="selectionEntry"/>
             <entryLink id="e4fc-af41-0ece-6a05" name="Venom Blade" hidden="false" collective="false" import="true" targetId="bac0-1ac3-c526-786e" type="selectionEntry"/>
           </entryLinks>
@@ -613,6 +599,7 @@
         <entryLink id="76b0-f95f-0f5b-8ef9" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
         <entryLink id="ea85-5755-02a5-3f2f" name="Relics of Ynnead" hidden="false" collective="false" import="true" targetId="9b35-7aef-974a-5b0f" type="selectionEntryGroup"/>
         <entryLink id="1f47-1968-4a41-6949" name="Warlord Trait" hidden="false" collective="false" import="true" targetId="64ad-12e1-bca2-9894" type="selectionEntryGroup"/>
+        <entryLink id="20b1-0d09-1bb2-73e8" name="Phantasm Grenade Launcher" hidden="false" collective="false" import="true" targetId="4448-243b-2379-2c73" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
@@ -727,12 +714,12 @@
       <modifierGroups>
         <modifierGroup>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60ad-499e-25e0-4891" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
           </conditions>
           <modifiers>
-            <modifier type="remove" field="category" value="53ad-d29f-5f37-2a82"/>
+            <modifier type="remove" field="category" value="105d-2b08-1dc3-2f69"/>
             <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
-            <modifier type="add" field="category" value="dbdf-5a53-d746-429d"/>
+            <modifier type="add" field="category" value="e95e-5a32-aa75-4fc7"/>
           </modifiers>
         </modifierGroup>
       </modifierGroups>
@@ -1096,14 +1083,14 @@
       <modifierGroups>
         <modifierGroup>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60ad-499e-25e0-4891" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
           </conditions>
           <modifiers>
-            <modifier type="remove" field="category" value="53ad-d29f-5f37-2a82"/>
+            <modifier type="remove" field="category" value="6dc4-d2cd-0f45-5586"/>
             <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
-            <modifier type="add" field="category" value="dbdf-5a53-d746-429d"/>
-            <modifier type="remove" field="category" value="99c9-6127-f78b-1f66"/>
-            <modifier type="remove" field="category" value="c3cc-22d9-1014-b496"/>
+            <modifier type="add" field="category" value="e95e-5a32-aa75-4fc7"/>
+            <modifier type="remove" field="category" value="ce1e-8a0d-dae0-8bd3"/>
+            <modifier type="remove" field="category" value="105d-2b08-1dc3-2f69"/>
           </modifiers>
         </modifierGroup>
       </modifierGroups>
@@ -1230,6 +1217,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="4f27-1486-dd47-0b85" name="Ravager" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="105d-2b08-1dc3-2f69"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="e95e-5a32-aa75-4fc7"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="d8af-dd17-1097-e7df" name="Explodes" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -1344,13 +1343,13 @@
       <modifierGroups>
         <modifierGroup>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60ad-499e-25e0-4891" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
           </conditions>
           <modifiers>
-            <modifier type="remove" field="category" value="53ad-d29f-5f37-2a82"/>
             <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
-            <modifier type="add" field="category" value="dbdf-5a53-d746-429d"/>
-            <modifier type="remove" field="category" value="99c9-6127-f78b-1f66"/>
+            <modifier type="add" field="category" value="e95e-5a32-aa75-4fc7"/>
+            <modifier type="remove" field="category" value="ce1e-8a0d-dae0-8bd3"/>
+            <modifier type="remove" field="category" value="105d-2b08-1dc3-2f69"/>
           </modifiers>
         </modifierGroup>
       </modifierGroups>
@@ -2024,14 +2023,14 @@
       <modifierGroups>
         <modifierGroup>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60ad-499e-25e0-4891" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
           </conditions>
           <modifiers>
-            <modifier type="remove" field="category" value="53ad-d29f-5f37-2a82"/>
+            <modifier type="remove" field="category" value="6dc4-d2cd-0f45-5586"/>
             <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
-            <modifier type="add" field="category" value="dbdf-5a53-d746-429d"/>
-            <modifier type="remove" field="category" value="99c9-6127-f78b-1f66"/>
-            <modifier type="remove" field="category" value="c3cc-22d9-1014-b496"/>
+            <modifier type="add" field="category" value="e95e-5a32-aa75-4fc7"/>
+            <modifier type="remove" field="category" value="ce1e-8a0d-dae0-8bd3"/>
+            <modifier type="remove" field="category" value="105d-2b08-1dc3-2f69"/>
           </modifiers>
         </modifierGroup>
       </modifierGroups>
@@ -2460,12 +2459,12 @@
       <modifierGroups>
         <modifierGroup>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60ad-499e-25e0-4891" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
           </conditions>
           <modifiers>
-            <modifier type="remove" field="category" value="53ad-d29f-5f37-2a82"/>
+            <modifier type="remove" field="category" value="105d-2b08-1dc3-2f69"/>
             <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
-            <modifier type="add" field="category" value="dbdf-5a53-d746-429d"/>
+            <modifier type="add" field="category" value="e95e-5a32-aa75-4fc7"/>
           </modifiers>
         </modifierGroup>
       </modifierGroups>
@@ -2536,12 +2535,12 @@
       <modifierGroups>
         <modifierGroup>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60ad-499e-25e0-4891" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
           </conditions>
           <modifiers>
-            <modifier type="remove" field="category" value="53ad-d29f-5f37-2a82"/>
+            <modifier type="remove" field="category" value="105d-2b08-1dc3-2f69"/>
             <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
-            <modifier type="add" field="category" value="dbdf-5a53-d746-429d"/>
+            <modifier type="add" field="category" value="e95e-5a32-aa75-4fc7"/>
           </modifiers>
         </modifierGroup>
       </modifierGroups>
@@ -2611,14 +2610,12 @@
       <modifierGroups>
         <modifierGroup>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60ad-499e-25e0-4891" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
           </conditions>
           <modifiers>
-            <modifier type="remove" field="category" value="53ad-d29f-5f37-2a82"/>
+            <modifier type="remove" field="category" value="105d-2b08-1dc3-2f69"/>
             <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
-            <modifier type="add" field="category" value="dbdf-5a53-d746-429d"/>
-            <modifier type="remove" field="category" value="99c9-6127-f78b-1f66"/>
-            <modifier type="remove" field="category" value="c3cc-22d9-1014-b496"/>
+            <modifier type="add" field="category" value="e95e-5a32-aa75-4fc7"/>
           </modifiers>
         </modifierGroup>
       </modifierGroups>
@@ -4120,6 +4117,16 @@
             <modifier type="add" field="category" value="dbdf-5a53-d746-429d"/>
           </modifiers>
         </modifierGroup>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="105d-2b08-1dc3-2f69"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="e95e-5a32-aa75-4fc7"/>
+          </modifiers>
+        </modifierGroup>
       </modifierGroups>
       <infoLinks>
         <infoLink id="ba50-ee78-f161-7361" name="Power from Pain" hidden="false" targetId="e6c3-8502-de0a-9515" type="rule"/>
@@ -5094,14 +5101,13 @@
       <modifierGroups>
         <modifierGroup>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60ad-499e-25e0-4891" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
           </conditions>
           <modifiers>
-            <modifier type="remove" field="category" value="53ad-d29f-5f37-2a82"/>
             <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
-            <modifier type="add" field="category" value="dbdf-5a53-d746-429d"/>
-            <modifier type="remove" field="category" value="99c9-6127-f78b-1f66"/>
-            <modifier type="remove" field="category" value="c3cc-22d9-1014-b496"/>
+            <modifier type="add" field="category" value="e95e-5a32-aa75-4fc7"/>
+            <modifier type="remove" field="category" value="ce1e-8a0d-dae0-8bd3"/>
+            <modifier type="remove" field="category" value="105d-2b08-1dc3-2f69"/>
           </modifiers>
         </modifierGroup>
       </modifierGroups>
@@ -5571,28 +5577,6 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b1f7-b1c1-5b1d-d499" name="Huskblade" hidden="false" collective="false" import="true" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdac-d87e-f8aa-5516" type="max"/>
-      </constraints>
-      <profiles>
-        <profile id="8bbf-3741-bf5c-c021" name="Huskblade" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">Melee</characteristic>
-            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Melee</characteristic>
-            <characteristic name="S" typeId="59b1-319e-ec13-d466">+1</characteristic>
-            <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
-            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="5.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="a293-6465-2a99-903f" name="Splinter pistol" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="178d-babc-b5c0-c0db" type="max"/>
@@ -5715,14 +5699,12 @@
       <modifierGroups>
         <modifierGroup>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60ad-499e-25e0-4891" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
           </conditions>
           <modifiers>
-            <modifier type="remove" field="category" value="53ad-d29f-5f37-2a82"/>
+            <modifier type="remove" field="category" value="105d-2b08-1dc3-2f69"/>
             <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
-            <modifier type="add" field="category" value="dbdf-5a53-d746-429d"/>
-            <modifier type="remove" field="category" value="99c9-6127-f78b-1f66"/>
-            <modifier type="remove" field="category" value="c3cc-22d9-1014-b496"/>
+            <modifier type="add" field="category" value="e95e-5a32-aa75-4fc7"/>
           </modifiers>
         </modifierGroup>
       </modifierGroups>
@@ -6844,31 +6826,6 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6aca-74ab-f40a-1966" name="Hungering Blade" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1f7-b1c1-5b1d-d499" type="equalTo"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fcf2-48b9-37a8-de0b" type="max"/>
-      </constraints>
-      <infoLinks>
-        <infoLink id="7000-def9-9da2-7404" name="Hungering Blade" hidden="false" targetId="2cec-eb16-6120-2e36" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="3b7c-2069-120d-0c97" name="Soul-Seeker" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -7131,7 +7088,7 @@
                 <conditionGroup type="or">
                   <conditions>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3ea9-f42c-d816-b91a" type="notInstanceOf"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1f7-b1c1-5b1d-d499" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="124a-de32-6682-0bd7" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>

--- a/Aeldari - Harlequins.cat
+++ b/Aeldari - Harlequins.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7d24-b92f-c5d5-3bf0" name="Aeldari - Harlequins" revision="47" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WindstormSCR @FarseerV" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="159" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7d24-b92f-c5d5-3bf0" name="Aeldari - Harlequins" revision="48" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WindstormSCR @FarseerV" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="159" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="7d24-b92f-pubN65537" name="Codex: Harlequins"/>
     <publication id="c6aa-38e7-468e-3cc9" name="White Dwarf May 2020" shortName="WD520" publisher="White Dwarf" publicationDate="May 2020"/>
@@ -328,7 +328,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b212-064c-a4a9-49f7" name="Shuriken Pistol" publicationId="7d24-b92f-pubN65537" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="b212-064c-a4a9-49f7" name="Shuriken Pistol - Old" publicationId="7d24-b92f-pubN65537" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="afd8-06e5-8d96-5695" name="Shuriken Pistol" publicationId="7d24-b92f-pubN65537" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -423,7 +423,7 @@
               <entryLinks>
                 <entryLink id="cde8-d244-a951-25ee" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0ecc-ffa4-aa9f-a698" type="selectionEntry"/>
                 <entryLink id="474d-902c-c235-98a6" name="New EntryLink" hidden="false" collective="false" import="true" targetId="dc08-7a78-9af8-9b6f" type="selectionEntry"/>
-                <entryLink id="1c54-6a2f-c12b-f8b8" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b212-064c-a4a9-49f7" type="selectionEntry"/>
+                <entryLink id="1c54-6a2f-c12b-f8b8" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -532,7 +532,7 @@
           <entryLinks>
             <entryLink id="0396-a08d-abf2-4989" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0ecc-ffa4-aa9f-a698" type="selectionEntry"/>
             <entryLink id="6624-da15-091a-82e2" name="New EntryLink" hidden="false" collective="false" import="true" targetId="dc08-7a78-9af8-9b6f" type="selectionEntry"/>
-            <entryLink id="0b74-5abc-c275-bff5" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b212-064c-a4a9-49f7" type="selectionEntry"/>
+            <entryLink id="0b74-5abc-c275-bff5" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -566,6 +566,15 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75a4-e61c-fb36-00ba" type="max"/>
           </constraints>
+        </entryLink>
+        <entryLink id="f2c9-022a-aafc-510b" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
@@ -705,7 +714,7 @@
           </constraints>
           <entryLinks>
             <entryLink id="c3e5-94c3-a5ba-610d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="dc08-7a78-9af8-9b6f" type="selectionEntry"/>
-            <entryLink id="039d-0e67-ae8a-5d60" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b212-064c-a4a9-49f7" type="selectionEntry"/>
+            <entryLink id="039d-0e67-ae8a-5d60" name="Shuriken Pistol" hidden="false" collective="false" import="true" targetId="00b1-e9ab-61a3-292e" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -758,6 +767,15 @@
           </constraints>
         </entryLink>
         <entryLink id="474a-2747-1035-fcc6" name="Pivotal Roles - Shadowseer" hidden="false" collective="false" import="true" targetId="5f1d-616d-887e-84c4" type="selectionEntryGroup"/>
+        <entryLink id="6ee6-71d7-fceb-8682" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
@@ -832,6 +850,15 @@
           </constraints>
         </entryLink>
         <entryLink id="86c6-e8da-9892-8c1b" name="Pivotal Roles - Death Jester" hidden="false" collective="false" import="true" targetId="2963-6e2a-c6e3-e38a" type="selectionEntryGroup"/>
+        <entryLink id="3cf3-1379-f524-d3cb" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>

--- a/Aeldari - Harlequins.cat
+++ b/Aeldari - Harlequins.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7d24-b92f-c5d5-3bf0" name="Aeldari - Harlequins" revision="48" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WindstormSCR @FarseerV" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="159" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7d24-b92f-c5d5-3bf0" name="Aeldari - Harlequins" revision="49" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WindstormSCR @FarseerV" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="159" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="7d24-b92f-pubN65537" name="Codex: Harlequins"/>
     <publication id="c6aa-38e7-468e-3cc9" name="White Dwarf May 2020" shortName="WD520" publisher="White Dwarf" publicationDate="May 2020"/>
@@ -328,25 +328,6 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b212-064c-a4a9-49f7" name="Shuriken Pistol - Old" publicationId="7d24-b92f-pubN65537" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="afd8-06e5-8d96-5695" name="Shuriken Pistol" publicationId="7d24-b92f-pubN65537" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">12&quot;</characteristic>
-            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Pistol 1</characteristic>
-            <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
-            <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
-            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Each time you make a wound roll of 6+ for this weapon, that hit is resolved with an AP of -3.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="5cec-256b-7cfd-038f" name="Star Bolas" publicationId="7d24-b92f-pubN65537" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="c942-b18e-373f-1349" name="Star Bolas" publicationId="7d24-b92f-pubN65537" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -367,6 +348,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="5c11-1cad-1fb1-5816" name="Troupe" publicationId="7d24-b92f-pubN65537" page="58" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="9139-0705-87d7-2d4b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <categoryLinks>
         <categoryLink id="b255-875a-9203-b30d" name="New CategoryLink" hidden="false" targetId="05e9-e880-b1fb-ce90" primary="false"/>
         <categoryLink id="1135-265a-0a27-a590" name="New CategoryLink" hidden="false" targetId="fb5a-2f35-6253-b891" primary="false"/>
@@ -453,6 +446,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="5f24-c0be-025f-16aa" name="Troupe Master" publicationId="7d24-b92f-pubN65537" page="56" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="9139-0705-87d7-2d4b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="e09c-9263-1993-9718" name="Troupe Master" publicationId="7d24-b92f-pubN65537" page="56" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -667,6 +672,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="2cb2-ebf2-3523-ad48" name="Shadowseer" publicationId="7d24-b92f-pubN65537" page="57" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="9139-0705-87d7-2d4b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="ed3a-6a75-ce36-ac5d" name="Shadowseer" publicationId="7d24-b92f-pubN65537" page="" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -784,6 +801,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="7c62-2472-fac5-49a1" name="Death Jester" publicationId="7d24-b92f-pubN65537" page="59" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="9139-0705-87d7-2d4b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="9ee8-12e9-c97d-137c" name="Death Jester" publicationId="7d24-b92f-pubN65537" page="59" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -867,6 +896,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="d96e-e7b4-6204-0b07" name="Starweaver" publicationId="7d24-b92f-pubN65537" page="63" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="9139-0705-87d7-2d4b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="2790-c5a1-a03c-6bca" name="Starweaver" publicationId="7d24-b92f-pubN65537" page="63" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -922,6 +963,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="3e87-4146-bac7-5c55" name="Voidweaver" publicationId="7d24-b92f-pubN65537" page="62" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="9139-0705-87d7-2d4b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="c758-104a-aac0-57b9" name="Voidweaver" publicationId="7d24-b92f-pubN65537" page="56" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -994,6 +1047,18 @@
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
+          </conditions>
+          <modifiers>
+            <modifier type="remove" field="category" value="fb5a-2f35-6253-b891"/>
+            <modifier type="add" field="category" value="ebb3-4f37-6e57-7a8e"/>
+            <modifier type="add" field="category" value="9139-0705-87d7-2d4b"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="c4f4-29e9-3ae9-7bbe" name="Rising Crescendo" hidden="false" targetId="60da-8dc8-7bf4-2efd" type="profile"/>
         <infoLink id="6f0d-4b64-2796-1200" name="Blur of Colour" hidden="false" targetId="1fde-5ed2-74f7-f766" type="profile"/>
@@ -1173,7 +1238,7 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b212-064c-a4a9-49f7" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00b1-e9ab-61a3-292e" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>

--- a/Aeldari - Ynnari.cat
+++ b/Aeldari - Ynnari.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2f0e-dd91-7676-722d" name="Aeldari - Ynnari" revision="59" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WindstormSCR @FarseerV" authorUrl="https://discord.gg/KqPVhds" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="159" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2f0e-dd91-7676-722d" name="Aeldari - Ynnari" revision="60" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WindstormSCR @FarseerV" authorUrl="https://discord.gg/KqPVhds" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="159" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <comment>This library will now become an Aeldari library - all shared pointy ear stuff will live here - eventually...</comment>
   <readme>This library will now become an Aeldari library - all shared pointy ear stuff will live here - eventually...</readme>
   <publications>
@@ -598,7 +598,9 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="equalTo"/>
                 <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="124a-de32-6682-0bd7" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1279-9620-9b6d-88ae" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -638,6 +640,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="5c45-15f8-bb62-2cbe" name="Song of Ynnead" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="00b1-e9ab-61a3-292e" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2b2-710d-fc22-95e8" type="max"/>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="03c6-8d93-c242-75a7" type="max"/>
@@ -1512,6 +1521,44 @@
       <costs>
         <cost name="pts" typeId="points" value="5.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1279-9620-9b6d-88ae" name="Star Glaive" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="cd66-c03f-9bcb-52a9" name="Star Glaive" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">Melee</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Melee</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">x2</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When attacking with this weapon, you must subtract 1 from the hit roll.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="00b1-e9ab-61a3-292e" name="Shuriken Pistol" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="cf90-6b1f-ca5c-7ddb" name="Shuriken pistol" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">12&quot;</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Pistol 1</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Each time you make a wound roll of 6+ for this weapon, that hit is resolved with an AP of -3 instead of 0.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>

--- a/Aeldari - Ynnari.cat
+++ b/Aeldari - Ynnari.cat
@@ -33,6 +33,7 @@
     <categoryEntry id="e95e-5a32-aa75-4fc7" name="Faction: Reborn Drukhari" hidden="false"/>
     <categoryEntry id="859a-9acf-049d-dcd9" name="Faction: Wych Cult of Strife" hidden="false"/>
     <categoryEntry id="85a4-070d-d3c6-dc3b" name="Faction: Reborn Asuryani" hidden="false"/>
+    <categoryEntry id="9139-0705-87d7-2d4b" name="Faction: Reborn Harlequin" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="a049-52ed-ef53-63ec" name="Yvraine" hidden="false" collective="false" import="true" targetId="1409-e740-c7c9-3758" type="selectionEntry"/>

--- a/Aeldari - Ynnari.cat
+++ b/Aeldari - Ynnari.cat
@@ -47,15 +47,6 @@
         </modifier>
       </modifiers>
     </entryLink>
-    <entryLink id="a1a6-d9fb-3187-fa28" name="Stratagem: Exalted of Ynnead" hidden="false" collective="false" import="true" targetId="746d-c99b-ba49-17bb" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4981-9c64-7ab7-7edc" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="1409-e740-c7c9-3758" name="Yvraine" publicationId="28ec-711c-pubN76527" page="78" hidden="false" collective="false" import="true" type="unit">
@@ -549,6 +540,7 @@
     <selectionEntry id="746d-c99b-ba49-17bb" name="Stratagem: Exalted of Ynnead" publicationId="5b08-09e5-a80a-fd67" page="91" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b840-e4c9-08e2-f599" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3242-73b4-23aa-ed62" type="max"/>
       </constraints>
       <profiles>
         <profile id="8c02-bbab-76b2-4085" name="Stratagem: Exalted of Ynnead" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -697,17 +689,20 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="2ce0-03a1-ec03-76aa" name="Warlord" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="4fcb-1fd9-2d03-b668" value="2.0">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="746d-c99b-ba49-17bb" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b24d-164f-af8c-68a7" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4fcb-1fd9-2d03-b668" type="max"/>
       </constraints>
-      <entryLinks>
-        <entryLink id="0cf2-9198-a99b-6845" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5315-22f3-11e9-c7e6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ea1-efa9-3d1f-fa7a" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
+      <categoryLinks>
+        <categoryLink id="5136-07c6-b1d0-b5af" name="Warlord" hidden="false" targetId="ae09-117e-a6fa-316b" primary="false"/>
+      </categoryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
@@ -1734,7 +1729,7 @@
             <conditionGroup type="and">
               <conditions>
                 <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ce0-03a1-ec03-76aa" type="notEqualTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="746d-c99b-ba49-17bb" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="746d-c99b-ba49-17bb" type="notEqualTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -2601,6 +2596,9 @@ form, it is automatically passed. In addition, each time a model with this form 
       </constraints>
       <selectionEntries>
         <selectionEntry id="a5f6-e065-b5c1-f7ae" name="*Custom Coven*" hidden="false" collective="false" import="true" type="upgrade">
+          <categoryLinks>
+            <categoryLink id="4290-d20e-55ee-e9d5" name="Faction: &lt;Haemonculus Coven&gt;" hidden="false" targetId="6dc4-d2cd-0f45-5586" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="6b92-6a3c-65a2-249d" name="Coven Obsessions" hidden="false" collective="false" import="true">
               <modifierGroups>
@@ -2772,6 +2770,9 @@ form, it is automatically passed. In addition, each time a model with this form 
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="3210-edbb-d711-b9e0" name="Faction: &lt;Haemonculus Coven&gt;" hidden="false" targetId="6dc4-d2cd-0f45-5586" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -2786,6 +2787,9 @@ form, it is automatically passed. In addition, each time a model with this form 
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="e912-92da-42d0-fc14" name="Faction: &lt;Haemonculus Coven&gt;" hidden="false" targetId="6dc4-d2cd-0f45-5586" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -2800,6 +2804,9 @@ form, it is automatically passed. In addition, each time a model with this form 
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="fd2c-19be-e317-86a5" name="Faction: &lt;Haemonculus Coven&gt;" hidden="false" targetId="6dc4-d2cd-0f45-5586" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -2815,6 +2822,9 @@ form, it is automatically passed. In addition, each time a model with this form 
       </constraints>
       <selectionEntries>
         <selectionEntry id="e132-5f1e-1f13-6805" name="*Custom Kabal*" hidden="false" collective="false" import="true" type="upgrade">
+          <categoryLinks>
+            <categoryLink id="2974-ac2f-c9f7-89eb" name="Faction: &lt;Kabal&gt;" hidden="false" targetId="105d-2b08-1dc3-2f69" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="962b-7967-4a87-44b0" name="Kabal Obsessions" hidden="false" collective="false" import="true">
               <constraints>
@@ -2975,6 +2985,9 @@ form, it is automatically passed. In addition, each time a model with this form 
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="4b68-a9e9-01ea-ac44" name="Faction: &lt;Kabal&gt;" hidden="false" targetId="105d-2b08-1dc3-2f69" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -2989,6 +3002,9 @@ form, it is automatically passed. In addition, each time a model with this form 
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="3603-c123-8032-7191" name="Faction: &lt;Kabal&gt;" hidden="false" targetId="105d-2b08-1dc3-2f69" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -3003,6 +3019,9 @@ form, it is automatically passed. In addition, each time a model with this form 
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="ca83-ae94-1256-3da5" name="Faction: &lt;Kabal&gt;" hidden="false" targetId="105d-2b08-1dc3-2f69" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -3017,6 +3036,9 @@ form, it is automatically passed. In addition, each time a model with this form 
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="d811-ad7a-f6ea-595b" name="Faction: &lt;Kabal&gt;" hidden="false" targetId="105d-2b08-1dc3-2f69" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -3032,6 +3054,9 @@ form, it is automatically passed. In addition, each time a model with this form 
       </constraints>
       <selectionEntries>
         <selectionEntry id="7fa3-a898-7ad6-3d89" name="*Custom Cult*" hidden="false" collective="false" import="true" type="upgrade">
+          <categoryLinks>
+            <categoryLink id="d088-48e2-7fb2-b14b" name="Faction: &lt;Wych Cult&gt;" hidden="false" targetId="ce1e-8a0d-dae0-8bd3" primary="false"/>
+          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="d52e-88e9-2192-5d23" name="Cult Obsessions" hidden="false" collective="false" import="true">
               <modifierGroups>
@@ -3217,6 +3242,9 @@ form, it is automatically passed. In addition, each time a model with this form 
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="590a-47c1-0a58-68dc" name="Faction: &lt;Wych Cult&gt;" hidden="false" targetId="ce1e-8a0d-dae0-8bd3" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -3232,6 +3260,9 @@ obsession, it is automatically passed.</characteristic>
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="d559-13ca-3b60-45a0" name="Faction: &lt;Wych Cult&gt;" hidden="false" targetId="ce1e-8a0d-dae0-8bd3" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -3246,6 +3277,9 @@ obsession, it is automatically passed.</characteristic>
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="fd40-3356-c730-aaff" name="Faction: &lt;Wych Cult&gt;" hidden="false" targetId="ce1e-8a0d-dae0-8bd3" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="pts" typeId="points" value="0.0"/>

--- a/Aeldari - Ynnari.cat
+++ b/Aeldari - Ynnari.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2f0e-dd91-7676-722d" name="Aeldari - Ynnari" revision="58" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WindstormSCR @FarseerV" authorUrl="https://discord.gg/KqPVhds" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="158" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2f0e-dd91-7676-722d" name="Aeldari - Ynnari" revision="59" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WindstormSCR @FarseerV" authorUrl="https://discord.gg/KqPVhds" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="159" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <comment>This library will now become an Aeldari library - all shared pointy ear stuff will live here - eventually...</comment>
   <readme>This library will now become an Aeldari library - all shared pointy ear stuff will live here - eventually...</readme>
   <publications>
@@ -14,7 +14,7 @@
     </profileType>
   </profileTypes>
   <categoryEntries>
-    <categoryEntry id="ebb3-4f37-6e57-7a8e" name="Faction: Ynnari" hidden="false"/>
+    <categoryEntry id="ebb3-4f37-6e57-7a8e" name="Ynnari" hidden="false"/>
     <categoryEntry id="c8df-4b67-2b52-4472" name="Yvraine" hidden="false"/>
     <categoryEntry id="48e7-cfd4-1ea3-5847" name="The Visarch" hidden="false"/>
     <categoryEntry id="94b1-311f-cf71-99dd" name="Daemon" hidden="false"/>
@@ -32,6 +32,7 @@
     <categoryEntry id="43ef-6837-7167-e8ec" name="Faction: Prophets of Flesh" hidden="false"/>
     <categoryEntry id="e95e-5a32-aa75-4fc7" name="Faction: Reborn Drukhari" hidden="false"/>
     <categoryEntry id="859a-9acf-049d-dcd9" name="Faction: Wych Cult of Strife" hidden="false"/>
+    <categoryEntry id="85a4-070d-d3c6-dc3b" name="Faction: Reborn Asuryani" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="a049-52ed-ef53-63ec" name="Yvraine" hidden="false" collective="false" import="true" targetId="1409-e740-c7c9-3758" type="selectionEntry"/>
@@ -600,6 +601,17 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="9ce9-34d4-da91-c9bf" name="Hungering Blade" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="124a-de32-6682-0bd7" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf07-6449-96f1-cb95" type="max"/>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="f4d2-2dbf-e979-5647" type="max"/>
@@ -994,10 +1006,10 @@
     </selectionEntry>
     <selectionEntry id="f044-1fd2-2aa0-0217" name="Relic of Ynnead" publicationId="5b08-09e5-a80a-fd67" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
-        <modifier type="set" field="d87e-56e9-068d-6c67" value="2.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="746d-c99b-ba49-17bb" type="equalTo"/>
-          </conditions>
+        <modifier type="increment" field="d87e-56e9-068d-6c67" value="1.0">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="746d-c99b-ba49-17bb" repeats="1" roundUp="false"/>
+          </repeats>
         </modifier>
         <modifier type="decrement" field="d87e-56e9-068d-6c67" value="1.0">
           <conditions>
@@ -1486,6 +1498,28 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="124a-de32-6682-0bd7" name="Huskblade" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5c0-2253-2f42-56b6" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="e929-6ef3-e01c-bef3" name="Huskblade" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">Melee</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Melee</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">+1</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="5.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="7f93-a621-fdeb-0426" name="Revenant Discipline" publicationId="6a4d-2a41-5e6b-c57a" hidden="false" collective="false" import="true">
@@ -1614,6 +1648,13 @@
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="2fc3-8ba7-0594-29f6" name="Warlord Trait (Ynnari)" hidden="false" collective="false" import="true">
+      <modifiers>
+        <modifier type="set" field="882f-3708-86b8-151e" value="2.0">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="746d-c99b-ba49-17bb" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f682-fc54-d21a-3941" type="max"/>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="882f-3708-86b8-151e" type="max"/>
@@ -1693,7 +1734,7 @@
             <conditionGroup type="and">
               <conditions>
                 <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ce0-03a1-ec03-76aa" type="notEqualTo"/>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d043-3847-e963-fb5d" type="notEqualTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="746d-c99b-ba49-17bb" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>


### PR DESCRIPTION
If someone could figure out a way to make the number of Warlord traits selected throughout a roster count correctly when one of the Trimuvirate is selected as warlord (with or without the Exhalted of Ynnead Stratagem) that would be appreciated!

Currently, in this configuration it is possible to select one too many WL's and I can't figure out an elegant way of doing it.