### PR TITLE
Fix selection types for several units - Deathwatch

### DIFF
--- a/Imperium - Deathwatch.cat
+++ b/Imperium - Deathwatch.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="203b-f8dd-2a64-2676" name="Imperium - Adeptus Astartes - Deathwatch" revision="165" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Technoblazed" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="221" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="203b-f8dd-2a64-2676" name="Imperium - Adeptus Astartes - Deathwatch" revision="166" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Technoblazed" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="1973-efc9-3214-865a" name="Codex: Space Marines"/>
     <publication id="b8dc-efc0-c6b3-2c9f" name="Codex Supplement: Deathwatch" publisher="Codex Supplement: Deathwatch" publicationDate="2020-11-07" publisherUrl="https://www.games-workshop.com/en-GB/Codex-Supplement-Deathwatch-EN-2020"/>
@@ -3375,7 +3375,7 @@
         <categoryLink id="7249-4542-12f2-156a" name="Smokescreen" hidden="false" targetId="bcda-ed2e-436a-073b" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="21e2-17e8-74ae-bb6f" name="Watch Sergeant" page="" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="21e2-17e8-74ae-bb6f" name="Watch Sergeant" page="" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d887-8bd2-fc96-ee8d" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79b2-529f-5d67-92cf" type="max"/>
@@ -6632,7 +6632,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d1e1-dc4a-6a3c-6fb5" name="Infiltrator Helix Adept" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="d1e1-dc4a-6a3c-6fb5" name="Infiltrator Helix Adept" hidden="false" collective="false" import="true" type="model">
       <infoLinks>
         <infoLink id="f6f4-2d5b-0fee-1fba" name="Infiltrator" hidden="false" targetId="b6ba-0bdc-7591-e18e" type="profile"/>
         <infoLink id="3192-dc8b-0ae1-aaa3" name="Helix gauntlet" hidden="false" targetId="5a87-5e7c-ac8c-66bb" type="profile"/>


### PR DESCRIPTION
Due to https://github.com/BSData/wh40k/issues/11182, the model/unit flag is not sometimes set properly. This PR fixes this for the Deathwatch catalog.