### PR TITLE
SM WLT Fixes

### DIFF
--- a/Imperium - Black Templars.cat
+++ b/Imperium - Black Templars.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8a47-6e7e-22fa-6014" name="Imperium - Adeptus Astartes - Black Templars" revision="34" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8a47-6e7e-22fa-6014" name="Imperium - Adeptus Astartes - Black Templars" revision="35" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="03ac-4576-88d8-3b67" name="Crusader Squad" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -465,15 +465,6 @@
       <infoLinks>
         <infoLink id="018a-b19d-36f0-43a5" name="Angels of Death" hidden="false" targetId="01a4-bec8-b573-fde7" type="rule"/>
         <infoLink id="9502-9319-3e23-0928" name="Rosarius" hidden="false" targetId="b355-bd49-c5a5-805f" type="profile"/>
-        <infoLink id="c839-bdeb-66d9-0c8e" name="Epitome of Piety" hidden="false" targetId="c21f-c5ba-a3e3-e039" type="profile">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="d0ae-3233-384e-4cd3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c8b-06c7-0f7e-4e56" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="b414-6a71-580c-06a2" name="New CategoryLink" hidden="false" targetId="c7b7-edbc-bc14-6238" primary="false"/>
@@ -514,6 +505,23 @@
             <modifier type="set" field="2f4f-fb22-ef59-1382" value="3.0"/>
           </modifiers>
         </entryLink>
+        <entryLink id="74ee-931d-6182-262d" name="Epitome of Piety" hidden="false" collective="false" import="true" targetId="260d-e1ec-3665-fb18" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="d0ae-3233-384e-4cd3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c8b-06c7-0f7e-4e56" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="9e6f-f723-b9fa-a463" value="1.0">
+              <conditions>
+                <condition field="selections" scope="d0ae-3233-384e-4cd3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c8b-06c7-0f7e-4e56" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e6f-f723-b9fa-a463" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
@@ -549,15 +557,6 @@
         <infoLink id="a1e7-fec8-47b3-c5de" name="Angels of Death" hidden="false" targetId="01a4-bec8-b573-fde7" type="rule"/>
         <infoLink id="2c9d-ebf9-e7a1-f9a9" name="Chapter Master" hidden="false" targetId="fdb4-b1a5-3c97-6400" type="profile"/>
         <infoLink id="67ba-5097-3b22-46c9" name="Iron Halo" hidden="false" targetId="242c-3bac-1ff3-48b0" type="profile"/>
-        <infoLink id="1f59-990f-7d66-a7bd" name="Frontline Commander" hidden="false" targetId="e301-1601-629d-c325" type="profile">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="ebef-2d11-1743-4b25" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c8b-06c7-0f7e-4e56" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink id="5b7e-8a68-c838-1c17" name="Rites of Battle" hidden="false" targetId="922c-75db-5ca4-3750" type="profile"/>
       </infoLinks>
       <categoryLinks>
@@ -612,6 +611,23 @@
           </constraints>
         </entryLink>
         <entryLink id="d189-0b1b-cf42-ebb7" name="Warlord" hidden="false" collective="false" import="true" targetId="01cf-00c7-c4af-701b" type="selectionEntry"/>
+        <entryLink id="f15b-729a-ed89-f96a" name="Frontline Commander" hidden="false" collective="false" import="true" targetId="e1c9-2ed0-7751-19c8" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ebef-2d11-1743-4b25" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="6556-416e-7532-7689" value="1.0">
+              <conditions>
+                <condition field="selections" scope="ebef-2d11-1743-4b25" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6556-416e-7532-7689" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
@@ -653,15 +669,6 @@ this model makes a melee attack against an enemy CHARACTER unit, you can re-roll
       </profiles>
       <infoLinks>
         <infoLink id="f670-469e-4fac-e362" name="Angels of Death" hidden="false" targetId="01a4-bec8-b573-fde7" type="rule"/>
-        <infoLink id="823a-8cfc-6318-e6d2" name="Oathkeeper" hidden="false" targetId="b89b-ed3a-bd0b-d5d8" type="profile">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="efe5-16b5-2443-aac3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c8b-06c7-0f7e-4e56" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink id="b879-2067-9e05-7de3" name="Skilful Parry" hidden="false" targetId="b134-f910-b333-e958" type="profile"/>
       </infoLinks>
       <categoryLinks>
@@ -712,6 +719,23 @@ this model makes a melee attack against an enemy CHARACTER unit, you can re-roll
           </constraints>
         </entryLink>
         <entryLink id="9c46-eed8-0a0e-4839" name="Warlord" hidden="false" collective="false" import="true" targetId="01cf-00c7-c4af-701b" type="selectionEntry"/>
+        <entryLink id="033a-c3b8-b90b-f72e" name="Oathkeeper" hidden="false" collective="false" import="true" targetId="3771-b66e-5fd3-1019" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="efe5-16b5-2443-aac3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c8b-06c7-0f7e-4e56" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="3ef3-37fa-82d6-51f4" value="1.0">
+              <conditions>
+                <condition field="selections" scope="efe5-16b5-2443-aac3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c8b-06c7-0f7e-4e56" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ef3-37fa-82d6-51f4" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
@@ -1683,6 +1707,48 @@ this model makes a melee attack against an enemy CHARACTER unit, you can re-roll
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="260d-e1ec-3665-fb18" name="Epitome of Piety" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ec2-f3cd-89fb-d0ce" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1990-e190-081a-f79a" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="6094-c0fe-841d-f0f8" name="Epitome of Piety" hidden="false" targetId="c21f-c5ba-a3e3-e039" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e1c9-2ed0-7751-19c8" name="Frontline Commander" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b8b-50b4-f50a-3624" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da86-664d-cdf3-0818" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="173c-6829-f226-e6c7" name="Frontline Commander" hidden="false" targetId="e301-1601-629d-c325" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3771-b66e-5fd3-1019" name="Oathkeeper" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="429a-19e8-1850-9195" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b11e-2403-6e2c-40d9" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="f04f-9043-9ccf-c860" name="Oathkeeper" hidden="false" targetId="b89b-ed3a-bd0b-d5d8" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="568d-b594-77c4-bc93" name="Warlord Traits" hidden="false" collective="false" import="true">
@@ -1713,35 +1779,10 @@ this model makes a melee attack against an enemy CHARACTER unit, you can re-roll
             </modifier>
           </modifiers>
           <selectionEntries>
-            <selectionEntry id="215d-c94b-72a1-ec88" name="Oathkeeper" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6125-27ce-cc06-3316" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="ab28-e6e4-9d60-825c" name="Oathkeeper" hidden="false" targetId="b89b-ed3a-bd0b-d5d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8687-d52d-5bff-1fcc" name="Epitome of Piety" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34ba-8b6a-1865-d837" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="0d52-0a70-c8ff-9f16" name="Epitome of Piety" hidden="false" targetId="c21f-c5ba-a3e3-e039" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="44a1-1251-626d-5569" name="Paragon of Fury" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f77b-fb91-1de6-2e50" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="838f-29ff-9437-c362" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="e517-75c9-eb46-52b1" name="Paragon of Fury" hidden="false" targetId="685c-eb45-48b7-e0e3" type="profile"/>
@@ -1755,6 +1796,7 @@ this model makes a melee attack against an enemy CHARACTER unit, you can re-roll
             <selectionEntry id="fcb8-c069-5739-7471" name="Master of Arms" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d02-1e16-5688-9397" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1713-721c-ef67-c39d" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="f77d-d23f-50c7-8ddf" name="Master of Arms" hidden="false" targetId="3e06-c474-af3a-562f" type="profile"/>
@@ -1768,6 +1810,7 @@ this model makes a melee attack against an enemy CHARACTER unit, you can re-roll
             <selectionEntry id="b15c-96b1-45b8-528b" name="Inspirational Fighter" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c2a-54ad-0d1a-0aa6" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efc0-4f36-5667-d356" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="daf6-fe8e-f774-df84" name="Inspirational Fighter" hidden="false" targetId="5410-4443-7437-b4c0" type="profile"/>
