### PR TITLE
fix(Imperial Fists): Expulsiaris condition selector

### DIFF
--- a/Imperium - Dark Angels.cat
+++ b/Imperium - Dark Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b8fe-8d38-37ec-90e8" name="Imperium - Adeptus Astartes - Dark Angels" revision="216" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Thairne" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="188" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="b8fe-8d38-37ec-90e8" name="Imperium - Adeptus Astartes - Dark Angels" revision="217" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Thairne" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="189" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="b8fe-8d38-pubN65537" name="Codex: Dark Angels"/>
   </publications>
@@ -7354,7 +7354,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c6a-091e-237c-d91d" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="bb3a-650f-0369-ab45" name="Master-crafted power sword" hidden="false" collective="false" import="true" targetId="7d93-d63c-bfba-c879" type="selectionEntry">
+            <entryLink id="bb3a-650f-0369-ab45" name="Master-crafted power sword" hidden="false" collective="false" import="true" targetId="2500-aed6-f77e-88f9" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85d9-cc72-959b-2bdb" type="max"/>
               </constraints>

--- a/Imperium - FW Adeptus Astartes.cat
+++ b/Imperium - FW Adeptus Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="dab7-e076-dd5e-d8aa" name="Imperium - FW Adeptus Astartes" revision="91" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="186" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="dab7-e076-dd5e-d8aa" name="Imperium - FW Adeptus Astartes" revision="92" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="189" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="dab7-e076-pubN133616" name="Codex: Space Wolves"/>
     <publication id="dab7-e076-pubN151451" name="Astraeus Super-heavy Tank PDF"/>
@@ -1762,17 +1762,36 @@
         <categoryLink id="8610-0990-92ba-62b5" name="Chief Apothecary" hidden="false" targetId="b42a-8708-00d3-bcc6" primary="false"/>
         <categoryLink id="89e7-468f-4f58-058a" name="Command Squad" hidden="false" targetId="127d-5d0f-4663-0235" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4c6a-921b-ded8-808c" name="Master-crafted power sword" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42ee-5ab6-7583-e685" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ceb-cd9c-04e2-da69" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="015e-852c-70ad-6aa7" name="Master-crafted power sword" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">Melee</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Melee</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">+1</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <entryLinks>
         <entryLink id="4dd7-8c32-6f5f-ba22" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="bb78-534a-7b77-edbc" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5fd-13b3-327c-b527" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3e8-eaa8-20b5-ecb8" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="1ff8-f0de-ebca-f64e" name="Master-crafted power sword" hidden="false" collective="false" import="true" targetId="7d93-d63c-bfba-c879" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b707-91e3-3bd6-5ffb" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33be-0068-27e2-320b" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="e862-7fe3-4ed3-df1b" name="Bloodfire" hidden="false" collective="false" import="true" targetId="9b0a-25bb-9380-8135" type="selectionEntry">

--- a/Imperium - Imperial Fists.cat
+++ b/Imperium - Imperial Fists.cat
@@ -2325,8 +2325,7 @@ Know Thy Enemy (Aura): While a friendly EXORCISTS CORE or EXORCISTS CHARACTER un
                     <conditionGroup type="and">
                       <conditions>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="equalTo"/>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d93-d63c-bfba-c879" type="equalTo"/>
-			<condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2500-aed6-f77e-88f9" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2500-aed6-f77e-88f9" type="equalTo"/>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c754-9c52-a162-2032" type="equalTo"/>
                       </conditions>
                     </conditionGroup>

--- a/Imperium - Imperial Fists.cat
+++ b/Imperium - Imperial Fists.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0b92-701a-704e-2d9f" name="Imperium - Adeptus Astartes - Imperial Fists" revision="44" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur " authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="188" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0b92-701a-704e-2d9f" name="Imperium - Adeptus Astartes - Imperial Fists" revision="44" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur " authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="189" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="94ea-2b86-14a0-402f" name="Captain Lysander" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -2326,6 +2326,8 @@ Know Thy Enemy (Aura): While a friendly EXORCISTS CORE or EXORCISTS CHARACTER un
                       <conditions>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="equalTo"/>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d93-d63c-bfba-c879" type="equalTo"/>
+			<condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2500-aed6-f77e-88f9" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c754-9c52-a162-2032" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>

