### PR TITLE
Fix selection types for several units - Death Guard

### DIFF
--- a/Chaos - Death Guard.cat
+++ b/Chaos - Death Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ce57-cc1c-37cb-cb71" name="Chaos - Death Guard" revision="144" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="221" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ce57-cc1c-37cb-cb71" name="Chaos - Death Guard" revision="145" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="ce57-cc1c-pubN85391" name="Index: Chaos FAQ"/>
     <publication id="ce57-cc1c-pubN108736" name="Codex: Heretic Astartes - Death Guard" publicationDate="23/01/2021"/>
@@ -2765,7 +2765,7 @@ Battle Round 4 - 9&quot;</description>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c5a2-5d3b-99c9-7b99" name="Death Guard Daemon Prince" page="0" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="c5a2-5d3b-99c9-7b99" name="Death Guard Daemon Prince" page="0" hidden="false" collective="false" import="true" type="model">
       <modifierGroups>
         <modifierGroup>
           <modifiers>
@@ -8529,7 +8529,7 @@ plague companies in the same Detachment, without preventing other units in that 
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e909-3b20-4914-4907" name="Plagueburst Crawler" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="e909-3b20-4914-4907" name="Plagueburst Crawler" hidden="false" collective="false" import="true" type="model">
       <modifierGroups>
         <modifierGroup>
           <modifiers>


### PR DESCRIPTION
Due to https://github.com/BSData/wh40k/issues/11182, the model/unit flag is not sometimes set properly. This PR fixes this for the Death Guard catalog.