### PR TITLE
Fix selection types for several units - Dark Angels

### DIFF
--- a/Imperium - Dark Angels.cat
+++ b/Imperium - Dark Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b8fe-8d38-37ec-90e8" name="Imperium - Adeptus Astartes - Dark Angels" revision="247" battleScribeVersion="2.03" authorName="BSData Developers" authorContact=" @FarseerVeraenthis" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="221" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="b8fe-8d38-37ec-90e8" name="Imperium - Adeptus Astartes - Dark Angels" revision="248" battleScribeVersion="2.03" authorName="BSData Developers" authorContact=" @FarseerVeraenthis" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="b8fe-8d38-pubN65537" name="Codex: Dark Angels"/>
   </publications>
@@ -5148,7 +5148,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f142-6890-334c-0994" name="Ezekiel" publicationId="b8fe-8d38-pubN65537" page="82" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="f142-6890-334c-0994" name="Ezekiel" publicationId="b8fe-8d38-pubN65537" page="82" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>


### PR DESCRIPTION
Due to https://github.com/BSData/wh40k/issues/11182, the model/unit flag is not sometimes set properly. This PR fixes this for the Dark Angels catalog.