--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="846d-3c14-21fc-369f" name="Imperium - Space Marines" revision="250" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="188" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="846d-3c14-21fc-369f" name="Imperium - Space Marines" revision="251" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="189" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="846d-3c14-pubN65537" name="Index: Imperium 1 &amp; Codex: Space Marines"/>
   </publications>
@@ -456,7 +456,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c0f-0bc5-27bf-2d25" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="0ea8-99df-4500-1b49" name="Master-crafted power sword" hidden="false" collective="false" import="true" targetId="7d93-d63c-bfba-c879" type="selectionEntry">
+        <entryLink id="0ea8-99df-4500-1b49" name="Master-crafted power sword" hidden="false" collective="false" import="true" targetId="2500-aed6-f77e-88f9" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="points" value="0.0"/>
           </modifiers>
@@ -588,7 +588,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbcf-b3ee-0fac-3f09" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="90c7-63a8-92aa-d9c5" name="Master-crafted power sword" hidden="false" collective="false" import="true" targetId="7d93-d63c-bfba-c879" type="selectionEntry">
+        <entryLink id="90c7-63a8-92aa-d9c5" name="Master-crafted power sword" hidden="false" collective="false" import="true" targetId="2500-aed6-f77e-88f9" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cdd-8749-5a79-28b1" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0113-908f-c3e7-8338" type="max"/>
@@ -1253,7 +1253,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1e3a-1d98-2cbb-af47" name="Master-crafted power sword" hidden="false" collective="false" import="true" targetId="7d93-d63c-bfba-c879" type="selectionEntry">
+        <entryLink id="1e3a-1d98-2cbb-af47" name="Master-crafted power sword" hidden="false" collective="false" import="true" targetId="2500-aed6-f77e-88f9" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="points" value="0.0"/>
           </modifiers>
@@ -12563,7 +12563,6 @@
             <conditionGroup type="and">
               <conditions>
                 <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="equalTo"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d93-d63c-bfba-c879" type="equalTo"/>
                 <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c754-9c52-a162-2032" type="equalTo"/>
                 <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2500-aed6-f77e-88f9" type="equalTo"/>
               </conditions>
@@ -15532,7 +15531,6 @@ Weapon: Purgatorus</characteristic>
               <conditions>
                 <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="equalTo"/>
                 <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2500-aed6-f77e-88f9" type="equalTo"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d93-d63c-bfba-c879" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -16043,7 +16041,7 @@ Weapon: Purgatorus</characteristic>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4564-0b9e-a85a-c917" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="007e-0faf-033e-6ad8" name="Master-crafted power sword" hidden="false" collective="false" import="true" targetId="7d93-d63c-bfba-c879" type="selectionEntry">
+                <entryLink id="007e-0faf-033e-6ad8" name="Master-crafted power sword" hidden="false" collective="false" import="true" targetId="2500-aed6-f77e-88f9" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d14-d90d-c968-3814" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d80-42cf-6836-bcf4" type="min"/>
@@ -16063,7 +16061,7 @@ Weapon: Purgatorus</characteristic>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
             </entryLink>
-            <entryLink id="cc4c-c16a-1e17-bec1" name="Master-crafted power sword" hidden="false" collective="false" import="true" targetId="7d93-d63c-bfba-c879" type="selectionEntry"/>
+            <entryLink id="cc4c-c16a-1e17-bec1" name="Master-crafted power sword" hidden="false" collective="false" import="true" targetId="2500-aed6-f77e-88f9" type="selectionEntry"/>
             <entryLink id="db2d-a8a7-e94c-6e84" name="Master-crafted stalker bolt rifle" hidden="false" collective="false" import="true" targetId="fa24-4b8c-d4bc-72b5" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -22346,7 +22344,6 @@ time a model in that unit makes an attack against the enemy unit you selected at
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2500-aed6-f77e-88f9" type="equalTo"/>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc0b-c19f-0b71-081e" type="equalTo"/>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d3c0-0759-f387-630f" type="equalTo"/>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d93-d63c-bfba-c879" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -22618,7 +22615,6 @@ time a model in that unit makes an attack against the enemy unit you selected at
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b050-572b-911b-d51c" type="equalTo"/>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="equalTo"/>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3292-34e6-f679-d5b9" type="equalTo"/>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d93-d63c-bfba-c879" type="equalTo"/>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90de-7b01-e401-888b" type="equalTo"/>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35c3-1805-7d83-be7a" type="equalTo"/>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="571f-9ce0-488c-0857" type="equalTo"/>

