### PR TITLE
Fix selection types for several units - Space Marines

### DIFF
--- a/Imperium - Black Templars.cat
+++ b/Imperium - Black Templars.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9419-6862-0e60-6eb3" name="Imperium - Adeptus Astartes - Black Templars" revision="16" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="221" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9419-6862-0e60-6eb3" name="Imperium - Adeptus Astartes - Black Templars" revision="17" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
-    <selectionEntry id="03ac-4576-88d8-3b67" name="Crusader Squad" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="03ac-4576-88d8-3b67" name="Crusader Squad" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="5.0">
           <conditions>
@@ -2980,7 +2980,7 @@ Passion:
     <infoLink id="77a2-f658-3e66-ab7e" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
   </infoLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="a0f4-2476-e5ce-e0cb" name="Cenobyte Servitors" hidden="true" collective="false" import="true" type="upgrade">
+    <selectionEntry id="a0f4-2476-e5ce-e0cb" name="Cenobyte Servitors" hidden="true" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="fb04-09fa-9338-64f0" type="max"/>
       </constraints>
@@ -3018,7 +3018,7 @@ Passion:
         <categoryLink id="559e-78fe-5b1d-69a3" name="New CategoryLink" hidden="false" targetId="0262-aa2e-a67e-6774" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="5944-7c03-6013-a92b" name="Cenobyte Servitor" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="5944-7c03-6013-a92b" name="Cenobyte Servitor" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="337d-c186-ca90-b4eb" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e16-b5d2-d5fd-4a37" type="max"/>

--- a/Imperium - FW Adeptus Astartes.cat
+++ b/Imperium - FW Adeptus Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="dab7-e076-dd5e-d8aa" name="Imperium - FW Adeptus Astartes" revision="103" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="221" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="dab7-e076-dd5e-d8aa" name="Imperium - FW Adeptus Astartes" revision="104" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="dab7-e076-pubN133616" name="Codex: Space Wolves"/>
     <publication id="dab7-e076-pubN151451" name="Astraeus Super-heavy Tank PDF"/>
@@ -9204,7 +9204,7 @@ This model also has a transport capacity of two &lt;CHAPTER&gt; VEHICLE models f
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0e71-00d8-d660-6255" name="Gabriel Angelos" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="0e71-00d8-d660-6255" name="Gabriel Angelos" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>

--- a/Imperium - Imperial Fists.cat
+++ b/Imperium - Imperial Fists.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0b92-701a-704e-2d9f" name="Imperium - Adeptus Astartes - Imperial Fists" revision="53" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur " authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="221" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0b92-701a-704e-2d9f" name="Imperium - Adeptus Astartes - Imperial Fists" revision="54" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur " authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
-    <selectionEntry id="94ea-2b86-14a0-402f" name="Captain Lysander" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="94ea-2b86-14a0-402f" name="Captain Lysander" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -136,7 +136,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2119-b883-7c60-5e46" name="Pedro Kantor" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="2119-b883-7c60-5e46" name="Pedro Kantor" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -278,7 +278,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3f9f-1d3f-5029-6a34" name="Tor Garadon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="3f9f-1d3f-5029-6a34" name="Tor Garadon" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>

--- a/Imperium - Salamanders.cat
+++ b/Imperium - Salamanders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="4501-8439-ec2c-efad" name="Imperium - Adeptus Astartes - Salamanders" revision="51" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="221" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="4501-8439-ec2c-efad" name="Imperium - Adeptus Astartes - Salamanders" revision="52" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="264d-cbed-e233-21d1" name="Adrax Agatone" hidden="false" collective="false" import="true" type="model">
       <modifiers>
@@ -161,7 +161,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6dd6-e606-b377-f261" name="Vulkan He&apos;stan" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="6dd6-e606-b377-f261" name="Vulkan He&apos;stan" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>

--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="846d-3c14-21fc-369f" name="Imperium - Space Marines" revision="290" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="221" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="846d-3c14-21fc-369f" name="Imperium - Space Marines" revision="291" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="846d-3c14-pubN65537" name="Index: Imperium 1 &amp; Codex: Space Marines"/>
   </publications>
