### PR TITLE
Add "wounds" text to all wound brackets resolving #11817

### DIFF
--- a/Tyranids.cat
+++ b/Tyranids.cat
@@ -829,7 +829,7 @@ Seed Spore Mines (Action): At the start of your Shooting phase, one BIOVORES uni
     </selectionEntry>
     <selectionEntry id="a886-3ba1-c505-1200" name="Exocrine" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="9f26-7669-789f-de1e" name="Exocrine [1] (8+)" publicationId="7150-5917-pubN65537" page="112" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="9f26-7669-789f-de1e" name="Exocrine [1] (8+ wounds)" publicationId="7150-5917-pubN65537" page="112" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">8&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
@@ -847,7 +847,7 @@ Seed Spore Mines (Action): At the start of your Shooting phase, one BIOVORES uni
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">In your Movement phase, if this model Remains Stationary or moves a total distance of less than half its Move characteristic, until the end of the turn, each time this model makes a ranged attack, the target does not receive the benefits of cover against that attack.</characteristic>
           </characteristics>
         </profile>
-        <profile id="5696-c98e-e70d-ef2c" name="Exocrine [2] (5-7)" publicationId="7150-5917-pubN65537" page="112" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="5696-c98e-e70d-ef2c" name="Exocrine [2] (5-7 wounds)" publicationId="7150-5917-pubN65537" page="112" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">7&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
@@ -860,7 +860,7 @@ Seed Spore Mines (Action): At the start of your Shooting phase, one BIOVORES uni
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
           </characteristics>
         </profile>
-        <profile id="c162-ecf7-8dfa-c2ea" name="Exocrine [3] (1-4)" publicationId="7150-5917-pubN65537" page="112" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="c162-ecf7-8dfa-c2ea" name="Exocrine [3] (1-4 wounds)" publicationId="7150-5917-pubN65537" page="112" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">5&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -1169,7 +1169,7 @@ An Infestation Node marker does not count as a model for any rules purposes.</ch
     </selectionEntry>
     <selectionEntry id="ee16-7977-eb9b-88e7" name="Harpy" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="ea83-bc08-3150-d0b9" name="Harpy [1] (7+)" publicationId="7150-5917-pubN65537" page="120" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="ea83-bc08-3150-d0b9" name="Harpy [1] (7+ wounds)" publicationId="7150-5917-pubN65537" page="120" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">15-40&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
@@ -1189,7 +1189,7 @@ An Infestation Node marker does not count as a model for any rules purposes.</ch
 • If you select a point on the battlefield, set up a new friendly SPORE MINES unit of 3 models on the battlefield not within 6&quot; of any enemy units and within 1&quot; of the selected point. If you are playing a game that uses a points limit, this unit does not cost any Reinforcement points.</characteristic>
           </characteristics>
         </profile>
-        <profile id="6c7a-198e-e5c7-56f0" name="Harpy [2] (4-6)" publicationId="7150-5917-pubN65537" page="120" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="6c7a-198e-e5c7-56f0" name="Harpy [2] (4-6 wounds)" publicationId="7150-5917-pubN65537" page="120" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">15-30&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
@@ -1202,7 +1202,7 @@ An Infestation Node marker does not count as a model for any rules purposes.</ch
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="b3d4-4677-eea7-ab04" name="Harpy [3] (1-3)" publicationId="7150-5917-pubN65537" page="120" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="b3d4-4677-eea7-ab04" name="Harpy [3] (1-3 wounds)" publicationId="7150-5917-pubN65537" page="120" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">15-20&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -1300,7 +1300,7 @@ An Infestation Node marker does not count as a model for any rules purposes.</ch
     </selectionEntry>
     <selectionEntry id="a753-2d35-9437-02d3" name="Haruspex" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="ee24-c750-4bbc-efc3" name="Haruspex [1] (8+)" publicationId="7150-5917-pubN65537" page="104" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="ee24-c750-4bbc-efc3" name="Haruspex [1] (8+ wounds)" publicationId="7150-5917-pubN65537" page="104" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">8&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
