### PR TITLE
Fixed Painboy on Warbike Power, Spelling Error

### DIFF
--- a/Orks.cat
+++ b/Orks.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3bba-af85-a93c-6bdf" name="Orks" revision="60" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Techno" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3bba-af85-a93c-6bdf" name="Orks" revision="61" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Techno" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="11b5-77b9-pubN65537" name="Codex: Orks 2021"/>
     <publication id="b556-84c7-4532-bca5" name="Da Red Gobbbo on Bounca" publisher="Da Red Gobbbo on Bounca Boxset" publicationDate="2021-11-13"/>
@@ -2449,7 +2449,7 @@ We recommend placing a Grot Oiler model next to the unit as a reminder, removing
         <cost name=" Scrap Points" typeId="932a-ae3d-c6c7-6938" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6f08-a7c2-fdc2-9565" name="Painboy on Warbike [Legends]" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="6f08-a7c2-fdc2-9565" name="Painboy on Warbike [Legends]" publicationId="28ec-711c-pubN118139" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -2561,7 +2561,7 @@ We recommend placing a Grot Oiler model next to the unit as a reminder, removing
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="90.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
         <cost name=" Scrap Points" typeId="932a-ae3d-c6c7-6938" value="0.0"/>
       </costs>
@@ -18572,7 +18572,7 @@ We recommend placing a Grot Orderly model next to the unit as a reminder, removi
               <characteristics>
                 <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">VEHICLE model only (excluding WALKERS and AIRCRAFT).
 
-- Add 1! to this model&apos;s Move characteristic.
+- Add 1&quot; to this model&apos;s Move characteristic.
 - Each time this model Advances, add an additional 2&quot; to this model&apos;s Move characteristic.</characteristic>
               </characteristics>
             </profile>


### PR DESCRIPTION
Fixed a spelling error in the Squig Hide Tyres description. Adjusted the power level for the Painboy on Warbike to match the current GW Legends document available at https://www.warhammer-community.com/wp-content/uploads/2019/12/7661dd41.pdf

Resolves Issue #12041.