@@ -2306,7 +2306,7 @@ This ability cannot be used with a Relic which replaces any of these weapons. </
         <categoryLink id="5227-4024-7f05-30a1" name="New CategoryLink" hidden="false" targetId="0262-aa2e-a67e-6774" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="be8c-72cb-5c46-bda0" name="Servitor" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="be8c-72cb-5c46-bda0" name="Servitor" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1df-5b9b-2d43-0f9a" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f80c-c168-fd44-d9f8" type="max"/>
@@ -4145,7 +4145,7 @@ This ability cannot be used with a Relic which replaces any of these weapons. </
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="f983-8547-26b5-5cdf" name="Space Wolf Scout" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="f983-8547-26b5-5cdf" name="Space Wolf Scout" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -4235,7 +4235,7 @@ This ability cannot be used with a Relic which replaces any of these weapons. </
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e8bb-2101-9809-b101" name="Scout w/Special weapon" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="e8bb-2101-9809-b101" name="Scout w/Special weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -7543,7 +7543,7 @@ This ability cannot be used with a Relic which replaces any of these weapons. </
             <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa29-cc49-528e-6f0b" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="bbef-d379-453d-dce0" name="Space Marine Biker w/Bolt Pistol" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="bbef-d379-453d-dce0" name="Space Marine Biker w/Bolt Pistol" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="set" field="a405-8d8f-5c4f-fa95" value="14.0">
                   <conditions>
@@ -7580,7 +7580,7 @@ This ability cannot be used with a Relic which replaces any of these weapons. </
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="ee66-0b18-b836-a882" name="Biker Sergeant" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="ee66-0b18-b836-a882" name="Biker Sergeant" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e49-b34b-5b0b-6994" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2cd-99f0-2b39-6370" type="max"/>
@@ -7642,7 +7642,7 @@ This ability cannot be used with a Relic which replaces any of these weapons. </
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="aff8-2540-01ce-ffb9" name="Space Marine Biker w/Special Weapon" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="aff8-2540-01ce-ffb9" name="Space Marine Biker w/Special Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="decrement" field="2ae0-ac48-40de-aab2" value="1.0">
                   <repeats>
@@ -7679,7 +7679,7 @@ This ability cannot be used with a Relic which replaces any of these weapons. </
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6db2-81d9-a49f-9868" name="Space Marine Biker w/Chainsword" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="6db2-81d9-a49f-9868" name="Space Marine Biker w/Chainsword" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="set" field="f849-bffe-cb68-58c3" value="14.0">
                   <conditions>
@@ -7716,7 +7716,7 @@ This ability cannot be used with a Relic which replaces any of these weapons. </
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3312-e399-4595-d34e" name="Space Marine Biker w/Plasma Pistol" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="3312-e399-4595-d34e" name="Space Marine Biker w/Plasma Pistol" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="decrement" field="b0e3-7511-acb9-0da9" value="1.0">
                   <repeats>
@@ -9084,7 +9084,7 @@ This ability cannot be used with a Relic which replaces any of these weapons. </
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="de6d-c0fc-c631-db83" name="Thunderfire Cannon" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="de6d-c0fc-c631-db83" name="Thunderfire Cannon" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -9144,7 +9144,7 @@ This ability cannot be used with a Relic which replaces any of these weapons. </
         <categoryLink id="76a5-756a-5548-9196" name="New CategoryLink" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="f1a3-48e8-0804-fb8e" name="Thunderfire Cannon" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="f1a3-48e8-0804-fb8e" name="Thunderfire Cannon" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08e7-4a94-bacd-54cf" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0007-2932-02aa-1e2b" type="max"/>
@@ -9172,7 +9172,7 @@ This ability cannot be used with a Relic which replaces any of these weapons. </
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="9906-614c-b10b-808a" name="Techmarine Gunner" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="9906-614c-b10b-808a" name="Techmarine Gunner" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="f3e9-8c28-270f-e50f" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7d3c-5969-1d9c-4e91" type="max"/>
@@ -16505,7 +16505,7 @@ Weapon: Purgatorus</characteristic>
                 <cost name="pts" typeId="points" value="45.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3f7e-7192-ab1d-9841" name="Eradicator with MM" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="3f7e-7192-ab1d-9841" name="Eradicator with MM" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="c8a0-f6a6-c24e-ff44" value="1.0">
                   <conditions>