@@ -1323,7 +1323,7 @@ An Infestation Node marker does not count as a model for any rules purposes.</ch
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">While an enemy unit is within 6&quot; of this model, subtract 2 from the Leadership characteristic of models in that unit.</characteristic>
           </characteristics>
         </profile>
-        <profile id="6184-afdb-1991-678c" name="Haruspex [2] (5-7)" publicationId="7150-5917-pubN65537" page="104" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="6184-afdb-1991-678c" name="Haruspex [2] (5-7 wounds)" publicationId="7150-5917-pubN65537" page="104" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">7&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
@@ -1336,7 +1336,7 @@ An Infestation Node marker does not count as a model for any rules purposes.</ch
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
           </characteristics>
         </profile>
-        <profile id="10b2-fda2-dae1-1874" name="Haruspex [3] (1-4)" publicationId="7150-5917-pubN65537" page="104" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="10b2-fda2-dae1-1874" name="Haruspex [3] (1-4 wounds)" publicationId="7150-5917-pubN65537" page="104" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">5&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -1396,7 +1396,7 @@ An Infestation Node marker does not count as a model for any rules purposes.</ch
     </selectionEntry>
     <selectionEntry id="7c4f-3eb2-a044-15a8" name="Hive Crone" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="ab28-27d6-b7b2-8271" name="Hive Crone [1] (7+)" publicationId="7150-5917-pubN65537" page="119" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="ab28-27d6-b7b2-8271" name="Hive Crone [1] (7+ wounds)" publicationId="7150-5917-pubN65537" page="119" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">15-40&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
@@ -1409,7 +1409,7 @@ An Infestation Node marker does not count as a model for any rules purposes.</ch
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="2c01-92b4-e161-5905" name="Hive Crone [2] (4-6)" publicationId="7150-5917-pubN65537" page="119" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="2c01-92b4-e161-5905" name="Hive Crone [2] (4-6 wounds)" publicationId="7150-5917-pubN65537" page="119" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">15-30&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
@@ -1422,7 +1422,7 @@ An Infestation Node marker does not count as a model for any rules purposes.</ch
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="5975-0d84-618d-64e5" name="Hive Crone [3] (1-3)" publicationId="7150-5917-pubN65537" page="119" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="5975-0d84-618d-64e5" name="Hive Crone [3] (1-3 wounds)" publicationId="7150-5917-pubN65537" page="119" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">15-20&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -1637,7 +1637,7 @@ Defensive Stance (Action): At the start of your Command phase, any number of HIV
     </selectionEntry>
     <selectionEntry id="add7-3535-a4cd-9ba5" name="Hive Tyrant" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="e278-e0f1-c658-0671" name="Hive Tyrant [1] (7+)" publicationId="7150-5917-pubN65537" page="90" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="e278-e0f1-c658-0671" name="Hive Tyrant [1] (7+ wounds)" publicationId="7150-5917-pubN65537" page="90" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">9&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">2+</characteristic>
@@ -1658,7 +1658,7 @@ Defensive Stance (Action): At the start of your Command phase, any number of HIV
             <characteristic name="Other" typeId="c2e2-f115-0003-5d7b">-</characteristic>
           </characteristics>
         </profile>
-        <profile id="b9e8-31c6-dcb2-f93a" name="Hive Tyrant [2] (4-6)" publicationId="7150-5917-pubN65537" page="90" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="b9e8-31c6-dcb2-f93a" name="Hive Tyrant [2] (4-6 wounds)" publicationId="7150-5917-pubN65537" page="90" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">8&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
@@ -1671,7 +1671,7 @@ Defensive Stance (Action): At the start of your Command phase, any number of HIV
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
           </characteristics>
         </profile>