@@ -1778,20 +1821,12 @@ this model makes a melee attack against an enemy CHARACTER unit, you can re-roll
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="ec11-a497-b2e1-98e5" name="Frontline Commander" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61d2-8549-705c-4729" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="af26-a7eb-37c4-efa2" name="Frontline Commander" hidden="false" targetId="e301-1601-629d-c325" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
           </selectionEntries>
+          <entryLinks>
+            <entryLink id="2b58-9be2-f155-ef47" name="Frontline Commander" hidden="false" collective="false" import="true" targetId="e1c9-2ed0-7751-19c8" type="selectionEntry"/>
+            <entryLink id="7c4b-9dfd-1c0c-15e2" name="Epitome of Piety" hidden="false" collective="false" import="true" targetId="260d-e1ec-3665-fb18" type="selectionEntry"/>
+            <entryLink id="029a-bbf8-427c-6eb1" name="Oathkeeper" hidden="false" collective="false" import="true" targetId="3771-b66e-5fd3-1019" type="selectionEntry"/>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>

--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Adeptus Astartes - Blood Angels" revision="214" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas | Twitter: @_alphalas" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Adeptus Astartes - Blood Angels" revision="215" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas | Twitter: @_alphalas" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="eb0f-c144-pubN65537" name="Codex: Blood Angels"/>
   </publications>
@@ -2990,12 +2990,7 @@
         </entryLink>
         <entryLink id="95c0-9e3f-5c9f-603e" name="3. Soulwarden" hidden="true" collective="false" import="true" targetId="034a-5cd0-4c82-e51b" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="e551-cb48-7ebf-bf45" value="1">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="b244-d9b8-ac21-388c" value="1">
+            <modifier type="set" field="e551-cb48-7ebf-bf45" value="1.0">
               <conditions>
                 <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
               </conditions>
@@ -3008,7 +3003,6 @@
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e551-cb48-7ebf-bf45" type="min"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b244-d9b8-ac21-388c" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="54c0-8d71-aac2-4781" name="Litanies" hidden="false" collective="false" import="true" targetId="3fdf-73fb-13e9-ed47" type="selectionEntryGroup"/>
@@ -5927,6 +5921,7 @@
         <selectionEntry id="a2c7-84fd-8c7c-4f6c" name="1. Speed of the Primarch" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a38e-4e7b-5091-8c06" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e279-da88-ea03-18fa" type="max"/>
           </constraints>
           <profiles>
             <profile id="d2f1-4663-fb99-1702" name="Speed of the Primarch" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -5944,6 +5939,7 @@
         <selectionEntry id="7ea0-91b3-9b0e-69db" name="2. Artisan of War" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2eb-1813-63d0-c2e8" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a900-f606-436c-5499" type="max"/>
           </constraints>
           <profiles>
             <profile id="ab5a-3c10-c96d-f01e" name="Artisan of War" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -5961,6 +5957,7 @@
         <selectionEntry id="034a-5cd0-4c82-e51b" name="3. Soulwarden" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c19b-65a9-3052-b66b" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="123a-7ec1-1a6e-3b17" type="max"/>
           </constraints>
           <profiles>
             <profile id="bc6e-9c5f-3fa8-747a" name="Soulwarden (Aura)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -5978,6 +5975,7 @@
         <selectionEntry id="f01d-0b09-9f26-885d" name="4. Heroic Bearing" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ea1-56c5-567c-ac91" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eece-f0c5-98a7-f2a2" type="max"/>
           </constraints>
           <profiles>
             <profile id="831b-12df-733d-754d" name="Heroic Bearing" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -5996,6 +5994,7 @@
         <selectionEntry id="4eaf-66ad-349d-087f" name="5. Gift of Foresight" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09e7-2dc8-9f5b-47a2" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3861-9bb6-1740-0f73" type="max"/>
           </constraints>
           <profiles>
             <profile id="6a53-575a-88ff-57e5" name="Gift of Foresight" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -6013,6 +6012,7 @@
         <selectionEntry id="41ba-2ea2-4eb9-2f79" name="6. Selfless Valour" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb9b-9cd8-c1b0-8e26" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8996-b6e0-a0e7-ecda" type="max"/>
           </constraints>
           <profiles>
             <profile id="6e2c-a41b-03b4-e823" name="Selfless Valour" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">

--- a/Imperium - Deathwatch.cat
+++ b/Imperium - Deathwatch.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="203b-f8dd-2a64-2676" name="Imperium - Adeptus Astartes - Deathwatch" revision="120" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Technoblazed" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="203b-f8dd-2a64-2676" name="Imperium - Adeptus Astartes - Deathwatch" revision="121" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Technoblazed" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="1973-efc9-3214-865a" name="Codex: Space Marines"/>
     <publication id="b8dc-efc0-c6b3-2c9f" name="Codex Supplement: Deathwatch" publisher="Codex Supplement: Deathwatch" publicationDate="2020-11-07" publisherUrl="https://www.games-workshop.com/en-GB/Codex-Supplement-Deathwatch-EN-2020"/>
@@ -6059,6 +6059,7 @@
             <selectionEntry id="16ee-69e9-9430-703e" name="1. Vigilance Incarnate" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd44-a622-d34a-ff5b" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c752-312e-3f85-c10e" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="86d4-bddb-4bdb-a1ad" name="1. Vigilance Incarnate" hidden="false" targetId="776d-da26-71b2-6cc7" type="profile"/>
@@ -6072,6 +6073,7 @@
             <selectionEntry id="c688-70f2-6976-60a9" name="2. Paragon of their Chapter" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d736-b7b7-c8a9-1323" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="55e8-9a3f-0531-9c13" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="f9f7-9da3-0fcb-e434" name="2. Paragon of their Chapter" hidden="false" targetId="d9bf-d2f3-fc21-8684" type="profile"/>
@@ -6093,6 +6095,7 @@
             <selectionEntry id="6d31-c59b-c6dd-71ce" name="3. Nowhere to Hide (Aura)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="879e-8df2-d984-ea76" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="92fe-e368-d548-14f4" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="83ce-9b2e-f601-c944" name="3. Nowhere to Hide (Aura)" hidden="false" targetId="a87c-2e33-7f8b-7eba" type="profile"/>
@@ -6106,6 +6109,7 @@
             <selectionEntry id="306b-c743-b9fc-b14d" name="4. Optimised Priority (Aura)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc0c-b623-e254-7ff8" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0d2c-574f-566a-abe8" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="88ff-094f-9308-2737" name="4. Optimised Priority (Aura)" hidden="false" targetId="bf21-20f3-26e8-65c7" type="profile"/>
@@ -6119,6 +6123,7 @@
             <selectionEntry id="5314-3e68-d1bb-572f" name="5. Castellan of the Black Vault" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18d3-85bb-5cb5-2715" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a6d5-9ab4-a01b-7d40" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="fbd7-a691-e4eb-e511" name="5. Castellan of the Black Vault" hidden="false" targetId="34cc-d7d7-d138-1620" type="profile"/>
@@ -6146,6 +6151,7 @@
             <selectionEntry id="a6b5-1a13-db73-6efd" name="6. The Ties That Bind (Aura)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa9a-f5b8-031c-326e" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="227c-60ea-6079-0e69" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="2e44-6b88-3cfe-15a1" name="6. The Ties That Bind (Aura)" hidden="false" targetId="0e1b-cf91-00c3-a4bb" type="profile"/>
