### PR TITLE
Adjusted Novitiate Superior Power Sword Cost

### DIFF
--- a/Imperium - Adepta Sororitas.cat
+++ b/Imperium - Adepta Sororitas.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d124-b283-2ff7-beae" name="Imperium - Adepta Sororitas" revision="188" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas, @CrusherJoe | Twitter: @_alphalas, @TheAwesomesauce" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="192" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d124-b283-2ff7-beae" name="Imperium - Adepta Sororitas" revision="188" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas, @CrusherJoe | Twitter: @_alphalas, @TheAwesomesauce" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="196" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="d124-b283-pubN72234" name="Codex: Adepta Sororitas 9th Edition"/>
   </publications>
@@ -7078,6 +7078,9 @@ At the end of the Fight phase, if this PRIEST model is in Engagement Range of an
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3e3-7e31-a626-7dff" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e673-5984-0cf0-c3c8" type="min"/>
                       </constraints>
+                      <costs>
+                        <cost name="pts" typeId="points" value="5.0"/>
+                      </costs>
                     </entryLink>
                   </entryLinks>
                   <costs>
@@ -7102,6 +7105,9 @@ At the end of the Fight phase, if this PRIEST model is in Engagement Range of an
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b398-9705-fbf0-68dd" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5b9-4a74-b8f4-e7cb" type="min"/>
                       </constraints>
+                      <costs>
+                        <cost name="pts" typeId="points" value="5.0"/>
+                      </costs>
                     </entryLink>
                   </entryLinks>
                   <costs>


### PR DESCRIPTION
Fix related to: [Imperium - Adepta Sororitas: Sisters Novitiate Superior has Incorrect Points Increase for Weapon Loadout #10655](https://github.com/BSData/wh40k/issues/10655)

Adjusted cost of the Power Sword locally inside of the Novitiate Superior's loadout options.