### PR TITLE
Fix selection types for several units - Chaos Knights

### DIFF
--- a/Chaos - Chaos Knights.cat
+++ b/Chaos - Chaos Knights.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5d84-5102-f22c-14d4" name="Chaos - Chaos Knights" revision="74" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5d84-5102-f22c-14d4" name="Chaos - Chaos Knights" revision="75" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="222" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="3f2c-38d3-b6df-df27" name="D3 Roll">
       <characteristicTypes>
@@ -3886,7 +3886,7 @@
         <categoryLink id="db79-8e52-4959-f880" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="1e52-a8e1-92e4-3005" name="War Dog Moirax" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="1e52-a8e1-92e4-3005" name="War Dog Moirax" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="add" field="category" value="7eb7-17ad-139b-4c57">
               <conditionGroups>


### PR DESCRIPTION
Due to https://github.com/BSData/wh40k/issues/11182, the model/unit flag is not sometimes set properly. This PR fixes this for the Chaos Knights catalog.