@@ -7750,7 +7756,7 @@ While a PROTEUS KILL TEAM unit only contains Veteran Bikers, it has the BIKER ke
     </profile>
     <profile id="d9bf-d2f3-fc21-8684" name="2. Paragon of their Chapter" publicationId="b8dc-efc0-c6b3-2c9f" page="37" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Select one Warlord Trait from the Chapter Warlord Traits (see Codex: Space marines) from this WARLORD. Replace all instances of that Chapter&apos;s keyword on that Warlord Trait with DEATHWATCH. If this WARLORD has the heraldy of one of those Chapters (or, other than Crimson Fists, Black Templars and Flesh Tearers, one of their successor Chapters), you must select that Chapter&apos;s Warlord Trait. Note that this cannot be a Chapter Warlord Trait found in a Codex supplement.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Select one Warlord Trait from the Chapter Warlord Traits (see Codex: Space Marines) for this WARLORD. Replace all instances of that Chapter&apos;s keyword on that Warlord Trait with DEATHWATCH. If this WARLORD has the heraldry of one of those Chapters (or, other than Crimson Fists, Black Templars and Flesh Tearers, one of their successor Chapters), you must select that Chapter&apos;s Warlord Trait. Note that this cannot be a Chapter Warlord Trait found in a Codex supplement.</characteristic>
       </characteristics>
     </profile>
     <profile id="a87c-2e33-7f8b-7eba" name="3. Nowhere to Hide (Aura)" publicationId="b8dc-efc0-c6b3-2c9f" page="37" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">

--- a/Imperium - Imperial Fists.cat
+++ b/Imperium - Imperial Fists.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0b92-701a-704e-2d9f" name="Imperium - Adeptus Astartes - Imperial Fists" revision="33" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur " authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0b92-701a-704e-2d9f" name="Imperium - Adeptus Astartes - Imperial Fists" revision="34" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur " authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="94ea-2b86-14a0-402f" name="Captain Lysander" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -43,15 +43,6 @@
         <infoLink id="8160-8faa-099f-8a6b" name="Teleport Strike" hidden="false" targetId="d566-23fd-55a5-103f" type="profile"/>
         <infoLink id="5e4c-0ec1-4e80-bebd" name="Iron Halo" hidden="false" targetId="242c-3bac-1ff3-48b0" type="profile"/>
         <infoLink id="8fd6-d382-8bb8-23c5" name="Storm shield" hidden="false" targetId="541d-ade9-7496-9c62" type="profile"/>
-        <infoLink id="45a1-4845-eb47-0e51" name="Architect of War" hidden="false" targetId="045c-abf3-7e15-5198" type="profile">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="94ea-2b86-14a0-402f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5db7-7b06-45d2-94a5" name="New CategoryLink" hidden="false" targetId="c7b7-edbc-bc14-6238" primary="false"/>
@@ -91,6 +82,23 @@
       </selectionEntries>
       <entryLinks>
         <entryLink id="da76-1a84-28ab-5269" name="Warlord" hidden="false" collective="false" import="true" targetId="01cf-00c7-c4af-701b" type="selectionEntry"/>
+        <entryLink id="0342-eef8-58c4-2fe5" name="Architect of War" hidden="false" collective="false" import="true" targetId="9d43-57f1-0fa5-b0fb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="94ea-2b86-14a0-402f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="4274-db11-9376-9451" value="1.0">
+              <conditions>
+                <condition field="selections" scope="94ea-2b86-14a0-402f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4274-db11-9376-9451" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
@@ -135,15 +143,6 @@
         <infoLink id="84e9-186b-8486-0d37" name="Angels of Death" hidden="false" targetId="01a4-bec8-b573-fde7" type="rule"/>
         <infoLink id="2359-452d-0f20-878f" name="Iron Halo" hidden="false" targetId="242c-3bac-1ff3-48b0" type="profile"/>
         <infoLink id="daea-e77c-a676-db00" name="Chapter Master" hidden="false" targetId="fdb4-b1a5-3c97-6400" type="profile"/>
-        <infoLink id="1087-99a2-a99a-cff6" name="Stoic Defender" hidden="false" targetId="6240-85a6-478e-9727" type="profile">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="2119-b883-7c60-5e46" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink id="ff6b-0e3f-e95d-6a7e" name="Rites of Battle" hidden="false" targetId="922c-75db-5ca4-3750" type="profile"/>
       </infoLinks>
       <categoryLinks>
@@ -198,6 +197,23 @@
           </constraints>
         </entryLink>
         <entryLink id="2a11-3bd9-c0ea-6d87" name="Warlord" hidden="false" collective="false" import="true" targetId="01cf-00c7-c4af-701b" type="selectionEntry"/>
+        <entryLink id="f794-686b-0968-92f7" name="Stoic Defender" hidden="false" collective="false" import="true" targetId="b52f-9ba2-f366-7a02" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="2119-b883-7c60-5e46" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="4138-cfe9-8438-90dc" value="1.0">
+              <conditions>
+                <condition field="selections" scope="2119-b883-7c60-5e46" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4138-cfe9-8438-90dc" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
@@ -293,6 +309,23 @@
           </constraints>
         </entryLink>
         <entryLink id="b423-85b5-b8a5-8849" name="Warlord" hidden="false" collective="false" import="true" targetId="01cf-00c7-c4af-701b" type="selectionEntry"/>
+        <entryLink id="d1b7-5654-d771-2a13" name="Siege Master" hidden="false" collective="false" import="true" targetId="a259-e77f-02b0-1bd6" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="3f9f-1d3f-5029-6a34" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="722e-bf7b-8657-aaa5" value="1.0">
+              <conditions>
+                <condition field="selections" scope="3f9f-1d3f-5029-6a34" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="722e-bf7b-8657-aaa5" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="145.0"/>
@@ -419,15 +452,6 @@
       <entryLinks>
         <entryLink id="628c-7ec3-5913-678a" name="Chapter Relics" hidden="false" collective="false" import="true" targetId="532b-2310-2778-61e1" type="selectionEntryGroup"/>
         <entryLink id="f51a-3079-53a2-f509" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5995-5ebe-47f7-892c" type="selectionEntryGroup"/>
-      </entryLinks>
-    </entryLink>
-    <entryLink id="126f-bde4-b4fe-6da8" name="Captain in Cataphractii Armor" hidden="false" collective="false" import="true" targetId="92b3-c77a-eff7-4d9b" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ad5e-64f9-e6b9-d1d7" name="HQ" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="3fdb-055d-09f5-08e2" name="Chapter Relics" hidden="false" collective="false" import="true" targetId="532b-2310-2778-61e1" type="selectionEntryGroup"/>
-        <entryLink id="bdba-3578-a26e-d9f9" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5995-5ebe-47f7-892c" type="selectionEntryGroup"/>
       </entryLinks>
     </entryLink>
     <entryLink id="0743-3e64-8c02-67b8" name="Captain in Gravis Armor" hidden="false" collective="false" import="true" targetId="5854-3db8-6043-ce0b" type="selectionEntry">
@@ -1288,6 +1312,61 @@
       </categoryLinks>
     </entryLink>
   </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="9d43-57f1-0fa5-b0fb" name="Architect of War" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="94be-70a9-5d49-cd2d" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="104f-f639-38e3-e7b0" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="e648-3982-d39d-c630" name="Architect of War" hidden="false" targetId="045c-abf3-7e15-5198" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a259-e77f-02b0-1bd6" name="Siege Master" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e6b7-ac99-3eea-ed24" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dba0-4ca0-9062-0e5a" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="5813-d35a-65fa-d5ff" name="Siege Master" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When resolving an attack made by this Warlord against a BUILDING or VEHICLE unit, add 1 to the wound roll.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b52f-9ba2-f366-7a02" name="Stoic Defender" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ff3e-64db-5e7b-73a3" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="65f2-b03d-9f7d-7b29" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2090-44b7-1e80-cd94" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="d5eb-6c56-1db2-9ff9" name="Stoic Defender" hidden="false" targetId="6240-85a6-478e-9727" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="5995-5ebe-47f7-892c" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
@@ -1343,6 +1422,9 @@
                   </conditions>
                 </modifier>
               </modifiers>
+              <constraints>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a681-ef87-5146-29ac" type="max"/>
+              </constraints>
               <infoLinks>
                 <infoLink id="b751-35fb-e0a5-a16c" name="Tenacious Opponent" hidden="false" targetId="759c-7ee7-95ae-6ac2" type="profile"/>
               </infoLinks>
@@ -1360,6 +1442,9 @@
                   </conditions>
                 </modifier>
               </modifiers>