-        <profile id="34a0-b07c-3554-4200" name="Hive Tyrant [3] (1-3)" publicationId="7150-5917-pubN65537" page="90" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="34a0-b07c-3554-4200" name="Hive Tyrant [3] (1-3 wounds)" publicationId="7150-5917-pubN65537" page="90" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
@@ -2140,7 +2140,7 @@ Diffusion Field (Aura): While a friendly &lt;HIVE FLEET&gt; unit is within 6&quo
     </selectionEntry>
     <selectionEntry id="92ec-64fb-e5a7-65c1" name="Mawloc" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="5354-fd5d-0063-0e71" name="Mawloc [1] (7+)" publicationId="7150-5917-pubN65537" page="109" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="5354-fd5d-0063-0e71" name="Mawloc [1] (7+ wounds)" publicationId="7150-5917-pubN65537" page="109" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">10&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
@@ -2158,7 +2158,7 @@ Diffusion Field (Aura): While a friendly &lt;HIVE FLEET&gt; unit is within 6&quo
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">In your Command phase, if any MAWLOC models from your army are underground (see the Death from Below ability, page 86), you can select one of those models and select one point on the battlefield and place a Terror from the Deep marker on that point. If you do so, that model cannot be set up using its Death from Below ability this turn and, at the start of the Reinforcements step of your next turn&apos;s Movement phase, roll one D6 for each enemy unit within 6&quot; of the centre of that marker, adding 1 if the unit being rolled for contains between 6 and 10 models, and adding 2 if the unit being rolled for contains 11 or more models: on a 3-6, that unit suffers D3 mortal wounds; on a 7+, that unit suffers D3+3 mortal wounds. Then set the selected MAWLOC model up anywhere on the battlefield that is within 12&quot; of the centre of that marker and not within Engagement Range of any enemy models, and remove that marker. If that MAWLOC model is set up within 9&quot; of any enemy models, until the end of the turn, it cannot charge.</characteristic>
           </characteristics>
         </profile>
-        <profile id="afaf-0538-1748-0410" name="Mawloc [2] (4-6)" publicationId="7150-5917-pubN65537" page="109" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="afaf-0538-1748-0410" name="Mawloc [2] (4-6 wounds)" publicationId="7150-5917-pubN65537" page="109" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">8&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
@@ -2171,7 +2171,7 @@ Diffusion Field (Aura): While a friendly &lt;HIVE FLEET&gt; unit is within 6&quo
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="54ef-ec36-f3dc-1b12" name="Mawloc [3] (1-3)" publicationId="7150-5917-pubN65537" page="109" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="54ef-ec36-f3dc-1b12" name="Mawloc [3] (1-3 wounds)" publicationId="7150-5917-pubN65537" page="109" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -2764,7 +2764,7 @@ Diffusion Field (Aura): While a friendly &lt;HIVE FLEET&gt; unit is within 6&quo
     </selectionEntry>
     <selectionEntry id="4fe0-a701-3f44-b703" name="Sporocyst" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="0d9d-03af-0c6a-7909" name="Sporocyst [1] (6+)" publicationId="7150-5917-pubN65537" page="121" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="0d9d-03af-0c6a-7909" name="Sporocyst [1] (6+ wounds)" publicationId="7150-5917-pubN65537" page="121" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">-</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -2794,7 +2794,7 @@ Diffusion Field (Aura): While a friendly &lt;HIVE FLEET&gt; unit is within 6&quo
 Seed Spores (Action): At the start of your Movement phase, one SPOROCYST model from your army can start to perform this action. The action is completed at the end of that phase. When it is completed, set up a new friendly SPORE MINES unit containing 6 models or a new friendly MUCOLID SPORES unit containing 1 model on the battlefield. That unit must set up more than 6&quot; away from any enemy units and wholly within 18&quot; of this model. If you are playing a game that uses a points limit, that unit does not cost any Reinforcement points.</characteristic>
           </characteristics>
         </profile>