@@ -17222,7 +17222,7 @@ Weapon: Purgatorus</characteristic>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f765-9572-4e80-f512" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="e17f-49df-2be8-3e65" name="Assault Intercessor" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="e17f-49df-2be8-3e65" name="Assault Intercessor" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7d7-8c0f-f1f3-dbbd" type="max"/>
               </constraints>
@@ -17267,7 +17267,7 @@ Weapon: Purgatorus</characteristic>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8d8e-ccc5-4f05-1e53" name="Assault Intercessor Sgt" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="8d8e-ccc5-4f05-1e53" name="Assault Intercessor Sgt" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32d7-2d19-3402-131b" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed1d-f599-8b02-8581" type="max"/>
@@ -18618,7 +18618,7 @@ Weapon: Purgatorus</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="539f-002b-82d7-378f" name="Primaris Techmarine" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="539f-002b-82d7-378f" name="Primaris Techmarine" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -19736,7 +19736,7 @@ Weapon: Purgatorus</characteristic>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d96d-9a72-9f05-aa1d" name="Gladiator Lancer" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="d96d-9a72-9f05-aa1d" name="Gladiator Lancer" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -19940,7 +19940,7 @@ Weapon: Purgatorus</characteristic>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="de9a-7ea4-0cfe-87ad" name="Gladiator Reaper" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="de9a-7ea4-0cfe-87ad" name="Gladiator Reaper" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -20078,7 +20078,7 @@ Weapon: Purgatorus</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5828-59fa-8fe8-03ae" name="Gladiator Valiant " hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="5828-59fa-8fe8-03ae" name="Gladiator Valiant " hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -21030,7 +21030,7 @@ Weapon: Purgatorus</characteristic>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9818-6bac-3e50-e194" name="Primaris Company Champion [Legends]" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="9818-6bac-3e50-e194" name="Primaris Company Champion [Legends]" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="add" field="category" value="b95f-a56d-1ae5-7b66">
           <conditions>
@@ -21101,7 +21101,7 @@ Weapon: Purgatorus</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e471-65c2-f777-5781" name="Kratos" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="e471-65c2-f777-5781" name="Kratos" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>

--- a/Imperium - Ultramarines.cat
+++ b/Imperium - Ultramarines.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="28e2-d179-3d66-a272" name="Imperium - Adeptus Astartes - Ultramarines" revision="63" battleScribeVersion="2.03" authorName="BSData Developers" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="221" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="28e2-d179-3d66-a272" name="Imperium - Adeptus Astartes - Ultramarines" revision="64" battleScribeVersion="2.03" authorName="BSData Developers" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
-    <selectionEntry id="f24f-c59b-5c04-a39a" name="Captain Sicarius" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="f24f-c59b-5c04-a39a" name="Captain Sicarius" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -164,7 +164,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e0c0-cc1b-45b7-3ca6" name="Chaplain Cassius" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="e0c0-cc1b-45b7-3ca6" name="Chaplain Cassius" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -319,7 +319,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4fbe-0fc1-3ec0-4c27" name="Chapter Ancient" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="4fbe-0fc1-3ec0-4c27" name="Chapter Ancient" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -421,7 +421,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="51c0-ec9e-b822-8e74" name="Chapter Champion" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="51c0-ec9e-b822-8e74" name="Chapter Champion" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -549,7 +549,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="26b5-2363-4ae0-282e" name="Chief Librarian Tigurius" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="26b5-2363-4ae0-282e" name="Chief Librarian Tigurius" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -717,7 +717,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d775-f28b-790e-3319" name="Chief Librarian Tigurius [Legends]" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="d775-f28b-790e-3319" name="Chief Librarian Tigurius [Legends]" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -1297,7 +1297,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1d94-fbe2-0706-0a16" name="Sergeant Chronus" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="1d94-fbe2-0706-0a16" name="Sergeant Chronus" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -1430,7 +1430,7 @@ if a VEHICLE model  being commanded by Sergeant Chornus is destroyed, set this m
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5d4e-81f1-caf9-1c7f" name="Sergeant Telion" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="5d4e-81f1-caf9-1c7f" name="Sergeant Telion" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -1562,7 +1562,7 @@ if a VEHICLE model  being commanded by Sergeant Chornus is destroyed, set this m
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="86ca-025e-aee9-7f65" name="Tyrannic War Veterans" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="86ca-025e-aee9-7f65" name="Tyrannic War Veterans" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="5.0">
           <conditions>
