### PR TITLE
Remove Space Wolves entries duplicated in Space Marines

### DIFF
--- a/Imperium - Space Wolves.cat
+++ b/Imperium - Space Wolves.cat
@@ -10497,5 +10497,6 @@ Litany of Hate:If this litany is inspiring, you can re-roll hit rolls for attack
     <catalogueLink id="4dc0-6a90-e2e3-b844" name="Imperium - FW Adeptus Astartes" targetId="dab7-e076-dd5e-d8aa" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="86d4-bec9-0343-673d" name="Imperium - Inquisition" targetId="e373-3c0a-1185-46ea" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="162d-039c-7e19-1259" name="Imperium - Officio Assassinorum" targetId="f731-6aa6-c141-8937" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="162d-039c-7e19-1259" name="Imperium - Space Marines" targetId="846d-3c14-21fc-369f" type="catalogue" importRootEntries="false"/>
   </catalogueLinks>
 </catalogue>

--- a/Imperium - Space Wolves.cat
+++ b/Imperium - Space Wolves.cat
@@ -45,7 +45,6 @@
     <categoryEntry id="bb97-ab6a-dd79-137e" name="Wolf Priest" hidden="false"/>
     <categoryEntry id="db1d-c5fb-fd8d-143d" name="Battle Leader" hidden="false"/>
     <categoryEntry id="2e2c-e640-47a0-2813" name="Ulrik The Slayer" hidden="false"/>
-    <categoryEntry id="48e5-ceed-000a-a99a" name="Dreadnought" hidden="false"/>
     <categoryEntry id="db51-bafa-0d7b-3142" name="Bjorn The Fell-Handed" hidden="false"/>
     <categoryEntry id="912a-5924-339a-e2d4" name="Arjac Rockfist" hidden="false"/>
     <categoryEntry id="766b-5215-896e-d2e9" name="Iron Priest" hidden="false"/>
@@ -68,15 +67,8 @@
     <categoryEntry id="cdc5-f012-f7e7-a6e9" name="Whirlwind" hidden="false"/>
     <categoryEntry id="5e78-7f37-7c0c-b0be" name="Razorback" hidden="false"/>
     <categoryEntry id="e386-bccd-fcac-10fd" name="Rhino Primaris" hidden="false"/>
-    <categoryEntry id="1b76-bf3e-0ade-7674" name="Drop Pod" hidden="false"/>
-    <categoryEntry id="13ac-0a73-2640-cc7a" name="Hellblasters" hidden="false"/>
-    <categoryEntry id="950e-d8f4-e019-ed79" name="Imperial Space Marine" hidden="false"/>
-    <categoryEntry id="bb53-a4d6-3823-86eb" name="Inceptor Squad" hidden="false"/>
-    <categoryEntry id="f4ac-7766-b308-64cb" name="Land Speeders" hidden="false"/>
     <categoryEntry id="bfbd-efd5-bc68-88a7" name="Primaris Ancient" hidden="false"/>
     <categoryEntry id="489e-4894-bbae-7058" name="Primaris Lieutenant" hidden="false"/>
-    <categoryEntry id="0262-aa2e-a67e-6774" name="Servitors" hidden="false"/>
-    <categoryEntry id="2edb-70de-3930-c790" name="Venerable Dreadnought" hidden="false"/>
     <categoryEntry id="cbda-3bd3-08bb-48d5" name="Wolf Guard Battle Leader" hidden="false"/>
     <categoryEntry id="9eb8-8127-3ec4-5f78" name="Grey Hunters" hidden="false"/>
     <categoryEntry id="ef51-e32b-2c58-5571" name="Wolf Scouts" hidden="false"/>
@@ -84,24 +76,11 @@
     <categoryEntry id="3ff2-0080-e500-32d3" name="Swiftclaw Attack Bikes" hidden="false"/>
     <categoryEntry id="71c8-6336-9dd6-9e8d" name="Thunderwolf Cavalry" hidden="false"/>
     <categoryEntry id="2c97-f835-1fbd-0945" name="Long Fangs" hidden="false"/>
-    <categoryEntry id="eaed-3964-68ad-28c0" name="Intercessor Squad" hidden="false"/>
     <categoryEntry id="dd06-3049-d027-b4fa" name="Fenrisian Wolves" hidden="false"/>
     <categoryEntry id="3718-f4de-a999-5d50" name="Scout" hidden="false"/>
     <categoryEntry id="b8c0-0d1b-912c-4d7e" name="Swiftclaw Attack Bikes" hidden="false"/>
     <categoryEntry id="7668-23ee-94a8-ebf5" name="Skyclaws" hidden="false"/>
-    <categoryEntry id="53b7-cff3-c3b4-d36a" name="Primaris" hidden="false"/>
-    <categoryEntry id="82df-13db-9e7b-15a3" name="Mk X Gravis" hidden="false"/>
-    <categoryEntry id="2d28-8fed-1b2d-1999" name="Ancient" hidden="false"/>
-    <categoryEntry id="d4db-2d06-de12-46f9" name="Lieutenants" hidden="false"/>
-    <categoryEntry id="8352-7f67-7e2b-3b4f" name="Captain" hidden="false"/>
     <categoryEntry id="6980-b61e-a8c6-1168" name="Techmarine" hidden="false"/>