-        <profile id="e09d-7d2d-80fc-73de" name="Sporocyst [2] (3-5)" publicationId="7150-5917-pubN65537" page="121" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="e09d-7d2d-80fc-73de" name="Sporocyst [2] (3-5 wounds)" publicationId="7150-5917-pubN65537" page="121" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">-</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -2807,7 +2807,7 @@ Seed Spores (Action): At the start of your Movement phase, one SPOROCYST model f
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="f4f2-0317-25ec-a389" name="Sporocyst [3] (6+)" publicationId="7150-5917-pubN65537" page="121" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="f4f2-0317-25ec-a389" name="Sporocyst [3] (6+ wounds)" publicationId="7150-5917-pubN65537" page="121" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">-</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -3099,7 +3099,7 @@ Seed Spores (Action): At the start of your Movement phase, one SPOROCYST model f
     </selectionEntry>
     <selectionEntry id="0507-f341-5267-7cc5" name="Tervigon" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="75ac-7f55-0333-a12a" name="Tervigon [1] (9+)" publicationId="7150-5917-pubN65537" page="94" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="75ac-7f55-0333-a12a" name="Tervigon [1] (9+ wounds)" publicationId="7150-5917-pubN65537" page="94" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">8&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
@@ -3139,7 +3139,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
 • Once per battle, this model can spawn a new unit of Termagants. If it does so, set up a new friendly &lt;HIVE FLEET&gt; TERMAGANTS unit on the battlefield not within Engagement Range of any enemy units and wholly within 6&quot; of this model. That TERMAGANTS unit contains 10 models, each equipped with fleshborers, and, if you are playing a game that uses a points limit, that unit does not cost any Reinforcement points.</characteristic>
           </characteristics>
         </profile>
-        <profile id="06ee-bdbe-186f-1c92" name="Tervigon [2] (5-8)" publicationId="7150-5917-pubN65537" page="94" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="06ee-bdbe-186f-1c92" name="Tervigon [2] (5-8 wounds)" publicationId="7150-5917-pubN65537" page="94" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">7&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
@@ -3152,7 +3152,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
           </characteristics>
         </profile>
-        <profile id="0c1d-91de-d3b6-97b1" name="Tervigon [3] (1-4)" publicationId="7150-5917-pubN65537" page="94" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="0c1d-91de-d3b6-97b1" name="Tervigon [3] (1-4 wounds)" publicationId="7150-5917-pubN65537" page="94" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -3261,7 +3261,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
     </selectionEntry>
     <selectionEntry id="cdd9-7d89-df58-3760" name="Toxicrene" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="8f67-5e10-5eff-735f" name="Toxicrene [1] (8+)" publicationId="7150-5917-pubN65537" page="100" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="8f67-5e10-5eff-735f" name="Toxicrene [1] (8+ wounds)" publicationId="7150-5917-pubN65537" page="100" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">8&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
@@ -3279,7 +3279,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the start of the Fight phase, for each enemy unit within Engagement Range of this model, roll one D6: on a 4+, that unit suffers D3 mortal wounds and is not eligible to fight this phase until after all eligible units from your army have done so.</characteristic>
           </characteristics>
         </profile>
-        <profile id="3b8c-a91b-b867-3d53" name="Toxicrene [2] (5-7)" publicationId="7150-5917-pubN65537" page="100" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="3b8c-a91b-b867-3d53" name="Toxicrene [2] (5-7 wounds)" publicationId="7150-5917-pubN65537" page="100" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">7&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
@@ -3292,7 +3292,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="9ec0-f318-6b9b-cade" name="Toxicrene [3] (1-4)" publicationId="7150-5917-pubN65537" page="100" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="9ec0-f318-6b9b-cade" name="Toxicrene [3] (1-4 wounds)" publicationId="7150-5917-pubN65537" page="100" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">5&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -3352,7 +3352,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
     </selectionEntry>
     <selectionEntry id="f628-1bb2-0620-3beb" name="Trygon" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="8ee3-0b55-2e61-60cb" name="Trygon [1] (7+)" publicationId="7150-5917-pubN65537" page="110" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="8ee3-0b55-2e61-60cb" name="Trygon [1] (7+ wounds)" publicationId="7150-5917-pubN65537" page="110" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">10&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