--- a/Imperium - Ultramarines.cat
+++ b/Imperium - Ultramarines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="28e2-d179-3d66-a272" name="Imperium - Adeptus Astartes - Ultramarines" revision="52" battleScribeVersion="2.03" authorName="BSData Developers" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="188" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="28e2-d179-3d66-a272" name="Imperium - Adeptus Astartes - Ultramarines" revision="53" battleScribeVersion="2.03" authorName="BSData Developers" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="189" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="f24f-c59b-5c04-a39a" name="Captain Sicarius" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -430,7 +430,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="8fee-c80e-7303-2960" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0fcb-9eb7-ca96-60f9" name="Master-crafted power sword" hidden="false" collective="false" import="true" targetId="7d93-d63c-bfba-c879" type="selectionEntry">
+            <entryLink id="0fcb-9eb7-ca96-60f9" name="Master-crafted power sword" hidden="false" collective="false" import="true" targetId="2500-aed6-f77e-88f9" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -3508,7 +3508,7 @@
                     <conditionGroup type="and">
                       <conditions>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="equalTo"/>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d93-d63c-bfba-c879" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2500-aed6-f77e-88f9" type="equalTo"/>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc0b-c19f-0b71-081e" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
@@ -3788,8 +3788,8 @@ While a friendly SILVER TEMPLAR PRIMARIS CORE unit is within 6&quot; of the bear
                     <conditionGroup type="and">
                       <conditions>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="equalTo"/>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d93-d63c-bfba-c879" type="equalTo"/>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2500-aed6-f77e-88f9" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c754-9c52-a162-2032" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>

--- a/Imperium - White Scars.cat
+++ b/Imperium - White Scars.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c010-4da2-5a55-a3be" name="Imperium - Adeptus Astartes - White Scars" revision="39" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="187" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c010-4da2-5a55-a3be" name="Imperium - Adeptus Astartes - White Scars" revision="40" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="189" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="38f8-60cb-7a29-7752" name="Khan on Bike" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -2072,7 +2072,7 @@
                     <conditionGroup type="and">
                       <conditions>
                         <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="equalTo"/>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d93-d63c-bfba-c879" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2500-aed6-f77e-88f9" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>

--- a/Warhammer 40,000.gst
+++ b/Warhammer 40,000.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="28ec-711c-d87f-3aeb" name="Warhammer 40,000 9th Edition" revision="189" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WH40k Data Dev" authorUrl="https://www.bsdata.net/contact" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="28ec-711c-d87f-3aeb" name="Warhammer 40,000 9th Edition" revision="190" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@WH40k Data Dev" authorUrl="https://www.bsdata.net/contact" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <readme>This is the game system file for Warhammer 40,000, supporting the 9th edition of the game.  It is required for all other catalogues to function.</readme>
   <publications>
     <publication id="28ec-711c-pubN72690" name="Warhammer 40,000 Core Book" shortName="BRB" publisher="Games Workshop" publicationDate="2020-07-25" publisherUrl="https://www.games-workshop.com/Warhammer-40000-9th-Rulebook-EN-2020"/>
@@ -3187,16 +3187,6 @@
     <selectionEntry id="b993-57b7-93c6-9acb" name="Eviscerator" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="a7ad-af76-1d5f-3d3e" name="Eviscerator" hidden="false" targetId="bb9f-390b-3b92-197c" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7d93-d63c-bfba-c879" name="Master-crafted power sword" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="9296-2312-898c-0d6a" name="Master-crafted power sword" hidden="false" targetId="4242-3014-c49c-9fe6" type="profile"/>
       </infoLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>


### PR DESCRIPTION
Explusiaris is an Exorcists (Imperial Fists successors) that replace a
Power Sword or a Master-Crafted Power Sword. The Indomitus Captain
(Primaris Captain with Master-crafted Sword and Relic Shield) have a
special wargear Selection with nested wargear, and the relic selector
does seem to work on it.

There is in fact multiple definitions of the same sword.

As a fix, this adds all the swords to the relic conditions

Closes: #10046