+              <constraints>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de88-d164-0a31-2f7f" type="max"/>
+              </constraints>
               <infoLinks>
                 <infoLink id="aace-8f40-19d1-6b76" name="Refuse to Die" hidden="false" targetId="3421-2042-b0e7-91ed" type="profile"/>
               </infoLinks>
@@ -1369,24 +1454,10 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="08e6-c302-5ec2-2863" name="Stoic Defender" hidden="false" collective="false" import="true" type="upgrade">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ff3e-64db-5e7b-73a3" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <infoLinks>
-                <infoLink id="d105-6aac-d087-7347" name="Stoic Defender" hidden="false" targetId="6240-85a6-478e-9727" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
           </selectionEntries>
+          <entryLinks>
+            <entryLink id="a870-d8e2-c887-835e" name="Stoic Defender" hidden="false" collective="false" import="true" targetId="b52f-9ba2-f366-7a02" type="selectionEntry"/>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="f88f-02ce-8872-0b90" name="Warlord Traits (Imperial Fists)" hidden="false" collective="false" import="true">
           <modifiers>
@@ -1415,41 +1486,20 @@
                 <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d043-3847-e963-fb5d" type="equalTo"/>
               </conditions>
             </modifier>
+            <modifier type="set" field="2b48-789e-0d1f-dd09" value="1.0">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c7a9-567e-dac8-844d" type="equalTo"/>
+              </conditions>
+            </modifier>
           </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b48-789e-0d1f-dd09" type="min"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry id="fe4d-d341-7161-7bad" name="Architect of War" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dc4-85f5-ca32-eb41" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="bda3-5854-73dd-e4ae" name="Architect of War" hidden="false" targetId="045c-abf3-7e15-5198" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0617-65ab-4050-d9ad" name="Siege Master" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d535-7508-453f-891d" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="0d8d-0990-b966-bf07" name="Siege Master" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-                  <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When resolving an attack made by this Warlord against a BUILDING or VEHICLE unit, add 1 to the wound roll.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="b0db-bfc4-8d32-6918" name="Indomitable" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b62d-a9d4-fb60-4c01" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6f6e-1ad2-ce2c-6f64" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac3b-8732-0fa0-39c5" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="2ff7-a64d-eb23-536b" name="Indomitable" hidden="false" targetId="057a-a839-dcd7-30d9" type="profile"/>
@@ -1462,7 +1512,8 @@
             </selectionEntry>
             <selectionEntry id="e058-7eb0-2286-d739" name="Fleetmaster" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c793-11f8-0edf-f34b" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eaa5-e778-82ed-f6ea" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9a5-45c2-d8b2-a903" type="max"/>
               </constraints>
               <profiles>
                 <profile id="8fe0-78d3-d0aa-7424" name="Fleetmaster" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1479,7 +1530,8 @@
             </selectionEntry>
             <selectionEntry id="415c-3212-6268-f79a" name="Stubborn Heroism" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee12-3426-2525-dec1" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0360-a282-8204-d127" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6037-7ac8-b2b6-2e25" type="max"/>
               </constraints>
               <profiles>
                 <profile id="18bc-a876-0396-0a95" name="Stubborn Heroism" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1496,7 +1548,8 @@
             </selectionEntry>
             <selectionEntry id="4d28-f558-443e-28b3" name="Hand of Dorn" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fb0-276f-3e73-7638" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ee21-e5f4-5cef-70c6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa51-444e-8684-cc19" type="max"/>
               </constraints>
               <profiles>
                 <profile id="0dd2-4a14-8b1b-4da7" name="Hand of Dorn" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1512,6 +1565,10 @@
               </costs>
             </selectionEntry>
           </selectionEntries>
+          <entryLinks>
+            <entryLink id="13da-ddec-7b48-6050" name="Architect of War" hidden="false" collective="false" import="true" targetId="9d43-57f1-0fa5-b0fb" type="selectionEntry"/>
+            <entryLink id="6a9e-446b-4f3f-7bb0" name="Siege Master" hidden="false" collective="false" import="true" targetId="a259-e77f-02b0-1bd6" type="selectionEntry"/>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>

--- a/Imperium - Iron Hands.cat
+++ b/Imperium - Iron Hands.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5b3d-59c0-a550-452a" name="Imperium - Adeptus Astartes - Iron Hands" revision="34" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5b3d-59c0-a550-452a" name="Imperium - Adeptus Astartes - Iron Hands" revision="35" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="e1a1-c276-086c-8bf2" name="Iron Father Feirros" hidden="false" collective="false" import="true" type="model">
       <modifiers>
@@ -66,30 +66,6 @@
         <categoryLink id="39f8-c535-f2b3-0643" name="Master of the Forge" hidden="false" targetId="ec7f-63af-0bf7-9b40" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="f5ab-f48c-b14f-30e1" name="Student of History" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8f3-68a2-6de9-7bd1" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="24f7-f5de-75bc-94f1" name="Student of History" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When this Warlord consolidates, they can move up to 6&quot; instead of 3&quot;, and do not have to end this move closer to the nearest enemy model</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="a2b8-da10-cdab-d47e" name="Harrowhand" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f77-3d81-f4ea-b4d3" type="min"/>
@@ -152,6 +128,23 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5bf-025a-f828-3abe" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c31f-848f-a1a1-27ba" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="2291-421d-0d01-5939" name="Student of History" hidden="false" collective="false" import="true" targetId="6479-f02e-34a1-8905" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="e1a1-c276-086c-8bf2" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="fdbc-90a5-e1e1-4a85" value="1.0">
+              <conditions>
+                <condition field="selections" scope="e1a1-c276-086c-8bf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdbc-90a5-e1e1-4a85" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -280,15 +273,6 @@
       <entryLinks>
         <entryLink id="2a40-cdb6-9a81-fd96" name="Chapter Relics" hidden="false" collective="false" import="true" targetId="a32a-ba73-8c86-dc85" type="selectionEntryGroup"/>
         <entryLink id="1896-b64c-2d69-5299" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="467b-9118-e1e4-e9a3" type="selectionEntryGroup"/>
-      </entryLinks>
-    </entryLink>
-    <entryLink id="b0ad-d3c6-747b-b18b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="92b3-c77a-eff7-4d9b" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1b87-b057-b74a-7903" name="HQ" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="a0be-ad6d-bfac-15ca" name="Chapter Relics" hidden="false" collective="false" import="true" targetId="a32a-ba73-8c86-dc85" type="selectionEntryGroup"/>
-        <entryLink id="2652-b0e7-d23f-5dde" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="467b-9118-e1e4-e9a3" type="selectionEntryGroup"/>
       </entryLinks>
     </entryLink>
     <entryLink id="0eea-5b24-86b7-6599" name="New EntryLink" hidden="false" collective="false" import="true" targetId="5854-3db8-6043-ce0b" type="selectionEntry">
@@ -1272,6 +1256,26 @@
       </categoryLinks>
     </entryLink>
   </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="6479-f02e-34a1-8905" name="Student of History" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cb8-040f-4fc7-6bab" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aaa9-06f5-61e6-3a70" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="c09c-dd5a-3710-67cd" name="Student of History" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When this Warlord consolidates, they can move up to 6&quot; instead of 3&quot;, and do not have to end this move closer to the nearest enemy model</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="a32a-ba73-8c86-dc85" name="Chapter Relics" hidden="true" collective="false" import="true">
       <modifiers>