@@ -3365,7 +3365,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="b88b-3573-af8b-cc74" name="Trygon [2] (4-6)" publicationId="7150-5917-pubN65537" page="110" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="b88b-3573-af8b-cc74" name="Trygon [2] (4-6 wounds)" publicationId="7150-5917-pubN65537" page="110" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">8&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
@@ -3378,7 +3378,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="1dde-aa8f-79c0-68f1" name="Trygon [3] (1-3)" publicationId="7150-5917-pubN65537" page="110" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="1dde-aa8f-79c0-68f1" name="Trygon [3] (1-3 wounds)" publicationId="7150-5917-pubN65537" page="110" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -3466,7 +3466,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
     </selectionEntry>
     <selectionEntry id="1864-f6fc-3f51-0c34" name="Trygon Prime" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="ae54-b754-8dac-cd99" name="Trygon Prime [1] (7+)" publicationId="7150-5917-pubN65537" page="95" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="ae54-b754-8dac-cd99" name="Trygon Prime [1] (7+ wounds)" publicationId="7150-5917-pubN65537" page="95" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">10&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
@@ -3479,7 +3479,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="de61-bc51-02b0-db83" name="Trygon Prime [2] (4-6)" publicationId="7150-5917-pubN65537" page="95" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="de61-bc51-02b0-db83" name="Trygon Prime [2] (4-6 wounds)" publicationId="7150-5917-pubN65537" page="95" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">8&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
@@ -3492,7 +3492,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="b6ee-fa3f-edae-3158" name="Trygon Prime [3] (1-3)" publicationId="7150-5917-pubN65537" page="95" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="b6ee-fa3f-edae-3158" name="Trygon Prime [3] (1-3 wounds)" publicationId="7150-5917-pubN65537" page="95" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -4029,7 +4029,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
     </selectionEntry>
     <selectionEntry id="0daf-d491-1f32-1322" name="Tyrannocyte" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="cde3-0c0e-ed61-294d" name="Tyrannocyte [1] (8+)" publicationId="7150-5917-pubN65537" page="118" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="cde3-0c0e-ed61-294d" name="Tyrannocyte [1] (8+ wounds)" publicationId="7150-5917-pubN65537" page="118" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">8&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -4047,7 +4047,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During deployment, this model must be set up high in the skies instead of setting it up on the battlefield, neither it, nor any embarked units within it, are counted towards any limits that the mission places on the maximum number of Reinforcement units you can have in your army. This TRANSPORT model can be set up in the Reinforcements step of your first, second or third Movement phase, regardless of any mission rules, anywhere on the battlefield that is more than 9&quot; away from any enemy models. Any units embarked within this TRANSPORT model must immediately disembark after it has been set up on the battlefield, and they must be set up more than 9&quot; away from any enemy models. After this TRANSPORT model has been set up on the battlefield, no models can embark within it.</characteristic>
           </characteristics>
         </profile>
-        <profile id="8258-ff2d-f3b8-fbda" name="Tyrannocyte [2] (5-7)" publicationId="7150-5917-pubN65537" page="118" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="8258-ff2d-f3b8-fbda" name="Tyrannocyte [2] (5-7 wounds)" publicationId="7150-5917-pubN65537" page="118" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -4060,7 +4060,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="5dc2-b1ad-5959-0ff1" name="Tyrannocyte [3] (1-4)" publicationId="7150-5917-pubN65537" page="118" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="5dc2-b1ad-5959-0ff1" name="Tyrannocyte [3] (1-4 wounds)" publicationId="7150-5917-pubN65537" page="118" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">4&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -4146,7 +4146,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
     </selectionEntry>
     <selectionEntry id="f535-4e40-2b57-2bf7" name="Tyrannofex" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="3ebb-6c04-c64a-3e6a" name="Tyrannofex [1] (9+)" publicationId="7150-5917-pubN65537" page="117" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="3ebb-6c04-c64a-3e6a" name="Tyrannofex [1] (9+ wounds)" publicationId="7150-5917-pubN65537" page="117" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">9&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
@@ -4159,7 +4159,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
           </characteristics>
         </profile>
-        <profile id="0a94-cb6e-0f87-aa76" name="Tyrannofex [2] (5-8)" publicationId="7150-5917-pubN65537" page="117" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="0a94-cb6e-0f87-aa76" name="Tyrannofex [2] (5-8 wounds)" publicationId="7150-5917-pubN65537" page="117" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">8&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
@@ -4172,7 +4172,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
           </characteristics>
         </profile>
