### PR TITLE
Fixing stats from new codex

### DIFF
--- a/Chaos - Chaos Space Marines.cat
+++ b/Chaos - Chaos Space Marines.cat
@@ -16435,7 +16435,7 @@ All units in your army with the HERETIC ASTARTES Faction keyword (excluding CHAO
             <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">12&quot;</characteristic>
             <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault D6</characteristic>
             <characteristic name="S" typeId="59b1-319e-ec13-d466">5</characteristic>
-            <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
             <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
             <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Sonic Weapon. Each time an attack made by this weapon targets a unit within half-range, add 1 to the Damage characteristic of that attack. Each time an attack is made with this weapon, that attack automatically hits the target.</characteristic>
           </characteristics>
@@ -21827,7 +21827,7 @@ Each model can only be corrupted once per turn.</characteristic>
             <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
             <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
             <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Each time an attack made by this weapon targets a unit within half-range, add 1 to the Damage characteristic of that attack.</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Sonic Weapon. Each time an attack made by this weapon targets a unit within half-range, add 1 to the Damage characteristic of that attack.</characteristic>
           </characteristics>
         </profile>
       </profiles>


### PR DESCRIPTION
Doom siren is -3AP and sonic blaster gets the sonic weapon keyword