@@ -1752,6 +1756,7 @@
             <selectionEntry id="b736-3fa6-93e7-3796" name="Merciless Logic" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24e7-1f05-2a95-cc9c" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2141-8f8e-5f14-587e" type="max"/>
               </constraints>
               <profiles>
                 <profile id="1fe6-6984-34f1-d1c4" name="Merciless Logic" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1769,6 +1774,7 @@
             <selectionEntry id="3014-3a2d-7704-a1b1" name="Target Protocols" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00fc-cb1b-5fd1-ec5d" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2721-39c7-313c-3243" type="max"/>
               </constraints>
               <profiles>
                 <profile id="aa99-bfb3-3cd3-426b" name="Target Protocols" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1786,6 +1792,7 @@
             <selectionEntry id="4e9c-ca19-32b1-1d11" name="All Flesh is Weakness" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26d8-8b37-3775-7d0a" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="29f6-510c-cf2c-4521" type="max"/>
               </constraints>
               <profiles>
                 <profile id="89de-f6e1-4092-b169" name="All Flesh is Weakness" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1800,26 +1807,10 @@
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="7ee9-90e0-8ec9-1a72" name="Student of History" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a389-d4b5-26de-372d" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="20f2-1c5d-379b-cc2b" name="Student of History" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-                  <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When this Warlord consolidates, they can move up to 6&quot; instead of 3&quot;, and do not have to end this move closer to the nearest enemy model</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="8e01-7b2a-3eac-e995" name="Will of Iron" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0305-9ca1-f611-5be8" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e457-989b-c682-9679" type="max"/>
               </constraints>
               <profiles>
                 <profile id="8e4d-acb9-6e03-205d" name="Will of Iron" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1837,6 +1828,7 @@
             <selectionEntry id="31f4-4328-a319-a9e3" name="Adept of the Omnissiah" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd44-e66f-80d4-a026" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1ebd-482a-1a4a-0ed5" type="max"/>
               </constraints>
               <profiles>
                 <profile id="23d2-ea12-ad11-ad8c" name="Adept of the Omnissiah" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1853,6 +1845,9 @@
               </costs>
             </selectionEntry>
           </selectionEntries>
+          <entryLinks>
+            <entryLink id="5fe6-955f-bfaa-1bc7" name="Student of History" hidden="false" collective="false" import="true" targetId="6479-f02e-34a1-8905" type="selectionEntry"/>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>

--- a/Imperium - Raven Guard.cat
+++ b/Imperium - Raven Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9503-9e14-1988-91a4" name="Imperium - Adeptus Astartes - Raven Guard" revision="35" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9503-9e14-1988-91a4" name="Imperium - Adeptus Astartes - Raven Guard" revision="36" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="cbd4-64ea-2787-3c13" name="Kayvaan Shrike [Legends]" hidden="false" collective="false" import="true" type="model">
       <modifiers>
@@ -41,15 +41,6 @@
         <infoLink id="ff8c-8398-d62f-e7cc" name="Angels of Death" hidden="false" targetId="01a4-bec8-b573-fde7" type="rule"/>
         <infoLink id="5c43-4a1f-35cc-a2fc" name="Chapter Master" hidden="false" targetId="fdb4-b1a5-3c97-6400" type="profile"/>
         <infoLink id="b364-81a8-b44e-b76a" name="Iron Halo" hidden="false" targetId="242c-3bac-1ff3-48b0" type="profile"/>
-        <infoLink id="168e-0e10-770e-46fd" name="Silent Stalker" hidden="false" targetId="2182-82ea-a803-b8ec" type="profile">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="cbd4-64ea-2787-3c13" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink id="d4ee-71e7-1f3c-7a20" name="Jump Pack Assault" hidden="false" targetId="d167-aae2-932c-cded" type="profile"/>
       </infoLinks>
       <categoryLinks>
@@ -100,6 +91,23 @@
         </entryLink>
         <entryLink id="3fb0-128f-92f0-4e49" name="Warlord" hidden="false" collective="false" import="true" targetId="01cf-00c7-c4af-701b" type="selectionEntry"/>
         <entryLink id="5f08-bd74-2034-4f2c" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="0334-f487-8229-0c1a" type="selectionEntry"/>
+        <entryLink id="4cd8-8a96-8c1f-8c62" name="Shadowmaster" hidden="false" collective="false" import="true" targetId="21ac-70ba-0fc5-3f59" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="cbd4-64ea-2787-3c13" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="7f11-4961-3d18-68c9" value="1.0">
+              <conditions>
+                <condition field="selections" scope="cbd4-64ea-2787-3c13" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f11-4961-3d18-68c9" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
@@ -152,15 +160,6 @@
         <infoLink id="e6ce-d437-5480-35fe" name="Angels of Death" hidden="false" targetId="01a4-bec8-b573-fde7" type="rule"/>
         <infoLink id="641f-34bb-c9e4-03b7" name="Chapter Master" hidden="false" targetId="fdb4-b1a5-3c97-6400" type="profile"/>
         <infoLink id="f9c4-91bb-91d7-d7d4" name="Iron Halo" hidden="false" targetId="242c-3bac-1ff3-48b0" type="profile"/>
-        <infoLink id="015f-4208-963c-90cb" name="Shadowmaster" hidden="false" targetId="2182-82ea-a803-b8ec" type="profile">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="0460-99db-b063-5670" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink id="ee46-1d0c-59a5-4361" name="Rites of Battle" hidden="false" targetId="922c-75db-5ca4-3750" type="profile"/>
       </infoLinks>
       <categoryLinks>
@@ -233,6 +232,23 @@
           </constraints>
         </entryLink>
         <entryLink id="0d14-0884-2cce-cd91" name="Warlord" hidden="false" collective="false" import="true" targetId="01cf-00c7-c4af-701b" type="selectionEntry"/>
+        <entryLink id="5860-2f83-b550-1496" name="Shadowmaster" hidden="false" collective="false" import="true" targetId="21ac-70ba-0fc5-3f59" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="0460-99db-b063-5670" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="6fd2-7706-2ad6-a7d5" value="1.0">
+              <conditions>
+                <condition field="selections" scope="0460-99db-b063-5670" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fd2-7706-2ad6-a7d5" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
@@ -359,15 +375,6 @@
       <entryLinks>
         <entryLink id="83a4-c271-451d-3aba" name="Chapter Relics" hidden="false" collective="false" import="true" targetId="2995-11a2-9ebb-2529" type="selectionEntryGroup"/>
         <entryLink id="bc83-25ec-681d-9f71" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3e75-d0f4-766e-d0f2" type="selectionEntryGroup"/>
-      </entryLinks>
-    </entryLink>
-    <entryLink id="db7a-c8db-ad75-4332" name="New EntryLink" hidden="false" collective="false" import="true" targetId="92b3-c77a-eff7-4d9b" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b719-be2e-b5dd-6893" name="HQ" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="0bad-eb8c-8f27-a1c3" name="Chapter Relics" hidden="false" collective="false" import="true" targetId="2995-11a2-9ebb-2529" type="selectionEntryGroup"/>
-        <entryLink id="cccf-b9b2-729f-0acd" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3e75-d0f4-766e-d0f2" type="selectionEntryGroup"/>
       </entryLinks>
     </entryLink>
     <entryLink id="e887-e9a4-5b21-1f20" name="New EntryLink" hidden="false" collective="false" import="true" targetId="5854-3db8-6043-ce0b" type="selectionEntry">
@@ -1225,6 +1232,22 @@
       </categoryLinks>
     </entryLink>
   </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="21ac-70ba-0fc5-3f59" name="Shadowmaster" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed27-acbb-d491-f93e" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1e9b-d35a-e2eb-5596" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="7631-6de9-561c-d8be" name="Silent Stalker" hidden="false" targetId="2182-82ea-a803-b8ec" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="168e-9e38-f042-684a" name="Disciplines" hidden="false" collective="false" import="true">
       <modifiers>