-        <profile id="8f87-6b9c-1751-3cc2" name="Tyrannofex [3] (1-4)" publicationId="7150-5917-pubN65537" page="117" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="8f87-6b9c-1751-3cc2" name="Tyrannofex [3] (1-4 wounds)" publicationId="7150-5917-pubN65537" page="117" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
@@ -4815,7 +4815,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="619d-7d97-6dae-26e7" type="max"/>
       </constraints>
       <profiles>
-        <profile id="2d16-64a7-60c2-a2b2" name="The Swarmlord [1] (7+)" publicationId="7150-5917-pubN65537" page="91" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="2d16-64a7-60c2-a2b2" name="The Swarmlord [1] (7+ wounds)" publicationId="7150-5917-pubN65537" page="91" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">9&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">2+</characteristic>
@@ -4846,7 +4846,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">In your Command phase, select one friendly &lt;HIVE FLEET&gt; CORE unit within Synaptic Link range of this model. Until the start of your next Command phase, that unit gains the Objective Secured ability (see the Warhammer 40,000 Core Book). If that unit already had this ability, models in that unit count as one additional model when determining control of an objective marker.</characteristic>
           </characteristics>
         </profile>
-        <profile id="e59b-0259-50de-484c" name="The Swarmlord [2] (4-6)" publicationId="7150-5917-pubN65537" page="91" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="e59b-0259-50de-484c" name="The Swarmlord [2] (4-6 wounds)" publicationId="7150-5917-pubN65537" page="91" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">8&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
@@ -4859,7 +4859,7 @@ TERVIGONS within range of a friendly &lt;HIVE FLEET&gt; TERMAGANT unit&apos;s Wa
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
           </characteristics>
         </profile>
-        <profile id="f3cc-e05a-9bb8-bb92" name="The Swarmlord [3] (1-3)" publicationId="7150-5917-pubN65537" page="91" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="f3cc-e05a-9bb8-bb92" name="The Swarmlord [3] (1-3 wounds)" publicationId="7150-5917-pubN65537" page="91" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
@@ -8759,7 +8759,7 @@ Unless the only units with this adaptation are part of an Auxiliary Support, Sup
     </selectionEntry>
     <selectionEntry id="d0f1-4f2b-4aa2-e6c6" name="Winged Hive Tyrant" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="ac3d-1b6c-3ea0-7d27" name="Winged Hive Tyrant [1] (7+)" publicationId="7150-5917-pubN65537" page="89" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="ac3d-1b6c-3ea0-7d27" name="Winged Hive Tyrant [1] (7+ wounds)" publicationId="7150-5917-pubN65537" page="89" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">16&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">2+</characteristic>
@@ -8780,7 +8780,7 @@ Unless the only units with this adaptation are part of an Auxiliary Support, Sup
             <characteristic name="Other" typeId="c2e2-f115-0003-5d7b">-</characteristic>
           </characteristics>
         </profile>
-        <profile id="36c1-39cc-8e9f-dd5a" name="Winged Hive Tyrant [2] (4-6)" publicationId="7150-5917-pubN65537" page="89" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="36c1-39cc-8e9f-dd5a" name="Winged Hive Tyrant [2] (4-6 wounds)" publicationId="7150-5917-pubN65537" page="89" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">12&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
@@ -8793,7 +8793,7 @@ Unless the only units with this adaptation are part of an Auxiliary Support, Sup
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="17a7-322b-904c-c258" name="Winged Hive Tyrant [3] (1-3)" publicationId="7150-5917-pubN65537" page="89" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+        <profile id="17a7-322b-904c-c258" name="Winged Hive Tyrant [3] (1-3 wounds)" publicationId="7150-5917-pubN65537" page="89" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="0bdf-a96e-9e38-7779">8&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>


### PR DESCRIPTION
Adds consistency for wound brackets for the Tyranid army by adding the word "wounds" after the wound values in the unit profiles.  This resolves #11817