### PR TITLE
Updated Space Marine Inceptor 40 -> 45pt

### DIFF
--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -7212,7 +7212,7 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="40.0"/>
+                <cost name="pts" typeId="points" value="45.0"/>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
@@ -7241,7 +7241,7 @@
                 <entryLink id="4c15-9562-74dc-86d2" name="Special-Issue Wargear" hidden="false" collective="false" import="true" targetId="81fa-73cf-0cea-37a0" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="40.0"/>
+                <cost name="pts" typeId="points" value="45.0"/>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>


### PR DESCRIPTION
Updated cost of SM Inceptor & Sergeant from 40 to 45.

As per FAQ:
```
*Page 205, Inceptor Squad
Change Unit Cost from ‘40 pts/model’ to ‘45 pts/model’
```
https://www.warhammer-community.com/wp-content/uploads/2019/09/ahfwKGINAYViDr8B.pdf