### PR TITLE
Add War Hymn selection to Adepta Sororitas Preacher

### DIFF
--- a/Imperium - Adepta Sororitas.cat
+++ b/Imperium - Adepta Sororitas.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d124-b283-2ff7-beae" name="Imperium - Adepta Sororitas" revision="187" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas, @CrusherJoe | Twitter: @_alphalas, @TheAwesomesauce" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="200" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d124-b283-2ff7-beae" name="Imperium - Adepta Sororitas" revision="188" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas, @CrusherJoe | Twitter: @_alphalas, @TheAwesomesauce" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="202" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="d124-b283-pubN72234" name="Codex: Adepta Sororitas 9th Edition"/>
   </publications>
@@ -3974,89 +3974,6 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4d42-7da1-32e1-5ccd" name="Hymns of Battle (Cult Imperialis)" publicationId="d124-b283-pubN72234" page="73" hidden="false" collective="false" import="true">
-          <modifiers>
-            <modifier type="decrement" field="dd9d-8a4d-88a2-e861" value="1.0"/>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18c-1b23-b83b-26c8" type="lessThan"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <modifierGroups>
-            <modifierGroup>
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18c-1b23-b83b-26c8" type="greaterThan"/>
-              </conditions>
-              <modifiers>
-                <modifier type="increment" field="dd9d-8a4d-88a2-e861" value="1.0"/>
-                <modifier type="increment" field="3dff-7001-29cd-b335" value="1.0"/>
-              </modifiers>
-            </modifierGroup>
-          </modifierGroups>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd9d-8a4d-88a2-e861" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dff-7001-29cd-b335" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="04a4-3bf1-d276-d4bd" name="1. Refrain of Blazing Piety" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c46-74cd-03a7-9930" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="d2c2-cd6b-a7ee-a1a1" name="1. Refrain of Blazing Piety" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-                  <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this hymn is inspiring, select one enemy unit that is within 12&quot; of and visible to this PRIEST model. That unit D3 mortal wounds (if that unit has the CHAOS keyword, it instead suffers 3 mortal wounds).</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3126-fa5d-b555-6b5a" name="2. Chorus of Spiritual Fortitude" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d46-19aa-44a8-1a18" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="febb-731b-42a2-29a3" name="2. Chorus of Spiritual Fortitude" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-                  <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this hymn is inspiring, select one friendly ADEPTUS MINISTORUM CORE, ADEPTUS MINISTORUM CHARACTER or ENGINE OF REDEMPTION unit within 6&quot; of this PRIEST model.
-If that unit or its models are being affected by any psychic powers manifested by enemy models, the effects of those psychic powers on that unit and its models end.
-Until the start of your next Command phase, that unit and the models it contains are not affected by any psychic power manifested by enemy units.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7b15-6f75-1d07-91f6" name="3. Psalm of Righteous Smiting" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e44a-8164-ea0d-2ca1" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="ca48-64ad-8810-ac00" name="3. Psalm of Righteous Smiting" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-                  <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this hymn is inspiring:
-Add 1 to this PRIEST model&apos;s Strength and Attacks characteristics
-Improve the Armour penetration characteristic of melee weapons this PRIEST mode is equipped with by 1 (excluding Relics).
-At the end of the Fight phase, if this PRIEST model is in Engagement Range of any enemy units, it can fight one additional time.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="1295-b868-9b4c-8641" name="Relics of the Ecclesiarchy" hidden="false" collective="false" import="true" targetId="1bb7-4aaf-cc19-abe1" type="selectionEntryGroup"/>
@@ -4069,6 +3986,7 @@ At the end of the Fight phase, if this PRIEST model is in Engagement Range of an
         <entryLink id="14bc-83a7-e387-f0cf" name="Custom Character Selections (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
         <entryLink id="bd89-1960-411a-6a54" name="Stratagem: Saint in the Making" hidden="false" collective="false" import="true" targetId="c3c4-b7c8-f63a-f43e" type="selectionEntry"/>
         <entryLink id="91a8-7f9e-8738-e817" name="Warlord Traits (Cult Imperialis)" hidden="false" collective="false" import="true" targetId="eef1-f4d8-6d87-99c7" type="selectionEntryGroup"/>
+        <entryLink id="a42f-4002-9685-b7d5" name="Hymns of Battle (Cult Imperialis)" hidden="false" collective="false" import="true" targetId="c42a-05c6-6788-016f" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>


### PR DESCRIPTION
Adepta Sororitas Preachers need a selection of War Hymns, too. For some reason (as opposed to the Missionary), the preacher did not have a link to the shared entry, but a custom entry that was set to hidden. This PR changes that. Locally tested.