### PR TITLE
Fix selection types for several units - Daemons

### DIFF
--- a/Chaos - Daemons.cat
+++ b/Chaos - Daemons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="422a-a40e-3f7c-e8b3" name="Chaos - Daemons" revision="114" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="220" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="422a-a40e-3f7c-e8b3" name="Chaos - Daemons" revision="115" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="422a-a40e-pubN71142" name="Dataslate: Be&apos;lakor"/>
   </publications>
@@ -2081,7 +2081,7 @@ Locus of Shadows (Aura) - While a friendly DAEMONIC DISCIPLES unit is within 6&q
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b91e-a5fc-d9d4-bf08" name="Karanak" page="0" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="b91e-a5fc-d9d4-bf08" name="Karanak" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f858-0818-a784-0c95" type="max"/>
       </constraints>
@@ -10869,7 +10869,7 @@ Matched Play: Models added to this unit using the Split ability must be paid for
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1395-5005-33d3-ee55" name="Rotigus" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="1395-5005-33d3-ee55" name="Rotigus" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="a3c9-ee39-a150-00d7" name="Rotigus" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>


### PR DESCRIPTION
Due to https://github.com/BSData/wh40k/issues/11182, the model/unit flag is not sometimes set properly. This PR fixes this for the Daemons catalog.