### PR TITLE
Fix/bs data#10725

### DIFF
--- a/Orks.cat
+++ b/Orks.cat
@@ -16435,7 +16435,15 @@ We recommend placing a Grot Orderly model next to the unit as a reminder, removi
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6336-6a8d-8fd6-54b6" type="max"/>
       </constraints>
       <infoLinks>
-        <infoLink id="6ac1-a3d9-1124-6cc9" name="Extra Kunnin&apos;" hidden="false" targetId="dce6-d65a-e6be-1fbd" type="profile"/>
+        <infoLink id="6ac1-a3d9-1124-6cc9" name="Extra Kunnin&apos;" hidden="false" targetId="dce6-d65a-e6be-1fbd" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae38-f508-d394-4a6d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -16445,6 +16453,13 @@ We recommend placing a Grot Orderly model next to the unit as a reminder, removi
       </costs>
     </selectionEntry>
     <selectionEntry id="4ade-db51-cffa-5a18" name="2. Counta-Taktics (Aura) (Blood Axes)" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae38-f508-d394-4a6d" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1395-7ce1-1a99-54cc" type="max"/>
       </constraints>
@@ -16459,6 +16474,13 @@ We recommend placing a Grot Orderly model next to the unit as a reminder, removi
       </costs>
     </selectionEntry>
     <selectionEntry id="3fad-8d91-a29e-6647" name="3. Duk An&apos; Kuvva (Blood Axes)" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae38-f508-d394-4a6d" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff6f-50fa-e02e-2f73" type="max"/>
       </constraints>
@@ -18021,19 +18043,17 @@ We recommend placing a Grot Orderly model next to the unit as a reminder, removi
         <selectionEntryGroup id="ad08-41dc-8dc7-8ed1" name="Blood Axes" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae38-f508-d394-4a6d" type="equalTo"/>
-                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f018-1dee-fada-f5cc" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae38-f508-d394-4a6d" type="equalTo"/>
+              </conditions>
             </modifier>
           </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="9325-072d-404d-1ade" type="max"/>
+          </constraints>
           <entryLinks>
             <entryLink id="520e-680f-b047-f1c8" name="1. Extra Kunnin&apos; (Blood Axes)" hidden="false" collective="false" import="true" targetId="9467-343a-f808-1329" type="selectionEntry"/>
-            <entryLink id="cb6e-9099-3046-9b33" name="2. Counta-Taktics (Aura)" hidden="false" collective="false" import="true" targetId="4ade-db51-cffa-5a18" type="selectionEntry"/>
+            <entryLink id="cb6e-9099-3046-9b33" name="2. Counta-Taktics (Aura) (Blood Axes)" hidden="false" collective="false" import="true" targetId="4ade-db51-cffa-5a18" type="selectionEntry"/>
             <entryLink id="7b6e-fde7-3806-d7f0" name="3. Duk An&apos; Kuvva (Blood Axes)" hidden="false" collective="false" import="true" targetId="3fad-8d91-a29e-6647" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>

--- a/Orks.cat
+++ b/Orks.cat
@@ -16431,19 +16431,18 @@ We recommend placing a Grot Orderly model next to the unit as a reminder, removi
       </costs>
     </selectionEntry>
     <selectionEntry id="9467-343a-f808-1329" name="1. Extra Kunnin&apos; (Blood Axes)" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ae38-f508-d394-4a6d" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6336-6a8d-8fd6-54b6" type="max"/>
       </constraints>
       <infoLinks>
-        <infoLink id="6ac1-a3d9-1124-6cc9" name="Extra Kunnin&apos;" hidden="false" targetId="dce6-d65a-e6be-1fbd" type="profile">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae38-f508-d394-4a6d" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
+        <infoLink id="6ac1-a3d9-1124-6cc9" name="Extra Kunnin&apos;" hidden="false" targetId="dce6-d65a-e6be-1fbd" type="profile"/>
       </infoLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -16456,7 +16455,7 @@ We recommend placing a Grot Orderly model next to the unit as a reminder, removi
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae38-f508-d394-4a6d" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ae38-f508-d394-4a6d" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -16477,7 +16476,7 @@ We recommend placing a Grot Orderly model next to the unit as a reminder, removi
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae38-f508-d394-4a6d" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ae38-f508-d394-4a6d" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>

--- a/Orks.cat
+++ b/Orks.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3bba-af85-a93c-6bdf" name="Orks" revision="35" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Tag8833 @Techno" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="200" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3bba-af85-a93c-6bdf" name="Orks" revision="36" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Tag8833 @Techno" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="200" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="11b5-77b9-pubN65537" name="Codex: Orks 2021"/>
     <publication id="b556-84c7-4532-bca5" name="Da Red Gobbbo on Bounca" publisher="Da Red Gobbbo on Bounca Boxset" publicationDate="2021-11-13"/>
@@ -1992,10 +1992,10 @@ Stage 2: Give &apos;Em Sum Dakka!
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="69e8-cb09-0ad3-5a61" name="Stratagem: Big Boss" hidden="false" collective="false" import="true" targetId="8320-3249-8d3a-e584" type="selectionEntry"/>
         <entryLink id="1587-4eee-ccde-1a06" name="Stratagem: Extra Gubbinz" hidden="false" collective="false" import="true" targetId="4491-c764-8c2e-d3d1" type="selectionEntry"/>
         <entryLink id="13e5-fb9e-26dc-89ad" name="Specialist Mobs" hidden="false" collective="false" import="true" targetId="c99c-6f81-ada0-9caa" type="selectionEntryGroup"/>
         <entryLink id="1558-308f-c26c-f06d" name="Mek Kustom Jobs" hidden="false" collective="false" import="true" targetId="102f-8b52-7d57-fe29" type="selectionEntryGroup"/>