@@ -1470,22 +1493,10 @@
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="035c-ce03-27e9-da56" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="6d77-dd27-87ec-d987" name="Shadowmaster" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5147-761a-5f9e-4947" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="c49d-9f85-4469-7696" name="Silent Stalker" hidden="false" targetId="2182-82ea-a803-b8ec" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="e3fa-dd05-889d-6e2b" name="Echo of the Ravenspire" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d384-fb80-f502-0b50" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="655e-583d-0aac-6f08" type="max"/>
               </constraints>
               <profiles>
                 <profile id="224a-b21c-1c28-85d7" name="Echo of the Ravenspire" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1503,6 +1514,7 @@
             <selectionEntry id="2176-1811-4ffa-0e09" name="Feigned Flight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ff2-9cd7-13f0-0526" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8cd8-4743-b5ee-bce1" type="max"/>
               </constraints>
               <profiles>
                 <profile id="0d17-e100-2fe8-b3e3" name="Feigned Flight" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1520,6 +1532,7 @@
             <selectionEntry id="ba32-0d6f-e313-5b5e" name="Master of Vigilance" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d968-2577-fbc8-b417" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3274-4240-08fa-b68b" type="max"/>
               </constraints>
               <profiles>
                 <profile id="0292-341d-e4bc-e81c" name="Master of Vigilance" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1537,6 +1550,7 @@
             <selectionEntry id="4b01-169b-aa52-8dc0" name="Swift and Deadly" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7544-5331-f79b-4dbe" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="12a5-53fa-1bb3-7e0a" type="max"/>
               </constraints>
               <profiles>
                 <profile id="88cb-c53d-7ab5-95bf" name="Swift and Deadly (Aura)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1554,6 +1568,7 @@
             <selectionEntry id="3081-a2d8-af4e-d672" name="Master of Ambush" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59c5-470b-ecf5-5dc3" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="99e0-6aac-0b5e-bb90" type="max"/>
               </constraints>
               <profiles>
                 <profile id="6c77-5a75-b942-6186" name="Master of Ambush" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1569,6 +1584,9 @@
               </costs>
             </selectionEntry>
           </selectionEntries>
+          <entryLinks>
+            <entryLink id="a0e3-8fb1-f175-fc36" name="Shadowmaster" hidden="false" collective="false" import="true" targetId="21ac-70ba-0fc5-3f59" type="selectionEntry"/>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>

--- a/Imperium - Salamanders.cat
+++ b/Imperium - Salamanders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="4501-8439-ec2c-efad" name="Imperium - Adeptus Astartes - Salamanders" revision="33" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="4501-8439-ec2c-efad" name="Imperium - Adeptus Astartes - Salamanders" revision="34" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="264d-cbed-e233-21d1" name="Adrax Agatone" hidden="false" collective="false" import="true" type="model">
       <modifiers>
@@ -42,20 +42,6 @@
       <infoLinks>
         <infoLink id="5b6d-d1d9-59e0-06b8" name="Rites of Battle" hidden="false" targetId="922c-75db-5ca4-3750" type="profile"/>
         <infoLink id="8259-b1a6-b864-2f63" name="Iron Halo" hidden="false" targetId="242c-3bac-1ff3-48b0" type="profile"/>
-        <infoLink id="668b-28bd-2be1-0a66" name="Lord of Fire (Aura)" hidden="false" targetId="cad8-6915-d846-4899" type="profile">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="264d-cbed-e233-21d1" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
-                    <condition field="selections" scope="264d-cbed-e233-21d1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5efd-6285-c9f7-2a5a" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="fe60-e7a6-22aa-e825" name="Captain" hidden="false" targetId="8352-7f67-7e2b-3b4f" primary="false"/>
@@ -124,6 +110,23 @@
           </constraints>
         </entryLink>
         <entryLink id="3f26-d9dc-370c-c93e" name="Warlord" hidden="false" collective="false" import="true" targetId="01cf-00c7-c4af-701b" type="selectionEntry"/>
+        <entryLink id="0e96-6891-5b6d-9710" name="Lord of Fire (Aura)" hidden="false" collective="false" import="true" targetId="4d58-a588-16c8-7a14" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="264d-cbed-e233-21d1" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="c746-4adf-b0a5-257d" value="1.0">
+              <conditions>
+                <condition field="selections" scope="264d-cbed-e233-21d1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c746-4adf-b0a5-257d" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
@@ -174,20 +177,6 @@
       </profiles>
       <infoLinks>
         <infoLink id="7855-b8d9-d219-1c23" name="Rites of Battle" hidden="false" targetId="922c-75db-5ca4-3750" type="profile"/>
-        <infoLink id="fe5b-9249-0511-c1f0" name="Anvil of Strength" hidden="false" targetId="05cc-be62-d02a-ff67" type="profile">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="6dd6-e606-b377-f261" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5efd-6285-c9f7-2a5a" type="equalTo"/>
-                    <condition field="selections" scope="6dd6-e606-b377-f261" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="26c0-2ef0-3277-9bf8" name="New CategoryLink" hidden="false" targetId="c7b7-edbc-bc14-6238" primary="false"/>
@@ -261,6 +250,23 @@
           </constraints>
         </entryLink>
         <entryLink id="a359-7bb5-2984-9241" name="Warlord" hidden="false" collective="false" import="true" targetId="01cf-00c7-c4af-701b" type="selectionEntry"/>
+        <entryLink id="69f0-5a3d-da68-e4fc" name="Anvil of Strength" hidden="false" collective="false" import="true" targetId="7d44-076e-2003-79a4" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="6dd6-e606-b377-f261" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="7f39-e971-a348-ae12" value="1.0">
+              <conditions>
+                <condition field="selections" scope="6dd6-e606-b377-f261" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f39-e971-a348-ae12" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
@@ -390,15 +396,6 @@
       <entryLinks>
         <entryLink id="ec99-78e4-14d6-d03e" name="Chapter Relics" hidden="false" collective="false" import="true" targetId="3c14-f2aa-db72-c3c9" type="selectionEntryGroup"/>
         <entryLink id="bd4c-624c-5c91-d85f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="e92c-a3a4-ffdf-8777" type="selectionEntryGroup"/>
-      </entryLinks>
-    </entryLink>
-    <entryLink id="bab9-9242-981c-0020" name="New EntryLink" hidden="false" collective="false" import="true" targetId="92b3-c77a-eff7-4d9b" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c64d-9eed-853e-3dcc" name="HQ" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="c3bd-31c6-707f-9884" name="Chapter Relics" hidden="false" collective="false" import="true" targetId="3c14-f2aa-db72-c3c9" type="selectionEntryGroup"/>
-        <entryLink id="b370-4736-9813-4ba7" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="e92c-a3a4-ffdf-8777" type="selectionEntryGroup"/>
       </entryLinks>
     </entryLink>
     <entryLink id="4f31-f57e-51ea-1739" name="New EntryLink" hidden="false" collective="false" import="true" targetId="5854-3db8-6043-ce0b" type="selectionEntry">
@@ -1342,6 +1339,40 @@
       </categoryLinks>
     </entryLink>
   </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="4d58-a588-16c8-7a14" name="Lord of Fire (Aura)" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d076-99ea-6621-0baf" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fdde-7b59-1505-522d" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="2ec1-b0f8-acbd-a75f" name="Lord of Fire (Aura)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You can re-roll the dice to determine the number of attacks made with flame weapons (see Codex: Space Marines) by friendly SALAMANDERS models whilst their unit is within 6&quot; of this Warlord.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7d44-076e-2003-79a4" name="Anvil of Strength" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70fe-a3dd-c433-1bfa" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d7e-4507-279c-6db1" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="0cef-dd82-db5b-b6fa" name="Anvil of Strength" hidden="false" targetId="05cc-be62-d02a-ff67" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="e92c-a3a4-ffdf-8777" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
