### PR TITLE
Fix model names in Legionaries and Noise Marines units

### DIFF
--- a/Chaos - Chaos Space Marines.cat
+++ b/Chaos - Chaos Space Marines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cb54-c035-5759-7697" name="Chaos - Chaos Space Marines" revision="212" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="243" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cb54-c035-5759-7697" name="Chaos - Chaos Space Marines" revision="213" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="243" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cb54-c035-pubN125652" name="Codex: Heretic Astartes - Chaos Space Marines"/>
     <publication id="cb54-c035-pubN153092" name="Imperium Nihilus: Vigilus Ablaze"/>
@@ -13739,7 +13739,7 @@ All units in your army with the HERETIC ASTARTES Faction keyword (excluding CHAO
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7158-eac1-b26a-17dc" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="f348-b327-8e54-434c" name="Marine w/ boltgun" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry id="f348-b327-8e54-434c" name="Legionary w/ boltgun" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd38-7956-adc1-c627" type="max"/>
               </constraints>
@@ -13769,24 +13769,24 @@ All units in your army with the HERETIC ASTARTES Faction keyword (excluding CHAO
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="34ee-3726-87dd-5c39" name="Marine w/ heavy or special weapon" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry id="34ee-3726-87dd-5c39" name="Legionary w/ heavy or special weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="be18-d9ac-4df5-485e" value="1.0">
                   <conditions>
                     <condition field="selections" scope="7b61-1289-ed7e-24c1" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="name" value="Marine w/ heavy weapon">
+                <modifier type="set" field="name" value="Legionary w/ heavy weapon">
                   <conditions>
                     <condition field="selections" scope="34ee-3726-87dd-5c39" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="08f8-b87d-a601-198c" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="name" value="Marine w/ special weapon">
+                <modifier type="set" field="name" value="Legionary w/ special weapon">
                   <conditions>
                     <condition field="selections" scope="34ee-3726-87dd-5c39" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8c6e-2e49-bf53-306b" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="name" value="Marine w/ plasma pistol">
+                <modifier type="set" field="name" value="Legionary w/ plasma pistol">
                   <conditions>
                     <condition field="selections" scope="34ee-3726-87dd-5c39" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="83be-1ba9-c326-4760" type="equalTo"/>
                   </conditions>
@@ -13899,7 +13899,7 @@ All units in your army with the HERETIC ASTARTES Faction keyword (excluding CHAO
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="4222-74f2-38d2-22c1" name="Marine w/ astartes chainsword" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry id="4222-74f2-38d2-22c1" name="Legionary w/ astartes chainsword" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d963-24f7-46d6-1bb5" type="max"/>
               </constraints>
@@ -13929,7 +13929,7 @@ All units in your army with the HERETIC ASTARTES Faction keyword (excluding CHAO
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="adf4-efb8-3e04-05fa" name="Marine w/ balefire tome" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry id="adf4-efb8-3e04-05fa" name="Legionary w/ balefire tome" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -14031,7 +14031,7 @@ All units in your army with the HERETIC ASTARTES Faction keyword (excluding CHAO
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e316-0877-9044-d826" name="Marine w/ heavy chainaxe" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry id="e316-0877-9044-d826" name="Legionary w/ heavy chainaxe" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af1d-0c1d-14cf-76f5" type="max"/>
               </constraints>
@@ -15891,7 +15891,7 @@ All units in your army with the HERETIC ASTARTES Faction keyword (excluding CHAO
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dce-f140-356a-f0b2" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8d98-59a4-6f96-f2d2" name="Marine w/ boltgun" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry id="8d98-59a4-6f96-f2d2" name="Noise Marine w/ boltgun" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="517a-3a1a-8fad-dc1c" type="max"/>
               </constraints>
@@ -15921,7 +15921,7 @@ All units in your army with the HERETIC ASTARTES Faction keyword (excluding CHAO
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="95ca-f802-a2ee-abbf" name="Marine w/ chainsword" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry id="95ca-f802-a2ee-abbf" name="Noise Marine w/ chainsword" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cb2-3795-3c25-8d6c" type="max"/>
               </constraints>
@@ -15951,7 +15951,7 @@ All units in your army with the HERETIC ASTARTES Faction keyword (excluding CHAO
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9e4e-866c-0b2c-def4" name="Marine w/ sonic blaster" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry id="9e4e-866c-0b2c-def4" name="Noise Marine w/ sonic blaster" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac8d-9c3f-eaa0-493d" type="max"/>
               </constraints>
@@ -15983,7 +15983,7 @@ All units in your army with the HERETIC ASTARTES Faction keyword (excluding CHAO
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9d86-8fb4-061f-571c" name="Marine w/ blastmaster" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry id="9d86-8fb4-061f-571c" name="Noise Marine w/ blastmaster" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31bd-16d7-db20-2705" type="max"/>
               </constraints>


### PR DESCRIPTION
As discussed in Discord - Legionaries and Noise Marines units have "Marine" models in them, which doesn't match the profiles in those units.