### PR TITLE
Fix selection types for several units - Space Wolves

### DIFF
--- a/Imperium - Space Wolves.cat
+++ b/Imperium - Space Wolves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="24b6-2b46-0063-2867" name="Imperium - Adeptus Astartes - Space Wolves" revision="220" battleScribeVersion="2.03" authorName="CrusherJoe, Mad-Spy" authorContact="@CrusherJoe, @Mad-Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="221" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="24b6-2b46-0063-2867" name="Imperium - Adeptus Astartes - Space Wolves" revision="221" battleScribeVersion="2.03" authorName="CrusherJoe, Mad-Spy" authorContact="@CrusherJoe, @Mad-Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="24b6-2b46-pubN65537" name="Codex: Space Wolves"/>
   </publications>
@@ -6730,7 +6730,7 @@ Litany of Hate:If this litany is inspiring, you can re-roll hit rolls for attack
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b6a6-c571-f3ca-0ff7" name="Stormwolf" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="b6a6-c571-f3ca-0ff7" name="Stormwolf" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>


### PR DESCRIPTION
Due to https://github.com/BSData/wh40k/issues/11182, the model/unit flag is not sometimes set properly. This PR fixes this for the Space Wolves catalog.