-    <categoryEntry id="f392-2fd4-9b99-d433" name="Aggressor Squad" hidden="false"/>
-    <categoryEntry id="c3f5-f3b2-bdbb-4742" name="Chaplain" hidden="false"/>
-    <categoryEntry id="27d2-2998-2f52-84cf" name="Librarian" hidden="false"/>
-    <categoryEntry id="4dbd-0c7e-ad6c-6d87" name="Redemptor Dreadnought" hidden="false"/>
-    <categoryEntry id="1932-effa-b590-5127" name="Reiver Squad" hidden="false"/>
-    <categoryEntry id="c66f-0ec3-0a99-d5d1" name="Repulsor" hidden="false"/>
-    <categoryEntry id="a2e7-ec78-a186-1448" name="Company Ancient" hidden="false"/>
     <categoryEntry id="7647-555a-b7d9-115c" name="Wulfen Dreadnought" hidden="false"/>
     <categoryEntry id="36aa-fda4-6bf3-bf61" name="Great Company Ancient" hidden="false"/>
     <categoryEntry id="afcf-9fa3-d188-3ee9" name="Great Company Champion" hidden="false"/>
@@ -113,10 +92,6 @@
     <categoryEntry id="9e4b-7407-8d75-2add" name="Stalker" hidden="false"/>
     <categoryEntry id="fc68-90be-c888-d8b2" name="Land Speeder Storm" hidden="false"/>
     <categoryEntry id="b51e-c770-1b9d-5313" name="Stormhawk Interceptor" hidden="false"/>
-    <categoryEntry id="5b58-36bd-930c-e8be" name="Phobos" hidden="false"/>
-    <categoryEntry id="ec1d-8b79-1471-e8fc" name="Eliminator Squad" hidden="false"/>
-    <categoryEntry id="1b53-08d9-7c68-b30e" name="Infiltrator Squad" hidden="false"/>
-    <categoryEntry id="6720-939f-b4ed-7718" name="Suppressor Squad" hidden="false"/>
     <categoryEntry id="d78a-9066-6f29-3930" name="Invictor Tactical Warsuit" hidden="false"/>
     <categoryEntry id="6f37-636e-dbf9-022a" name="Reiver" hidden="false"/>
     <categoryEntry id="6276-ca3a-7a45-120e" name="Incursor Squad" hidden="false"/>
@@ -8128,9 +8103,6 @@
     <rule id="730f-8283-6f5b-8470" name="Fire Discipline" hidden="false">
       <description>At the start of each of your Shooting phases, pick one enemy unit on the battlefield.  You can re-roll hit rolls of 1 for any models from this unit that target that enemy unit you picked that phase.</description>
     </rule>
-    <rule id="6f8e-9512-0008-d677" name="Explodes (6&quot;/D6)" hidden="false">
-      <description>If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield and before any embarked models disembark. On a 6 it explodes, and each unit within 6&quot; suffers D6 mortal wounds.</description>
-    </rule>
     <rule id="05af-49f8-8692-ec9f" name="Hunters Unleashed" hidden="false">
       <description>In any turn in which a unit with this ability made a charge move, was charged or performed a Heroic Intervention, you can add 1 to its hit rolls in the Fight phase. In addition, CHARACTERSwith this ability can perform a Heroic Intervention if, after the enemy has completed all of their charge moves, there are any enemy units within 6&quot; of them. They can move up to 6&quot; when performing a Heroic Intervention, so long as they end the move closer to the nearest enemy model.</description>
     </rule>
@@ -8177,24 +8149,6 @@ The Armour Penetration characteristic of Pistol and melee weapons this model is 
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="3e31-4e4b-6ab6-d90b" name="Combat Squads" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-      <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Before any models are deployed at the start of the game, this unit when containing its maximum number of models, may be split into two units each containing an equal number of models.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="4fc6-74e0-0f86-4b23" name="Veteran Sergeant" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
-      <characteristics>
-        <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
-        <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
-        <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
-        <characteristic name="S" typeId="2218-aa3c-265f-2939">4</characteristic>
-        <characteristic name="T" typeId="9c9f-9774-a358-3a39">4</characteristic>
-        <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
-        <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">3</characteristic>
-        <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">9</characteristic>
-        <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
-      </characteristics>
-    </profile>
     <profile id="c2e0-258c-bbac-59c9" name="Ragnar Blackmane" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
       <characteristics>
         <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
@@ -10026,24 +9980,9 @@ Neither this transport, nor any units embarked within it, are counted towards an
         <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
       </characteristics>
     </profile>