@@ -1394,22 +1425,10 @@
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d8d5-eddd-9b9f-376a" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="109e-8011-5199-49ac" name="Anvil of Strength" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fc0-9d82-7b63-3db4" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="2c0b-ea90-be0f-b257" name="Anvil of Strength" hidden="false" targetId="05cc-be62-d02a-ff67" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="2729-0760-afeb-91d9" name="Miraculous Constitution" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a997-b4d9-23f6-2288" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6e9c-0dc9-3fab-85c6" type="max"/>
               </constraints>
               <profiles>
                 <profile id="a0c3-295a-5716-8019" name="Miraculous Constitution" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1427,6 +1446,7 @@
             <selectionEntry id="3b9a-a817-74a4-3fc8" name="Never Give Up" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd7e-38bc-b687-536a" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="202e-713f-f8dd-ef8b" type="max"/>
               </constraints>
               <profiles>
                 <profile id="8651-2eae-3978-a661" name="Never Give Up" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1444,6 +1464,7 @@
             <selectionEntry id="9858-0ed5-023b-3de6" name="Forge Master" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="579d-ace1-6ba1-328a" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d34e-2ca4-b30c-b311" type="max"/>
               </constraints>
               <profiles>
                 <profile id="23a6-ed50-4283-1d61" name="Forge Master" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1461,6 +1482,7 @@
             <selectionEntry id="d080-1cc7-a398-6e1c" name="Patient and Determined" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c94d-e778-627b-130a" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b472-b363-bf9e-6450" type="max"/>
               </constraints>
               <profiles>
                 <profile id="c107-98d5-70a9-4e5e" name="Patient and Determined" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1475,24 +1497,11 @@
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b03f-dcc2-b1d7-0faf" name="Lord of Fire (Aura)" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="149f-f45f-a7fa-9baa" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="cad8-6915-d846-4899" name="Lord of Fire (Aura)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-                  <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You can re-roll the dice to determine the number of attacks made with flame weapons (see Codex: Space Marines) by friendly SALAMANDERS models whilst their unit is within 6&quot; of this Warlord.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
           </selectionEntries>
+          <entryLinks>
+            <entryLink id="55fc-f20d-975c-4528" name="Lord of Fire (Aura)" hidden="false" collective="false" import="true" targetId="4d58-a588-16c8-7a14" type="selectionEntry"/>
+            <entryLink id="8e23-2484-e7ea-0802" name="Anvil of Strength" hidden="false" collective="false" import="true" targetId="7d44-076e-2003-79a4" type="selectionEntry"/>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>

--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="846d-3c14-21fc-369f" name="Imperium - Space Marines" revision="229" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="846d-3c14-21fc-369f" name="Imperium - Space Marines" revision="230" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="846d-3c14-pubN65537" name="Index: Imperium 1 &amp; Codex: Space Marines"/>
   </publications>
@@ -23590,6 +23590,7 @@ Each time this WARLORD is selected to return a destroyed model to a unit by usin
         <selectionEntry id="c5de-8701-961c-7278" name="Fear Made Manifest" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f926-c49f-c782-f6da" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dc84-0954-fe0b-cee3" type="max"/>
           </constraints>
           <profiles>
             <profile id="ce03-811d-fda3-7739" name="Fear Made Manifest (Aura)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -23609,6 +23610,7 @@ Each time this WARLORD is selected to return a destroyed model to a unit by usin
         <selectionEntry id="5d5b-da31-11fc-2482" name="Champion of Humanity" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fde-3933-2d13-dd02" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="77e9-e1a4-0156-3949" type="max"/>
           </constraints>
           <profiles>
             <profile id="5eba-4a4c-bd5f-d8bc" name="Champion of Humanity" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -23627,6 +23629,7 @@ Each time this WARLORD makes a melee attack against a CHARACTER unit, add 1 to t
         <selectionEntry id="90a6-7b5a-61db-ed0f" name="Iron Resolve" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5035-3151-8243-e9d3" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="556a-30b0-01a2-04ee" type="max"/>
           </constraints>
           <profiles>
             <profile id="2eb1-0abe-75a5-fe92" name="Iron Resolve" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -23645,6 +23648,7 @@ Each time your warlord loses a wound, roll one D6, on a 6 that wound is not lost
         <selectionEntry id="f97c-1373-4465-41dd" name="Rites of War" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9297-e7fc-7b09-f81f" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a052-36de-7405-1c8f" type="max"/>
           </constraints>
           <profiles>
             <profile id="0059-ca19-819e-000c" name="Rites of War" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -23662,6 +23666,7 @@ Each time your warlord loses a wound, roll one D6, on a 6 that wound is not lost
         <selectionEntry id="786a-6191-3e44-5a28" name="Storm of Fire" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f2d-d994-d2e4-6bfe" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c208-fded-9b51-c81a" type="max"/>
           </constraints>
           <profiles>
             <profile id="0b2c-b1a7-4c82-cfcd" name="Storm of Fire" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -23679,6 +23684,7 @@ Each time your warlord loses a wound, roll one D6, on a 6 that wound is not lost
         <selectionEntry id="53e3-9d00-87e4-f41c" name="The Imperium&apos;s Sword" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2104-4bc2-326b-d4aa" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2b17-3f24-83d3-edb7" type="max"/>
           </constraints>
           <profiles>
             <profile id="cae8-c991-182a-d531" name="The Imperium&apos;s Sword" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -23914,6 +23920,7 @@ Each time this WARLORD is selected to use the Commanding Oratory stratagem, that
         <selectionEntry id="681b-e638-ce54-9ef0" name="1. Shoot and Fade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e78-71dc-23d8-bcd9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="09f1-c711-2973-7283" type="max"/>
           </constraints>
           <profiles>
             <profile id="e625-3100-7be4-e2c4" name="Shoot and Fade" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -23931,6 +23938,7 @@ Each time this WARLORD is selected to use the Commanding Oratory stratagem, that
         <selectionEntry id="69c9-0d4d-f9dd-3f49" name="2. Lord of Deceit" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71f8-7789-df3e-f44d" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5c20-761a-538f-9700" type="max"/>
           </constraints>
           <profiles>
             <profile id="630e-2956-47a9-c957" name="Lord of Deceit" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -23948,6 +23956,7 @@ Each time this WARLORD is selected to use the Commanding Oratory stratagem, that
         <selectionEntry id="8d9a-5996-419e-48be" name="3. Master of the Vanguard" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c310-653e-da77-33fc" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e298-7b74-4115-ce7c" type="max"/>
           </constraints>
           <profiles>
             <profile id="ee69-f809-aecb-8388" name="Master of the Vanguard" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -23967,6 +23976,7 @@ Each time this WARLORD is selected to use the Commanding Oratory stratagem, that
         <selectionEntry id="9fe4-cc52-979b-c3dd" name="4. Stealth Adept" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbcf-d261-8b40-50e0" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6ffd-5099-b408-d4c9" type="max"/>
           </constraints>
           <profiles>
             <profile id="2301-14cf-8cc8-03e7" name="Stealth Adept" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -23984,6 +23994,7 @@ Each time this WARLORD is selected to use the Commanding Oratory stratagem, that
         <selectionEntry id="b045-d4e1-0029-84c2" name="5. Target Priority" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4f5-e5be-42e1-cbf5" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="10a0-eee5-3921-7df2" type="max"/>
           </constraints>
           <profiles>
             <profile id="385d-3bbd-7a41-11eb" name="Target Priority" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -24001,6 +24012,7 @@ Each time this WARLORD is selected to use the Commanding Oratory stratagem, that
         <selectionEntry id="95be-64c0-009c-84ac" name="6. Marksman&apos;s Honors" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="940c-5301-3af6-a187" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="53bc-ffed-fcb6-dd61" type="max"/>
           </constraints>
           <profiles>
             <profile id="c4e7-a427-507a-02df" name="Marksman&apos;s Honors" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">

--- a/Imperium - White Scars.cat
+++ b/Imperium - White Scars.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c010-4da2-5a55-a3be" name="Imperium - Adeptus Astartes - White Scars" revision="32" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c010-4da2-5a55-a3be" name="Imperium - Adeptus Astartes - White Scars" revision="33" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="178" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="38f8-60cb-7a29-7752" name="Khan on Bike" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -137,15 +137,6 @@
         <infoLink id="5c83-41cf-f766-53e7" name="Rites of Battle" hidden="false" targetId="922c-75db-5ca4-3750" type="profile"/>
         <infoLink id="0eb4-fd95-9061-dbd5" name="Iron Halo" hidden="false" targetId="242c-3bac-1ff3-48b0" type="profile"/>
         <infoLink id="e87f-c027-b1cc-3811" name="Angels of Death" hidden="false" targetId="01a4-bec8-b573-fde7" type="rule"/>
