### PR TITLE
Fix selection types for several units - 1000 sons

### DIFF
--- a/Chaos - Thousand Sons.cat
+++ b/Chaos - Thousand Sons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c553-15f3-3890-be39" name="Chaos - Thousand Sons" revision="125" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="221" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c553-15f3-3890-be39" name="Chaos - Thousand Sons" revision="126" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="b805-771c-6a82-7307" name="Codex: Thousand Sons 2021" publicationDate="2021-08-14"/>
   </publications>
@@ -4250,7 +4250,7 @@
         <cost name=" Cabal Points" typeId="6a06-928d-a42e-4293" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c5a2-5d3b-99c9-7b99" name="Thousand Sons Daemon Prince" page="0" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="c5a2-5d3b-99c9-7b99" name="Thousand Sons Daemon Prince" page="0" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="5746-8975-d4e5-72f6" name="Thousand Sons Daemon Prince" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <modifiers>


### PR DESCRIPTION
Due to https://github.com/BSData/wh40k/issues/11182, the model/unit flag is not sometimes set properly. This PR fixes this for the 1000 sons catalog.