### PR TITLE
Added the 'Shock Troops' ability to the Cadian Shock Troops

### DIFF
--- a/Imperium - Astra Militarum - Library.cat
+++ b/Imperium - Astra Militarum - Library.cat
@@ -17341,6 +17341,13 @@ friendly VEHICLE OFFICER and SUPER-HEAVY units.</characteristic>
           </modifiers>
         </modifierGroup>
       </modifierGroups>
+      <profiles>
+        <profile id="1421-9a3c-2fbe-4f5a" name="Shock Troops" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time a model in this unit makes a ranged attack with a lasgun or laspistol, an unmodified hit roll of 6 scores 1 additional hit.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
         <infoLink id="18b9-6704-390e-9a18" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
         <infoLink id="7ccd-c0b6-20ea-a1d3" name="Shock Trooper" hidden="false" targetId="66e6-ea38-4809-6033" type="profile"/>


### PR DESCRIPTION
I notice the Cadian shock troops didn't have the Shock Troops ability on the sheets.  I added in an entry for them so it now shows up.