### PR TITLE
Fix selection types for several units - Adepta Sororitas

### DIFF
--- a/Imperium - Adepta Sororitas.cat
+++ b/Imperium - Adepta Sororitas.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d124-b283-2ff7-beae" name="Imperium - Adepta Sororitas" revision="206" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas, @CrusherJoe | Twitter: @_alphalas, @TheAwesomesauce" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="221" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d124-b283-2ff7-beae" name="Imperium - Adepta Sororitas" revision="207" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas, @CrusherJoe | Twitter: @_alphalas, @TheAwesomesauce" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <readme>Wow, we didn&apos;t get screwed this time. I&apos;m shocked.
 </readme>
   <publications>
@@ -1129,7 +1129,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2c1c-4fcd-f444-497f" name="Exorcist" page="" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="2c1c-4fcd-f444-497f" name="Exorcist" page="" hidden="false" collective="false" import="true" type="model">
       <infoLinks>
         <infoLink id="7ea1-eaea-445a-2211" name="Shield of Faith" hidden="false" targetId="58e0-6802-a36d-babe" type="rule"/>
         <infoLink id="cef6-66de-d6af-19f0" name="Acts of Faith" hidden="false" targetId="6d3f2230-86ac-8ae9-caaf-086dc960e681" type="rule"/>
@@ -1638,7 +1638,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="33d2-af62-73dc-e166" name="Missionary" page="" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="33d2-af62-73dc-e166" name="Missionary" page="" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="8a58-c8c3-9580-59c0" value="0.0">
           <conditions>
@@ -2311,7 +2311,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e9f1-555d-a13e-1c46" name="Immolator" page="" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="e9f1-555d-a13e-1c46" name="Immolator" page="" hidden="false" collective="false" import="true" type="model">
       <infoLinks>
         <infoLink id="ee40-c33f-0aa0-7aae" name="Shield of Faith" hidden="false" targetId="58e0-6802-a36d-babe" type="rule"/>
         <infoLink id="3ad9-8d4c-9595-f5a8" name="Acts of Faith" hidden="false" targetId="6d3f2230-86ac-8ae9-caaf-086dc960e681" type="rule"/>
@@ -2401,7 +2401,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="caaf-8409-e170-3286" name="Celestine and Geminae Superia" publicationId="d124-b283-pubN72234" page="98" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="caaf-8409-e170-3286" name="Celestine and Geminae Superia" publicationId="d124-b283-pubN72234" page="98" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="ae33-681f-e4b9-413d" type="max"/>
       </constraints>
@@ -2830,7 +2830,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9be6-1599-e087-859f" name="Sororitas Rhino" page="" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="9be6-1599-e087-859f" name="Sororitas Rhino" page="" hidden="false" collective="false" import="true" type="model">
       <infoLinks>
         <infoLink id="c748-a8e8-aa0f-49ed" name="Shield of Faith" hidden="false" targetId="58e0-6802-a36d-babe" type="rule"/>
         <infoLink id="9dd7-7e78-b935-4782" name="Acts of Faith" hidden="false" targetId="6d3f2230-86ac-8ae9-caaf-086dc960e681" type="rule"/>
@@ -3774,7 +3774,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f97b-ff32-9d2a-2e94" name="Preacher" publicationId="d124-b283-pubN72234" page="83" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="f97b-ff32-9d2a-2e94" name="Preacher" publicationId="d124-b283-pubN72234" page="83" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="c46c-8388-1284-fb92" name="Priest" publicationId="d124-b283-pubN72234" page="97,103,107" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -5316,7 +5316,7 @@ At the end of the Fight phase, if this PRIEST model is in Engagement Range of an
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4e8a-f723-76eb-14dc" name="Arch-Confessor Kyrinov [Legends]" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="4e8a-f723-76eb-14dc" name="Arch-Confessor Kyrinov [Legends]" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="0b93-53c5-efeb-3c8e" name="Arch-Confessor Kyrinov" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -5482,7 +5482,7 @@ At the end of the Fight phase, if this PRIEST model is in Engagement Range of an
         <cost name="pts" typeId="points" value="45.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="cd9c-e25f-1d3a-88f7" name="Morvenn Vahl" publicationId="d124-b283-pubN72234" page="93" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="cd9c-e25f-1d3a-88f7" name="Morvenn Vahl" publicationId="d124-b283-pubN72234" page="93" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set-primary" field="category" value="26b0-4bb9-73aa-d3d7">
           <conditions>
