### PR TITLE
Fix selection types for several units - Adeptus Custodes

### DIFF
--- a/Imperium - Adeptus Custodes.cat
+++ b/Imperium - Adeptus Custodes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0fb8-6813-9c29-a03d" name="Imperium - Adeptus Custodes" revision="111" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Techno" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="221" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0fb8-6813-9c29-a03d" name="Imperium - Adeptus Custodes" revision="112" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Techno" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="1f0f-230b-a715-7d27" name="Codex: Adeptus Custodes" shortName="" publisher=""/>
   </publications>
@@ -2452,7 +2452,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="385c-bee5-b0f3-0480" name="Contemptor-Galatus Dreadnought" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="385c-bee5-b0f3-0480" name="Contemptor-Galatus Dreadnought" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -2975,7 +2975,7 @@
         <categoryLink id="4399-2933-c31b-fd1b" name="Faction: &lt;Shield Host&gt;" hidden="false" targetId="98f2-b15c-d922-d1a7" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="c3e7-90db-c6d2-a9b5" name="Agamatus Custodian" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="c3e7-90db-c6d2-a9b5" name="Agamatus Custodian" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8166-8c1a-8ac0-34f1" type="max"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77af-616e-dcc7-dc81" type="min"/>
@@ -3079,7 +3079,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a136-e61b-112f-edde" name="Venatari Custodians" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="a136-e61b-112f-edde" name="Venatari Custodians" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="8.0">
           <conditions>
@@ -3490,7 +3490,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="653c-9e55-a52e-5206" name="Orion Assault Dropship" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="653c-9e55-a52e-5206" name="Orion Assault Dropship" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -3661,7 +3661,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="94ed-7b82-08f2-eea8" name="Ares Gunship" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="94ed-7b82-08f2-eea8" name="Ares Gunship" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -3987,7 +3987,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d233-0d52-7b70-1fdd" name="Anathema Psykana Rhino" page="" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="d233-0d52-7b70-1fdd" name="Anathema Psykana Rhino" page="" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>


### PR DESCRIPTION
Due to https://github.com/BSData/wh40k/issues/11182, the model/unit flag is not sometimes set properly. This PR fixes this for the Adeptus Custodes catalog.