### PR TITLE
increment revision to 13

### DIFF
--- a/Leagues of Votann.cat
+++ b/Leagues of Votann.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="787f-957c-4fe1-4648" name="Leagues of Votann" revision="12" battleScribeVersion="2.03" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="787f-957c-4fe1-4648" name="Leagues of Votann" revision="13" battleScribeVersion="2.03" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="d6df-3d52-c2ca-4ee6" name="Faction: Votann" hidden="false"/>
     <categoryEntry id="5c58-cce2-32c5-540d" name="Greater Thurian League" hidden="false"/>
@@ -3343,11 +3343,12 @@ The destruction of an E-COG is ignored for the purposes of Morale tests. If this
                       <costs>
                         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
-                    <entryLink id="ecea-c690-fbc8-ae62" name="L7 missile launcher" hidden="false" collective="false" import="true" targetId="8baa-812c-7b1d-c17c" type="selectionEntry">
+                    <entryLink id="ecea-c690-fbc8-ae62" name="L7 Missile launcher and sagitaur missile launcher" hidden="false" collective="false" import="true" targetId="513f-8d08-523b-b223" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f976-9f34-b2aa-6ef1" type="min"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58d3-64de-4ef4-e8b3" type="max"/>
@@ -3356,6 +3357,8 @@ The destruction of an E-COG is ignored for the purposes of Morale tests. If this
                   </entryLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -3413,6 +3416,7 @@ The destruction of an E-COG is ignored for the purposes of Morale tests. If this
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b317-1618-ac3e-3c65" name="MATR autocannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -5668,6 +5672,55 @@ Each time a model with this custom (excluding COG models) makes a melee attack a
 - The Damage characteristic of that weapon is increased by 1.
 - The Armour Penetration characteristic of that weapon is increased by 1.
 - Each time an attack by that weapon hits a unit that has 1 or more Judgement tokens, that attack automatically wounds the target.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="513f-8d08-523b-b223" name="L7 Missile launcher and sagitaur missile launcher" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="91db-a9df-acfe-a711" name="L7 missile launcher" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">-</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">-</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">-</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">-</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Before selecting targets, select one of the profiles below to make attacks with.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="bc47-3ee9-708a-05a0" name="L7 missile launcher - Blast" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">30&quot;</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">HunTR D6</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">5</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7c1f-9c08-ce09-0a9c" name="L7 missile launcher - Focused" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">30&quot;</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">HunTR 1</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">9</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D6</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b74e-ac08-0980-a54c" name="Sagitaur missile launcher" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 2</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">10</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
           </characteristics>
         </profile>
       </profiles>


### PR DESCRIPTION
fixes #12018
L7/sagitaur missing sagitaur data by implementing its own L7 launcher profile that includes the sagitaur launcher data