### PR TITLE
fix Land Raider Achilles points

### DIFF
--- a/Imperium - FW Adeptus Astartes.cat
+++ b/Imperium - FW Adeptus Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="dab7-e076-dd5e-d8aa" name="Imperium - FW Adeptus Astartes" revision="91" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="186" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="dab7-e076-dd5e-d8aa" name="Imperium - FW Adeptus Astartes" revision="92" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="189" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="dab7-e076-pubN133616" name="Codex: Space Wolves"/>
     <publication id="dab7-e076-pubN151451" name="Astraeus Super-heavy Tank PDF"/>
@@ -2878,9 +2878,9 @@
         <categoryLink id="1f39-9c0a-ab98-0c9f" name="Smokescreen" hidden="false" targetId="5bbb-5804-a0c8-b175" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e294-c6f8-dbc5-bf93" name="Sponsons" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="e294-c6f8-dbc5-bf93" name="Sponsons" hidden="false" collective="false" import="true" defaultSelectionEntryId="955c-6825-55c5-b5ab">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1028-de0c-4f7a-59cd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1028-de0c-4f7a-59cd" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83c8-2959-ded9-397a" type="max"/>
           </constraints>
           <entryLinks>
@@ -2898,6 +2898,9 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79be-90a5-8244-9ffe" type="max"/>
           </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
         </entryLink>
         <entryLink id="4073-ee35-82d8-8d97" name="Hunter-killer missile" hidden="false" collective="false" import="true" targetId="f6ce-b334-6526-0cfe" type="selectionEntry">
           <constraints>


### PR DESCRIPTION
This fixes multiple things for the Land Raider Achilles:

* Points for the Storm Bolter are now 5 points
* Sponsor definition is more accurate. It is not possible to have a land
  Raider without sponsors, and the default culverins are now selected

closes  #10038