@@ -1775,7 +1775,7 @@ if a VEHICLE model  being commanded by Sergeant Chornus is destroyed, set this m
         <categoryLink id="fc36-a66c-20aa-f528" name="Core" hidden="false" targetId="08f1-d244-eb44-7e01" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="907c-8e95-73da-bc41" name="Victrix Honour Guard" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="907c-8e95-73da-bc41" name="Victrix Honour Guard" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7973-b1c4-d025-41cd" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59f3-a249-b33f-78cd" type="max"/>
@@ -1834,7 +1834,7 @@ if a VEHICLE model  being commanded by Sergeant Chornus is destroyed, set this m
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c886-ae30-c6b0-3a36" name="Roboute Guilliman" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="c886-ae30-c6b0-3a36" name="Roboute Guilliman" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -2054,7 +2054,7 @@ if a VEHICLE model  being commanded by Sergeant Chornus is destroyed, set this m
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c88d-09ac-bd54-1fc7" name="Uriel Ventris" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="c88d-09ac-bd54-1fc7" name="Uriel Ventris" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -2221,7 +2221,7 @@ if a VEHICLE model  being commanded by Sergeant Chornus is destroyed, set this m
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="79cd-c8c4-23cf-118d" name="Captain Nasiem" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="79cd-c8c4-23cf-118d" name="Captain Nasiem" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -2341,7 +2341,7 @@ if a VEHICLE model  being commanded by Sergeant Chornus is destroyed, set this m
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="41b6-b617-a122-5292" name="Epistolary Lykandos" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="41b6-b617-a122-5292" name="Epistolary Lykandos" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -2472,7 +2472,7 @@ if a VEHICLE model  being commanded by Sergeant Chornus is destroyed, set this m
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9a04-1f70-d99f-39c0" name="Orator Sephax" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="9a04-1f70-d99f-39c0" name="Orator Sephax" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -2576,7 +2576,7 @@ if a VEHICLE model  being commanded by Sergeant Chornus is destroyed, set this m
         <cost name="pts" typeId="points" value="90.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="edd3-7cfc-5669-8a51" name="Ancient Kae" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="edd3-7cfc-5669-8a51" name="Ancient Kae" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>

--- a/Imperium - White Scars.cat
+++ b/Imperium - White Scars.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c010-4da2-5a55-a3be" name="Imperium - Adeptus Astartes - White Scars" revision="47" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="221" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c010-4da2-5a55-a3be" name="Imperium - Adeptus Astartes - White Scars" revision="48" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Acebaur" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
-    <selectionEntry id="38f8-60cb-7a29-7752" name="Khan on Bike" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="38f8-60cb-7a29-7752" name="Khan on Bike" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -88,7 +88,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="cf7c-2f40-c736-021a" name="Kor&apos;sarro Khan" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="cf7c-2f40-c736-021a" name="Kor&apos;sarro Khan" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -240,7 +240,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b9c6-4c9f-9b89-0ea4" name="Kor&apos;sarro Khan [Legends]" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="b9c6-4c9f-9b89-0ea4" name="Kor&apos;sarro Khan [Legends]" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -386,7 +386,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fdb5-313d-f40b-ab1e" name="Kor&apos;sarro Khan on Moondrakkan [Legends]" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="fdb5-313d-f40b-ab1e" name="Kor&apos;sarro Khan on Moondrakkan [Legends]" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>


### PR DESCRIPTION
Due to https://github.com/BSData/wh40k/issues/11182, the model/unit flag is not sometimes set properly. This PR fixes this for the Space Marines catalog.