@@ -6447,7 +6447,7 @@ At the end of the Fight phase, if this PRIEST model is in Engagement Range of an
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2f21-55f2-c323-73a7" name="Dogmata" publicationId="d124-b283-pubN72234" page="107" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="2f21-55f2-c323-73a7" name="Dogmata" publicationId="d124-b283-pubN72234" page="107" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="8425-6db6-8b79-0774" name="Dogmata" publicationId="d124-b283-pubN72234" page="107" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -6557,7 +6557,7 @@ At the end of the Fight phase, if this PRIEST model is in Engagement Range of an
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7be4-0b79-7cd1-e99e" name="Castigator" publicationId="d124-b283-pubN72234" page="117" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="7be4-0b79-7cd1-e99e" name="Castigator" publicationId="d124-b283-pubN72234" page="117" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="5385-1c39-dad7-f65c" name="Castigator [1] (6+ wounds remaining)" publicationId="d124-b283-pubN72234" page="117" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -7091,7 +7091,7 @@ At the end of the Fight phase, if this PRIEST model is in Engagement Range of an
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3be4-7c14-8360-eec6" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8b81-3e38-35bb-ef7c" name="Sister Novitiate w/ Sacred Banner" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="8b81-3e38-35bb-ef7c" name="Sister Novitiate w/ Sacred Banner" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56f7-9a8b-d420-2f90" type="max"/>
               </constraints>
@@ -7119,7 +7119,7 @@ At the end of the Fight phase, if this PRIEST model is in Engagement Range of an
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="128c-11a7-092e-87bd" name="Sister Novitiate w/ Simulacrum Imperialis" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="128c-11a7-092e-87bd" name="Sister Novitiate w/ Simulacrum Imperialis" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bb5-3a05-9830-d5ea" type="max"/>
               </constraints>
@@ -7147,7 +7147,7 @@ At the end of the Fight phase, if this PRIEST model is in Engagement Range of an
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="1777-43a6-a182-0002" name="Sister Novitiate w/ Ministorum Flamer" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="1777-43a6-a182-0002" name="Sister Novitiate w/ Ministorum Flamer" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e1e-3eae-fcd9-6d73" type="max"/>
               </constraints>
@@ -7197,7 +7197,7 @@ At the end of the Fight phase, if this PRIEST model is in Engagement Range of an
         <cost name="pts" typeId="points" value="75.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4753-39f3-9e7d-71c3" name="Sister Novitiate (Autogun)" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="4753-39f3-9e7d-71c3" name="Sister Novitiate (Autogun)" hidden="false" collective="false" import="true" type="model">
       <infoLinks>
         <infoLink id="a210-f55b-08c3-879a" name="Sister Novitiate" hidden="false" targetId="6333-f693-882c-ccb5" type="profile"/>
       </infoLinks>
@@ -7227,7 +7227,7 @@ At the end of the Fight phase, if this PRIEST model is in Engagement Range of an
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a754-8d27-9911-fdfe" name="Sister Novitiate (Melee Weapon)" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="a754-8d27-9911-fdfe" name="Sister Novitiate (Melee Weapon)" hidden="false" collective="false" import="true" type="model">
       <infoLinks>
         <infoLink id="7a50-74e4-2733-f9b7" name="Sister Novitiate" hidden="false" targetId="6333-f693-882c-ccb5" type="profile"/>
       </infoLinks>


### PR DESCRIPTION
Due to https://github.com/BSData/wh40k/issues/11182, the model/unit flag is not sometimes set properly. This PR fixes this for the Adepta Sororitas catalog.