-        <infoLink id="c45b-7eba-bbab-e8fe" name="Trophy Taker" hidden="false" targetId="5a64-bf04-2541-912e" type="profile">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="cf7c-2f40-c736-021a" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5515-eaed-82e5-c85c" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -197,6 +188,23 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea5c-1a7e-ff96-6e3d" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="844b-2c61-ef5b-30cd" name="Trophy Taker" hidden="false" collective="false" import="true" targetId="2e58-768d-0861-c3fe" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="cf7c-2f40-c736-021a" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="2555-21ef-f23d-ebc5" value="1.0">
+              <conditions>
+                <condition field="selections" scope="cf7c-2f40-c736-021a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2555-21ef-f23d-ebc5" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="110.0"/>
@@ -244,15 +252,6 @@
         <infoLink id="5692-a0ae-ce80-1eb4" name="Rites of Battle" hidden="false" targetId="922c-75db-5ca4-3750" type="profile"/>
         <infoLink id="b29d-87e0-e1c4-d03e" name="Iron Halo" hidden="false" targetId="242c-3bac-1ff3-48b0" type="profile"/>
         <infoLink id="d4f6-9ca7-53b1-2338" name="Angels of Death" hidden="false" targetId="01a4-bec8-b573-fde7" type="rule"/>
-        <infoLink id="f8dd-29c7-c85a-72c9" name="Trophy Taker" hidden="false" targetId="5a64-bf04-2541-912e" type="profile">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="b9c6-4c9f-9b89-0ea4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ebe6-4251-0920-162f" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -298,6 +297,23 @@
           </constraints>
         </entryLink>
         <entryLink id="4b7e-7d57-8161-0aa7" name="Warlord" hidden="false" collective="false" import="true" targetId="01cf-00c7-c4af-701b" type="selectionEntry"/>
+        <entryLink id="313d-4eb3-14d0-ebdd" name="Trophy Taker" hidden="false" collective="false" import="true" targetId="2e58-768d-0861-c3fe" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="b9c6-4c9f-9b89-0ea4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="5d5d-57b2-67c4-3896" value="1.0">
+              <conditions>
+                <condition field="selections" scope="b9c6-4c9f-9b89-0ea4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d5d-57b2-67c4-3896" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="90.0"/>
@@ -345,15 +361,6 @@
         <infoLink id="27da-323e-91a8-f608" name="Angels of Death" hidden="false" targetId="01a4-bec8-b573-fde7" type="rule"/>
         <infoLink id="f295-e9d0-b812-08e0" name="Rites of Battle" hidden="false" targetId="922c-75db-5ca4-3750" type="profile"/>
         <infoLink id="af2a-f7ed-de18-b0a6" name="Iron Halo" hidden="false" targetId="242c-3bac-1ff3-48b0" type="profile"/>
-        <infoLink id="a044-58f0-206f-543f" name="Trophy Taker" hidden="false" targetId="5a64-bf04-2541-912e" type="profile">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="fdb5-313d-f40b-ab1e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink id="b8b6-7a8d-337d-efb6" name="Turbo-boost" hidden="false" targetId="c027-2e84-7468-0607" type="profile"/>
       </infoLinks>
       <categoryLinks>
@@ -411,6 +418,23 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c168-7b06-441c-454d" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31b5-daf5-8b3b-cf76" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="3ea0-90a1-666d-4e61" name="Trophy Taker" hidden="false" collective="false" import="true" targetId="2e58-768d-0861-c3fe" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="fdb5-313d-f40b-ab1e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="a6a8-8df1-d904-2cb1" value="1.0">
+              <conditions>
+                <condition field="selections" scope="fdb5-313d-f40b-ab1e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01cf-00c7-c4af-701b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6a8-8df1-d904-2cb1" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -537,15 +561,6 @@
       <entryLinks>
         <entryLink id="8a24-7796-f2ca-1fa2" name="Chapter Relics" hidden="false" collective="false" import="true" targetId="80ed-10b8-d2d5-a5e0" type="selectionEntryGroup"/>
         <entryLink id="3b49-13bb-5c6e-4dfc" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="453e-769a-4240-c489" type="selectionEntryGroup"/>
-      </entryLinks>
-    </entryLink>
-    <entryLink id="a7cf-b905-9ccb-f5e2" name="Captain in Cataphractii Armor" hidden="false" collective="false" import="true" targetId="92b3-c77a-eff7-4d9b" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="89ee-9e27-fb5f-dd0c" name="HQ" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="2b74-f476-63f9-3fea" name="Chapter Relics" hidden="false" collective="false" import="true" targetId="80ed-10b8-d2d5-a5e0" type="selectionEntryGroup"/>
-        <entryLink id="4386-ffca-6cd9-9ba1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="453e-769a-4240-c489" type="selectionEntryGroup"/>
       </entryLinks>
     </entryLink>
     <entryLink id="1cc4-a5d2-0936-e4ab" name="Captain in Gravis Armor" hidden="false" collective="false" import="true" targetId="5854-3db8-6043-ce0b" type="selectionEntry">
@@ -1413,6 +1428,26 @@
       </entryLinks>
     </entryLink>
   </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="2e58-768d-0861-c3fe" name="Trophy Taker" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e080-11bf-a2dc-7e25" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="52ee-8ff7-52a4-acaa" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="c5f7-bab4-8e59-6d18" name="Trophy Taker" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When this Warlord destroys an enemy CHARACTER model, add 1 to their Attacks characteristic until the end of the battle.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="453e-769a-4240-c489" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
@@ -1468,6 +1503,7 @@
             <selectionEntry id="9abb-08a2-c75f-c59e" name="Chogorian Storm" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7454-d4cc-106b-8d9b" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d8f0-4c33-969d-2f52" type="max"/>
               </constraints>
               <profiles>
                 <profile id="104a-dbc1-aad6-812c" name="Chogorian Storm" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1485,6 +1521,7 @@
             <selectionEntry id="dedd-361b-3132-59cf" name="Deadly Hunter" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74ce-b6df-b216-e167" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c085-2614-89e5-896a" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="db46-62c3-0b56-a28b" name="Deadly Hunter" hidden="false" targetId="da2d-565c-a02f-0887" type="profile"/>
@@ -1493,23 +1530,6 @@
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                 <cost name="pts" typeId="points" value="0.0"/>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2cd4-8911-3d1f-b85d" name="Trophy Taker" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08e7-9706-599f-2793" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="5a64-bf04-2541-912e" name="Trophy Taker" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-                  <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When this Warlord destroys an enemy CHARACTER model, add 1 to their Attacks characteristic until the end of the battle.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9bb1-bfbe-0588-5675" name="Master Rider" hidden="false" collective="false" import="true" type="upgrade">
@@ -1526,6 +1546,7 @@
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3757-a162-6f9d-cb36" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2d91-36b8-656f-fc1e" type="max"/>
               </constraints>
               <profiles>
                 <profile id="81ca-475b-47c7-d95d" name="Master Rider" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1543,6 +1564,7 @@
             <selectionEntry id="8439-a958-26c8-65e1" name="Hunter&apos;s Instincts" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f296-55b7-0d4c-e53d" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d688-055e-a1a8-ce66" type="max"/>
               </constraints>
               <profiles>
                 <profile id="0dba-3ec0-ef18-4afa" name="Hunter&apos;s Instincts" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1560,6 +1582,7 @@
             <selectionEntry id="4ec3-7b60-a2f2-ef25" name="Master of Snares" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfe8-8f9e-106e-1b6e" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="93d1-1492-1344-bed5" type="max"/>
               </constraints>
               <profiles>
                 <profile id="d227-811f-053f-cae2" name="Master of Snares" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1575,6 +1598,9 @@
               </costs>
             </selectionEntry>
           </selectionEntries>
+          <entryLinks>
+            <entryLink id="4ff5-53d0-6c16-5fb5" name="Trophy Taker" hidden="false" collective="false" import="true" targetId="2e58-768d-0861-c3fe" type="selectionEntry"/>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>


### PR DESCRIPTION
- Closes #9390
- Added Max 1 in Roster to ALL SM WLTs as needed (so that Hero of the Chapter doesn't allow duplicates).
- Switched all Named Chars to the "new style" WLTs (hidden till Warlord then min1) to allow the above validation to work.