-    <profile id="bd1b-dc88-554f-122b" name="Crushing Charge" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-      <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a D6 each time this an Inceptor finishes a charge move within 1&quot; of an enemy unit; on a 6, that unit suffers a mortal wound.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="33ea-29e3-151e-9f9b" name="Meteoric Descent" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-      <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During deployment, you can set it up in high orbit instead of placing it on the battlefield. At the end of any of your Movement phases this unit can use a meteoric descent - set it up anywhere on the battlefield that is more than 9&quot; away from any enemy models.</characteristic>
-      </characteristics>
-    </profile>
     <profile id="fb24-ed64-acc4-e5ee" name="Transport Landraider" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
       <characteristics>
         <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 10 SPACE WOLVES INFANTRY models. Each TERMINATOR, JUMP PACK or WULFEN model takes the space of two other models. It may not transport PRIMARIS models.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="26a1-7cd2-c9e6-d6ab" name="Frag Assault Launchers" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-      <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a D6 each time this models finishes a charge move within 1&quot; of an enemy unit; on a 4+ that unit suffers D3 mortal wounds.</characteristic>
       </characteristics>
     </profile>
     <profile id="87a7-bfb8-548c-23b0" name="Aquila Aegis Field" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -10069,11 +10008,6 @@ Neither this transport, nor any units embarked within it, are counted towards an
     <profile id="237b-7182-b78e-4d55" name="Transport Landraider Crusader" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
       <characteristics>
         <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 16 SPACE WOLVES INFANTRY models. Each TERMINATOR, JUMP PACK or WULFEN model takes the space of two other models. It may not transport PRIMARIS models.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="3f33-636e-17fd-9a79" name="Anti-grav Upwash" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-      <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Models in this unit have a Move of 20&quot;, instead of 16&quot;, whilst the unit contains 3 models.</characteristic>
       </characteristics>
     </profile>
     <profile id="82a3-d5da-6435-481b" name="Company Heroes" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -10110,24 +10044,9 @@ Neither this transport, nor any units embarked within it, are counted towards an
         <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 6 SPACE WOLVES INFANTRY models. It cannot transport JUMP PACK, TERMINATOR, PRIMARIS, or WULFEN models.</characteristic>
       </characteristics>
     </profile>
-    <profile id="88cf-5c51-9f6b-7f26" name="Self-repair" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-      <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a D6 at the start of each of your turns; on a 6, this model regains one lost wound.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="7472-621a-b7e6-1819" name="Servo-skull Hub" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-      <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">In each of your shooting phases, choose one of the following effects:&lt;br&gt; Targeting Data Skull: Add 1 to hit rolls made for a single friendly SPACE WOLVES unit within 12&quot; of this model until the end of the phase. &lt;br&gt;&lt;br&gt; Repair Skull: Choose a single SPACE WOLVES VEHICLE within 12&quot; of this model. That model regains 1 lost wound. &lt;br&gt;&lt;br&gt; Vox Skull: Subtract 1 from Morale tests taken for friendly SPACE WOLVES units within 12&quot; of this model until your next shooting phase.</characteristic>
-      </characteristics>
-    </profile>
     <profile id="9af5-224e-592a-23ae" name="Transport Primaris" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
       <characteristics>
         <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 6 SPACE WOLVES INFANTRY models. It cannot transport JUMP PACK, TERMINATOR, PRIMARIS, or CENTURION models.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="6593-d4db-3ad3-7de0" name="Unyielding Ancient" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-      <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Roll a D6 each time this model loses a wound; on a 6 the damage is ignored and that wound is not lost.</characteristic>
       </characteristics>
     </profile>
     <profile id="9428-95b5-8d77-4e7a" name="Flamestorm Gauntlets (Melee)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -10287,51 +10206,6 @@ Neither this transport, nor any units embarked within it, are counted towards an
         <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
         <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
         <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="14e3-2aff-d68d-b565" name="Bolt Carbine" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
-        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 2</characteristic>
-        <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
-        <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
-        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="7f73-3131-afbf-e23e" name="Ironhail Heavy Stubber" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
-        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 3</characteristic>
-        <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
-        <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
-        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="faad-78a5-6c85-2288" name="Icarus Ironhail Heavy Stubber" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
-        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 3</characteristic>
-        <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
-        <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
-        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Add 1 to all hit rolls made for this weapon against targets that can FLY. Subtract 1 from the hit rolls made for this weapon against all other targets.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="50ea-a0de-bbfa-8449" name="Auto Launchers" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-      <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Instead of shooting any weapons in the Shooting phase, the vehicle can use its Auto Launchers; until your next Shooting phase your opponent must subtract 1 from all hit rolls for ranged weapons that target this vehicle.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="0385-2744-d0c8-c271" name="Krakstorm Grenade Launcher" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">18&quot;</characteristic>
-        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 1</characteristic>
-        <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
-        <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
-        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
         <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
       </characteristics>
     </profile>


### PR DESCRIPTION
Based on this script: https://gist.github.com/amis92/760757b559e4b070d6c4b037192637cd

@alphalas looks good?

I already added link to SM in Space Wolves, otherwise it wouldn't open correctly in Data Editor.