+        <entryLink id="3eaf-b65e-7d5a-2789" name="Stratagem: Big Boss" hidden="false" collective="false" import="true" targetId="8320-3249-8d3a-e584" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="55.0"/>
@@ -2350,7 +2350,7 @@ We recommend placing a Grot Oiler model next to the unit as a reminder, removing
         <entryLink id="a910-f814-5210-388e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
         <entryLink id="7de7-b272-0d8c-b860" name="Warlord" hidden="false" collective="false" import="true" targetId="66cb-c463-e3ee-7e1d" type="selectionEntry"/>
         <entryLink id="ea72-2388-9ce3-b27f" name="Relic Gubbinz" hidden="false" collective="false" import="true" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
-        <entryLink id="825c-f952-db78-8945" name="Is a Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
+        <entryLink id="825c-f952-db78-8945" name="Is a Custom Character (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
         <entryLink id="0c8e-91e5-d3f9-4bf6" name="Custom Character Selections (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
         <entryLink id="e7f7-e498-bc2d-f908" name="Stratagem: Field Commander" hidden="false" collective="false" import="true" targetId="d043-3847-e963-fb5d" type="selectionEntry">
           <modifiers>
@@ -2363,6 +2363,8 @@ We recommend placing a Grot Oiler model next to the unit as a reminder, removing
         </entryLink>
         <entryLink id="5643-5cf8-cd4c-868d" name="Specialist Mobs" hidden="false" collective="false" import="true" targetId="c99c-6f81-ada0-9caa" type="selectionEntryGroup"/>
         <entryLink id="9edf-964d-aefd-5657" name="Mek Kustom Jobs" hidden="false" collective="false" import="true" targetId="102f-8b52-7d57-fe29" type="selectionEntryGroup"/>
+        <entryLink id="7545-bea4-2274-9a3c" name="Stratagem: Big Boss" hidden="false" collective="false" import="true" targetId="8320-3249-8d3a-e584" type="selectionEntry"/>
+        <entryLink id="c570-a1f3-bb9f-4606" name="Stratagem: Extra Gubbinz" hidden="false" collective="false" import="true" targetId="4491-c764-8c2e-d3d1" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="81.0"/>
@@ -2737,6 +2739,8 @@ We recommend placing a Grot Oiler model next to the unit as a reminder, removing
         <entryLink id="ff73-6d77-700b-84ad" name="Relic Gubbinz" hidden="false" collective="false" import="true" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
         <entryLink id="cda0-6dc2-0893-93e6" name="Is a Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
         <entryLink id="71a6-e1a6-0b3a-17b9" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="e2a0-6b3c-3564-df64" name="Stratagem: Big Boss" hidden="false" collective="false" import="true" targetId="8320-3249-8d3a-e584" type="selectionEntry"/>
+        <entryLink id="88d3-25f7-4d7e-029d" name="Stratagem: Extra Gubbinz" hidden="false" collective="false" import="true" targetId="4491-c764-8c2e-d3d1" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="90.0"/>
@@ -8040,6 +8044,8 @@ We recommend placing a Grot Oiler model next to the unit as a reminder, removing
             </modifier>
           </modifiers>
         </entryLink>
+        <entryLink id="207b-0cef-19c1-dfed" name="Stratagem: Big Boss" hidden="false" collective="false" import="true" targetId="8320-3249-8d3a-e584" type="selectionEntry"/>
+        <entryLink id="2cc6-8d8e-ef23-22e5" name="Stratagem: Extra Gubbinz" hidden="false" collective="false" import="true" targetId="4491-c764-8c2e-d3d1" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
@@ -8158,6 +8164,8 @@ We recommend placing two Grot Oiler models next to this Mek Boss Buzzgob model a
             </modifier>
           </modifiers>
         </entryLink>
+        <entryLink id="6d1d-f51b-0f86-ae76" name="Stratagem: Big Boss" hidden="false" collective="false" import="true" targetId="8320-3249-8d3a-e584" type="selectionEntry"/>
+        <entryLink id="0377-6730-9c62-622a" name="Stratagem: Extra Gubbinz" hidden="false" collective="false" import="true" targetId="4491-c764-8c2e-d3d1" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
@@ -13572,6 +13580,7 @@ We recommend placing two Grot Oiler models next to this Mek Boss Buzzgob model a
         <entryLink id="22ed-7950-bf46-259f" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
         <entryLink id="7d11-b5cb-504b-f939" name="Warlord" hidden="false" collective="false" import="true" targetId="66cb-c463-e3ee-7e1d" type="selectionEntry"/>
         <entryLink id="68f6-a238-397e-2dfa" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="4be7-f0b8-bfd8-709f" name="Stratagem: Big Boss" hidden="false" collective="false" import="true" targetId="8320-3249-8d3a-e584" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="1.0"/>


### PR DESCRIPTION
Fix for issue:  [Orks: Warzone Octarius Book 2 Blood Axes Warlord Traits Should Not Require Warlord #10725](https://github.com/BSData/wh40k/issues/10725).

Adjusted to allow only one selection max, making the buttons become radio buttons as per the rest of the Catalog.
Removed the Blood Axe Warlord requirement from the selection group hide modifier group.