### PR TITLE
Corrected M characteristic for Angron's third profile.

### DIFF
--- a/Chaos - World Eaters.cat
+++ b/Chaos - World Eaters.cat
@@ -1,92 +1,92 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <catalogue id="0702-ace1-d159-5c4b" name="Chaos - World Eaters" revision="2" battleScribeVersion="2.03" authorName="@Mad-Spy" authorUrl="https://www.bsdata.net" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="247" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
-    <publication id="f46d-2654-1dd6-67c5" name="Codex: World Eaters" shortName="Codex: WE" publicationDate="11/02/2023"/>
+    <publication id="f46d-2654-1dd6-67c5" name="Codex: World Eaters" shortName="Codex: WE" publicationDate="11/02/2023" />
   </publications>
   <profileTypes>
     <profileType id="ab7d-ff53-d1ac-686c" name="Mutated Beyond Reason">
       <characteristicTypes>
-        <characteristicType id="5921-a76d-5c6f-f170" name="Effect"/>
+        <characteristicType id="5921-a76d-5c6f-f170" name="Effect" />
       </characteristicTypes>
     </profileType>
   </profileTypes>
   <categoryEntries>
-    <categoryEntry id="f096-f6b1-0904-2985" name="Faction: Butcher Astartes" hidden="false"/>
-    <categoryEntry id="9c4d-556e-5ec1-7ad6" name="Warp Locus" hidden="false"/>
-    <categoryEntry id="9a45-e58b-0980-cd80" name="Angron" hidden="false"/>
-    <categoryEntry id="df1a-10b8-3827-fe77" name="Khârn the Betrayer" hidden="false"/>
-    <categoryEntry id="bf74-355d-6bc8-abe5" name="Lord Invocatus" hidden="false"/>
-    <categoryEntry id="e12a-408e-574b-4a6c" name="Faction: World Eaters" hidden="false"/>
-    <categoryEntry id="6672-bdc5-34dc-68f2" name="World Eaters Lord" hidden="false"/>
-    <categoryEntry id="9375-72bf-28af-27aa" name="Master of Executions" hidden="false"/>
-    <categoryEntry id="a010-81a3-ed60-ba97" name="Khorne Berserkers" hidden="false"/>
-    <categoryEntry id="3db4-481a-d6ce-d2ad" name="Icon" hidden="false"/>
+    <categoryEntry id="f096-f6b1-0904-2985" name="Faction: Butcher Astartes" hidden="false" />
+    <categoryEntry id="9c4d-556e-5ec1-7ad6" name="Warp Locus" hidden="false" />
+    <categoryEntry id="9a45-e58b-0980-cd80" name="Angron" hidden="false" />
+    <categoryEntry id="df1a-10b8-3827-fe77" name="Khârn the Betrayer" hidden="false" />
+    <categoryEntry id="bf74-355d-6bc8-abe5" name="Lord Invocatus" hidden="false" />
+    <categoryEntry id="e12a-408e-574b-4a6c" name="Faction: World Eaters" hidden="false" />
+    <categoryEntry id="6672-bdc5-34dc-68f2" name="World Eaters Lord" hidden="false" />
+    <categoryEntry id="9375-72bf-28af-27aa" name="Master of Executions" hidden="false" />
+    <categoryEntry id="a010-81a3-ed60-ba97" name="Khorne Berserkers" hidden="false" />
+    <categoryEntry id="3db4-481a-d6ce-d2ad" name="Icon" hidden="false" />
     <categoryEntry id="184d-2f9a-fb60-ba22" name="Cultists" hidden="false">
       <modifiers>
         <modifier type="increment" field="10d8-6826-6a41-9680" value="1.0">
           <repeats>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08f1-d244-eb44-7e01" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08f1-d244-eb44-7e01" repeats="1" roundUp="false" />
           </repeats>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a207-a133-6adb-25f3" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a207-a133-6adb-25f3" type="notInstanceOf" />
           </conditions>
         </modifier>
         <modifier type="increment" field="10d8-6826-6a41-9680" value="1.0">
           <repeats>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a010-81a3-ed60-ba97" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a010-81a3-ed60-ba97" repeats="1" roundUp="false" />
           </repeats>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="10d8-6826-6a41-9680" type="max"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="10d8-6826-6a41-9680" type="max" />
       </constraints>
     </categoryEntry>
-    <categoryEntry id="d520-aa13-3b1f-0a72" name="Jakhals" hidden="false"/>
-    <categoryEntry id="437e-91ed-c310-e18a" name="Terminator" hidden="false"/>
-    <categoryEntry id="9f38-06d1-9246-49e6" name="Terminator Squad" hidden="false"/>
-    <categoryEntry id="6dfa-171f-086c-a487" name="Eightbound" hidden="false"/>
-    <categoryEntry id="ebbb-88ba-3fd2-ff8e" name="Exalted Eightbound" hidden="false"/>
+    <categoryEntry id="d520-aa13-3b1f-0a72" name="Jakhals" hidden="false" />
+    <categoryEntry id="437e-91ed-c310-e18a" name="Terminator" hidden="false" />
+    <categoryEntry id="9f38-06d1-9246-49e6" name="Terminator Squad" hidden="false" />
+    <categoryEntry id="6dfa-171f-086c-a487" name="Eightbound" hidden="false" />
+    <categoryEntry id="ebbb-88ba-3fd2-ff8e" name="Exalted Eightbound" hidden="false" />
   </categoryEntries>
   <selectionEntries>
     <selectionEntry id="b813-0db0-8d66-335c" name="Subfaction" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b585-52ac-4868-cc64" type="min"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd5d-a49f-d246-a2ee" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b585-52ac-4868-cc64" type="min" />
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd5d-a49f-d246-a2ee" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="9c53-6242-92c9-b43a" name="New CategoryLink" hidden="false" targetId="fcff-0f21-93e6-1ddc" primary="true"/>
+        <categoryLink id="9c53-6242-92c9-b43a" name="New CategoryLink" hidden="false" targetId="fcff-0f21-93e6-1ddc" primary="true" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="348f-d71b-10cd-7373" name="Subfaction" hidden="false" collective="false" import="true" defaultSelectionEntryId="a767-04ba-ff37-1531">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12c7-3953-21fc-6e82" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db6c-ba57-8d42-8403" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12c7-3953-21fc-6e82" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db6c-ba57-8d42-8403" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="a767-04ba-ff37-1531" name="World Eaters" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="1029-5185-faaa-11ea" name="Disciples of the Red Angel" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
   </selectionEntries>
@@ -95,54 +95,54 @@
       <modifiers>
         <modifier type="set" field="39d7-90ff-dc3e-3fd7" value="1.0">
           <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="39d7-90ff-dc3e-3fd7" type="min"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="39d7-90ff-dc3e-3fd7" type="min" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="b0f9-66ce-a91d-2eee" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
+        <categoryLink id="b0f9-66ce-a91d-2eee" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="d3eb-0563-234c-887c" name="Angron" hidden="false" collective="false" import="true" targetId="709c-3853-42df-daa1" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b27c-a511-78bf-9bac" name="New CategoryLink" hidden="false" targetId="26b0-4bb9-73aa-d3d7" primary="true"/>
+        <categoryLink id="b27c-a511-78bf-9bac" name="New CategoryLink" hidden="false" targetId="26b0-4bb9-73aa-d3d7" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="c6f2-6987-2b3c-3261" name="Khârn the Betrayer" hidden="false" collective="false" import="true" targetId="3ed9-a350-1375-253e" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
     </entryLink>
-    <entryLink id="3950-d27d-7b83-001a" name="Lord Invocatus" hidden="false" collective="false" import="true" targetId="3f7c-2cb9-a6c8-b08c" type="selectionEntry"/>
+    <entryLink id="3950-d27d-7b83-001a" name="Lord Invocatus" hidden="false" collective="false" import="true" targetId="3f7c-2cb9-a6c8-b08c" type="selectionEntry" />
     <entryLink id="5507-a5ee-e676-6e0f" name="World Eaters Daemon Prince" hidden="false" collective="false" import="true" targetId="19b5-e189-b896-f8d5" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
           </conditions>
         </modifier>
       </modifiers>
     </entryLink>
-    <entryLink id="0361-872f-57b0-9a3a" name="World Eaters Lord on Juggernaut" hidden="false" collective="false" import="true" targetId="8328-9c8a-56f1-4066" type="selectionEntry"/>
+    <entryLink id="0361-872f-57b0-9a3a" name="World Eaters Lord on Juggernaut" hidden="false" collective="false" import="true" targetId="8328-9c8a-56f1-4066" type="selectionEntry" />
     <entryLink id="d7bf-5e6e-f815-1cdd" name="World Eaters Master of Executions" hidden="false" collective="false" import="true" targetId="d96e-ed0c-06f8-4fa5" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
@@ -151,7 +151,7 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
@@ -160,7 +160,7 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
@@ -169,41 +169,41 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="6d45-1936-8479-93c5" value="1.0">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d45-1936-8479-93c5" type="max"/>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d45-1936-8479-93c5" type="max" />
       </constraints>
     </entryLink>
     <entryLink id="2046-c875-3af1-776d" name="Eightbound" hidden="false" collective="false" import="true" targetId="26cd-dc2c-1890-d51a" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="b64f-689b-eac4-eab3" value="1.0">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b64f-689b-eac4-eab3" type="max"/>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b64f-689b-eac4-eab3" type="max" />
       </constraints>
     </entryLink>
     <entryLink id="95e1-1f42-0ad8-950c" name="Exalted Eightbound" hidden="false" collective="false" import="true" targetId="405b-f054-eaca-ce5c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="7ef7-32f2-3ead-e16e" value="1.0">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7ef7-32f2-3ead-e16e" type="max"/>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7ef7-32f2-3ead-e16e" type="max" />
       </constraints>
     </entryLink>
     <entryLink id="afdf-335d-b227-4ce3" name="Helbrute" hidden="false" collective="false" import="true" targetId="8f3c-44d3-a785-230f" type="selectionEntry">
@@ -212,8 +212,8 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -224,24 +224,24 @@
       <modifiers>
         <modifier type="set" field="a3e4-1e79-92ea-415c" value="1.0">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3e4-1e79-92ea-415c" type="max"/>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3e4-1e79-92ea-415c" type="max" />
       </constraints>
     </entryLink>
     <entryLink id="762f-cfde-2bee-1aef" name="Chaos Land Raider" hidden="false" collective="false" import="true" targetId="ba7e-a053-3b01-0f3a" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
           </conditions>
         </modifier>
       </modifiers>
@@ -250,7 +250,7 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
           </conditions>
         </modifier>
       </modifiers>
@@ -261,8 +261,8 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -275,8 +275,8 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -287,7 +287,7 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
           </conditions>
         </modifier>
       </modifiers>
@@ -296,7 +296,7 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
           </conditions>
         </modifier>
       </modifiers>
@@ -307,22 +307,22 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
     </entryLink>
-    <entryLink id="190e-752b-a257-310e" name="Heldrake" hidden="false" collective="false" import="true" targetId="7935-7aa6-2360-63d5" type="selectionEntry"/>
-    <entryLink id="0e54-50d8-2345-967f" name="Khorne Lord of Skulls" hidden="false" collective="false" import="true" targetId="a091-f3a1-d9d7-5ab9" type="selectionEntry"/>
-    <entryLink id="ff0a-ee47-98c7-d1ea" name="Stratagem: Heroic Support" hidden="false" collective="false" import="true" targetId="cbd4-34fb-6ba6-9593" type="selectionEntry"/>
+    <entryLink id="190e-752b-a257-310e" name="Heldrake" hidden="false" collective="false" import="true" targetId="7935-7aa6-2360-63d5" type="selectionEntry" />
+    <entryLink id="0e54-50d8-2345-967f" name="Khorne Lord of Skulls" hidden="false" collective="false" import="true" targetId="a091-f3a1-d9d7-5ab9" type="selectionEntry" />
+    <entryLink id="ff0a-ee47-98c7-d1ea" name="Stratagem: Heroic Support" hidden="false" collective="false" import="true" targetId="cbd4-34fb-6ba6-9593" type="selectionEntry" />
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="709c-3853-42df-daa1" name="Angron" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3c20-3b82-10c7-8ace" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3c20-3b82-10c7-8ace" type="max" />
       </constraints>
       <profiles>
         <profile id="e48c-b789-6159-6d81" name="Angron 1 (10+ wounds remaining)" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -353,7 +353,7 @@
         </profile>
         <profile id="7738-dbe0-9f2a-a3d1" name="Angron 3 (1-5 wounds remaining)" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
-            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">10&quot;</characteristic>
+            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">8&quot;</characteristic>
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">2+</characteristic>
             <characteristic name="BS" typeId="381b-eb28-74c3-df5f">2+</characteristic>
             <characteristic name="S" typeId="2218-aa3c-265f-2939">9</characteristic>
@@ -385,29 +385,29 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="1f79-265b-660e-3b07" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="1a09-12f3-5d64-aa30" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="1f79-265b-660e-3b07" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="1a09-12f3-5d64-aa30" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="d914-5526-7db9-ca93" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="3a20-9cef-8a05-170f" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="2b63-96cc-f63d-41a8" name="Monster" hidden="false" targetId="3b77-decb-d468-6bcc" primary="false"/>
-        <categoryLink id="1194-b4f1-b3ef-d71f" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
-        <categoryLink id="36ed-a42d-34d6-8e99" name="Fly" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false"/>
-        <categoryLink id="8576-5daa-8b55-ff94" name="Supreme Commander" hidden="false" targetId="5750-de0a-589d-eacf" primary="false"/>
-        <categoryLink id="9394-881a-3c24-698c" name="Primarch" hidden="false" targetId="298f-d173-2159-919f" primary="false"/>
-        <categoryLink id="79dd-a7b3-e38a-f42e" name="Warp Locus" hidden="false" targetId="9c4d-556e-5ec1-7ad6" primary="false"/>
-        <categoryLink id="aee1-d2a7-39f0-6d11" name="Angron" hidden="false" targetId="9a45-e58b-0980-cd80" primary="false"/>
-        <categoryLink id="c8c2-50a2-db4d-65e0" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
-        <categoryLink id="da98-65f0-bc21-48ca" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="3c15-ceb7-dd8c-b195" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="9a23-e825-ee7a-b68f" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false"/>
+        <categoryLink id="d914-5526-7db9-ca93" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="3a20-9cef-8a05-170f" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="2b63-96cc-f63d-41a8" name="Monster" hidden="false" targetId="3b77-decb-d468-6bcc" primary="false" />
+        <categoryLink id="1194-b4f1-b3ef-d71f" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false" />
+        <categoryLink id="36ed-a42d-34d6-8e99" name="Fly" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false" />
+        <categoryLink id="8576-5daa-8b55-ff94" name="Supreme Commander" hidden="false" targetId="5750-de0a-589d-eacf" primary="false" />
+        <categoryLink id="9394-881a-3c24-698c" name="Primarch" hidden="false" targetId="298f-d173-2159-919f" primary="false" />
+        <categoryLink id="79dd-a7b3-e38a-f42e" name="Warp Locus" hidden="false" targetId="9c4d-556e-5ec1-7ad6" primary="false" />
+        <categoryLink id="aee1-d2a7-39f0-6d11" name="Angron" hidden="false" targetId="9a45-e58b-0980-cd80" primary="false" />
+        <categoryLink id="c8c2-50a2-db4d-65e0" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
+        <categoryLink id="da98-65f0-bc21-48ca" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="3c15-ceb7-dd8c-b195" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="9a23-e825-ee7a-b68f" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4472-e4eb-6eec-e7ee" name="Samni&apos;arius and Spinegrinder" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0672-06c9-b044-3920" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b04-932f-2586-1538" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0672-06c9-b044-3920" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b04-932f-2586-1538" type="max" />
           </constraints>
           <profiles>
             <profile id="2898-f97e-77ac-2872" name="Samni&apos;arius and Spinegrinder" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -442,9 +442,9 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="6905-129d-0353-129f" name="The Red Angel" hidden="true" collective="false" import="true" type="upgrade">
@@ -455,28 +455,28 @@
                   <conditionGroups>
                     <conditionGroup type="and">
                       <conditions>
-                        <condition field="selections" scope="709c-3853-42df-daa1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c798-5187-ae58-d556" type="equalTo"/>
-                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
-                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76d2-6e71-243f-ad3d" type="equalTo"/>
+                        <condition field="selections" scope="709c-3853-42df-daa1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c798-5187-ae58-d556" type="equalTo" />
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77a-cc54-efcf-a09a" type="equalTo" />
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76d2-6e71-243f-ad3d" type="equalTo" />
                       </conditions>
                     </conditionGroup>
                     <conditionGroup type="and">
                       <conditions>
-                        <condition field="selections" scope="709c-3853-42df-daa1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6771-6ab3-1672-6a39" type="equalTo"/>
+                        <condition field="selections" scope="709c-3853-42df-daa1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6771-6ab3-1672-6a39" type="equalTo" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </conditionGroup>
               </conditionGroups>
               <modifiers>
-                <modifier type="set" field="hidden" value="false"/>
-                <modifier type="set" field="4dad-a2ad-56db-a898" value="1.0"/>
+                <modifier type="set" field="hidden" value="false" />
+                <modifier type="set" field="4dad-a2ad-56db-a898" value="1.0" />
               </modifiers>
             </modifierGroup>
           </modifierGroups>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb84-5f11-27ac-7803" type="max"/>
-            <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4dad-a2ad-56db-a898" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb84-5f11-27ac-7803" type="max" />
+            <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4dad-a2ad-56db-a898" type="min" />
           </constraints>
           <profiles>
             <profile id="5d7d-d843-f8cf-9687" name="The Red Angel (Aura)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -486,42 +486,42 @@
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="9b46-9713-3f99-e728" name="Warlord" hidden="false" collective="false" import="true" targetId="c798-5187-ae58-d556" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e58a-78af-5fa2-7db4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e58a-78af-5fa2-7db4" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="b1b8-2797-d0c1-c09b" name="Stratagem: Warlord Trait" hidden="false" collective="false" import="true" targetId="6771-6ab3-1672-6a39" type="selectionEntry"/>
+        <entryLink id="b1b8-2797-d0c1-c09b" name="Stratagem: Warlord Trait" hidden="false" collective="false" import="true" targetId="6771-6ab3-1672-6a39" type="selectionEntry" />
       </entryLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="18.0"/>
-        <cost name="pts" typeId="points" value="360.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="18.0" />
+        <cost name="pts" typeId="points" value="360.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="c798-5187-ae58-d556" name="Warlord" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b465-f3c9-d72c-388b" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b465-f3c9-d72c-388b" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="d9e1-ac7f-b7b6-2ae3" name="Warlord" hidden="false" targetId="ae09-117e-a6fa-316b" primary="false"/>
+        <categoryLink id="d9e1-ac7f-b7b6-2ae3" name="Warlord" hidden="false" targetId="ae09-117e-a6fa-316b" primary="false" />
       </categoryLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="3ed9-a350-1375-253e" name="Khârn the Betrayer" page="" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9716-2fca-aabf-0f24" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9716-2fca-aabf-0f24" type="max" />
       </constraints>
       <profiles>
         <profile id="34b2-abd1-2648-23d8" name="Khârn the Betrayer" page="0" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -551,26 +551,26 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="b84f-4f97-2742-b231" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="4b44-f001-3b3d-f11d" name="Sigil of Corruption" hidden="false" targetId="be83-9fb0-70fb-44f4" type="profile"/>
-        <infoLink id="4b57-a402-2178-a47c" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="b84f-4f97-2742-b231" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="4b44-f001-3b3d-f11d" name="Sigil of Corruption" hidden="false" targetId="be83-9fb0-70fb-44f4" type="profile" />
+        <infoLink id="4b57-a402-2178-a47c" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a32d-7fc9-9f9d-3ca9" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
-        <categoryLink id="7da6-1148-d06d-cb4f" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="7971-dfc2-ff6f-abdb" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="690a-16f8-5063-c4b5" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-        <categoryLink id="c57e-873f-7610-cb54" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
-        <categoryLink id="e183-f986-6833-7c9a" name="Khârn the Betrayer" hidden="false" targetId="df1a-10b8-3827-fe77" primary="false"/>
-        <categoryLink id="2d5f-cec4-b2b7-506b" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="ed8e-7ceb-7403-a6ca" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="88c3-11c4-6855-3ced" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
+        <categoryLink id="a32d-7fc9-9f9d-3ca9" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true" />
+        <categoryLink id="7da6-1148-d06d-cb4f" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="7971-dfc2-ff6f-abdb" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="690a-16f8-5063-c4b5" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false" />
+        <categoryLink id="c57e-873f-7610-cb54" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false" />
+        <categoryLink id="e183-f986-6833-7c9a" name="Khârn the Betrayer" hidden="false" targetId="df1a-10b8-3827-fe77" primary="false" />
+        <categoryLink id="2d5f-cec4-b2b7-506b" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="ed8e-7ceb-7403-a6ca" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="88c3-11c4-6855-3ced" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6583-3d13-3eaf-2676" name="Gorechild" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7cf-0c03-5dd9-10a2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3218-9071-106d-30cf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7cf-0c03-5dd9-10a2" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3218-9071-106d-30cf" type="min" />
           </constraints>
           <profiles>
             <profile id="1071-3488-e46b-a9ba" name="Gorechild" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -585,15 +585,15 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0" />
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="0128-98a8-35a2-fb0f" name="Khârn&apos;s plasma pistol" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f20-e69f-510b-c950" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="516f-8dd7-df19-71d2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f20-e69f-510b-c950" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="516f-8dd7-df19-71d2" type="min" />
           </constraints>
           <profiles>
             <profile id="0cd9-f2ff-28cf-4796" name="Khârn&apos;s plasma pistol" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -608,9 +608,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0" />
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="9fc5-3788-c744-66df" name="Arch-slaughterer" hidden="true" collective="false" import="true" type="upgrade">
@@ -619,28 +619,28 @@ In a Boarding Action, this ability only affects friendly units that are visible 
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="3ed9-a350-1375-253e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6771-6ab3-1672-6a39" type="equalTo"/>
+                    <condition field="selections" scope="3ed9-a350-1375-253e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6771-6ab3-1672-6a39" type="equalTo" />
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="and">
                       <conditions>
-                        <condition field="selections" scope="3ed9-a350-1375-253e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c798-5187-ae58-d556" type="equalTo"/>
-                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
-                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76d2-6e71-243f-ad3d" type="equalTo"/>
+                        <condition field="selections" scope="3ed9-a350-1375-253e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c798-5187-ae58-d556" type="equalTo" />
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77a-cc54-efcf-a09a" type="equalTo" />
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76d2-6e71-243f-ad3d" type="equalTo" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </conditionGroup>
               </conditionGroups>
               <modifiers>
-                <modifier type="set" field="hidden" value="false"/>
-                <modifier type="set" field="455d-0723-9538-c1f0" value="1.0"/>
+                <modifier type="set" field="hidden" value="false" />
+                <modifier type="set" field="455d-0723-9538-c1f0" value="1.0" />
               </modifiers>
             </modifierGroup>
           </modifierGroups>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf00-1219-14fc-2f88" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="455d-0723-9538-c1f0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf00-1219-14fc-2f88" type="max" />
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="455d-0723-9538-c1f0" type="min" />
           </constraints>
           <profiles>
             <profile id="d782-7aee-fc78-6e6a" name="Arch-slaughterer" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -650,31 +650,31 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="173f-274d-7891-38e4" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34f1-1be5-d999-4b71" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f635-5215-9c7d-4c90" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34f1-1be5-d999-4b71" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f635-5215-9c7d-4c90" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="36af-2a39-9bf3-effb" name="Warlord" hidden="false" collective="false" import="true" targetId="c798-5187-ae58-d556" type="selectionEntry"/>
-        <entryLink id="e19d-018c-1b7a-a8bd" name="Stratagem: Warlord Trait" hidden="false" collective="false" import="true" targetId="6771-6ab3-1672-6a39" type="selectionEntry"/>
+        <entryLink id="36af-2a39-9bf3-effb" name="Warlord" hidden="false" collective="false" import="true" targetId="c798-5187-ae58-d556" type="selectionEntry" />
+        <entryLink id="e19d-018c-1b7a-a8bd" name="Stratagem: Warlord Trait" hidden="false" collective="false" import="true" targetId="6771-6ab3-1672-6a39" type="selectionEntry" />
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="140.0" />
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="3f7c-2cb9-a6c8-b08c" name="Lord Invocatus" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a932-8d37-f867-bd44" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a932-8d37-f867-bd44" type="max" />
       </constraints>
       <profiles>
         <profile id="b2ab-e4c7-9916-5237" name="Lord Invocatus" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -692,30 +692,30 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="220c-0333-56b3-908f" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="1d5f-d9ef-3b2d-dd3a" name="Sigil of Corruption" hidden="false" targetId="be83-9fb0-70fb-44f4" type="profile"/>
-        <infoLink id="40f2-c411-dfd6-600d" name="Warp Strike" hidden="false" targetId="04e9-0e24-3b6e-8f06" type="rule"/>
-        <infoLink id="ea1b-0eab-7217-2b02" name="Leading the Charge (Aura)" hidden="false" targetId="ba46-e3a8-a227-7982" type="profile"/>
-        <infoLink id="2805-69e4-8cea-3afa" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="220c-0333-56b3-908f" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="1d5f-d9ef-3b2d-dd3a" name="Sigil of Corruption" hidden="false" targetId="be83-9fb0-70fb-44f4" type="profile" />
+        <infoLink id="40f2-c411-dfd6-600d" name="Warp Strike" hidden="false" targetId="04e9-0e24-3b6e-8f06" type="rule" />
+        <infoLink id="ea1b-0eab-7217-2b02" name="Leading the Charge (Aura)" hidden="false" targetId="ba46-e3a8-a227-7982" type="profile" />
+        <infoLink id="2805-69e4-8cea-3afa" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="be83-3d5c-b1de-345b" name="HQ" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
-        <categoryLink id="20ac-dbb5-c631-51a7" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="8306-d8af-f2e9-c7d0" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="c8c4-7a3e-05eb-8f5d" name="Cavalry" hidden="false" targetId="ad01-caec-17d9-cb8d" primary="false"/>
-        <categoryLink id="63d8-a3e8-fbe8-e5b9" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
-        <categoryLink id="3065-0b3e-3d3a-677d" name="Fly" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false"/>
-        <categoryLink id="c9de-4896-08d1-b40e" name="Lord Invocatus" hidden="false" targetId="bf74-355d-6bc8-abe5" primary="false"/>
-        <categoryLink id="e7b1-2b88-4cd4-affd" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="d6a2-d1bd-546c-c248" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="3cfa-2653-4a6d-77c2" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false"/>
-        <categoryLink id="d813-a672-89eb-abd1" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
+        <categoryLink id="be83-3d5c-b1de-345b" name="HQ" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true" />
+        <categoryLink id="20ac-dbb5-c631-51a7" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="8306-d8af-f2e9-c7d0" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="c8c4-7a3e-05eb-8f5d" name="Cavalry" hidden="false" targetId="ad01-caec-17d9-cb8d" primary="false" />
+        <categoryLink id="63d8-a3e8-fbe8-e5b9" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false" />
+        <categoryLink id="3065-0b3e-3d3a-677d" name="Fly" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false" />
+        <categoryLink id="c9de-4896-08d1-b40e" name="Lord Invocatus" hidden="false" targetId="bf74-355d-6bc8-abe5" primary="false" />
+        <categoryLink id="e7b1-2b88-4cd4-affd" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="d6a2-d1bd-546c-c248" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="3cfa-2653-4a6d-77c2" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false" />
+        <categoryLink id="d813-a672-89eb-abd1" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0acb-5640-a760-6834" name="Coward&apos;s Bane" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6a6-4c12-48c5-431d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cef0-36b2-8cc7-ce85" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6a6-4c12-48c5-431d" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cef0-36b2-8cc7-ce85" type="max" />
           </constraints>
           <profiles>
             <profile id="6cf3-18eb-9460-9fa2" name="Coward&apos;s Bane" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -730,9 +730,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="41ac-e815-6dc7-601d" name="Road of Eight Bloody Steps" hidden="true" collective="false" import="true" type="upgrade">
@@ -741,28 +741,28 @@ In a Boarding Action, this ability only affects friendly units that are visible 
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="3f7c-2cb9-a6c8-b08c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6771-6ab3-1672-6a39" type="equalTo"/>
+                    <condition field="selections" scope="3f7c-2cb9-a6c8-b08c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6771-6ab3-1672-6a39" type="equalTo" />
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="and">
                       <conditions>
-                        <condition field="selections" scope="3f7c-2cb9-a6c8-b08c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c798-5187-ae58-d556" type="equalTo"/>
-                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
-                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76d2-6e71-243f-ad3d" type="equalTo"/>
+                        <condition field="selections" scope="3f7c-2cb9-a6c8-b08c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c798-5187-ae58-d556" type="equalTo" />
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77a-cc54-efcf-a09a" type="equalTo" />
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76d2-6e71-243f-ad3d" type="equalTo" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </conditionGroup>
               </conditionGroups>
               <modifiers>
-                <modifier type="set" field="hidden" value="false"/>
-                <modifier type="set" field="afba-648d-bd8f-eca5" value="1.0"/>
+                <modifier type="set" field="hidden" value="false" />
+                <modifier type="set" field="afba-648d-bd8f-eca5" value="1.0" />
               </modifiers>
             </modifierGroup>
           </modifierGroups>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7c1-677f-8da4-0977" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afba-648d-bd8f-eca5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7c1-677f-8da4-0977" type="max" />
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afba-648d-bd8f-eca5" type="min" />
           </constraints>
           <profiles>
             <profile id="82c7-37a8-0df9-89e1" name="Road of Eight Bloody Steps" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -772,39 +772,39 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="d82b-6e7d-7200-7b6d" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="0334-f487-8229-0c1a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f06a-2efb-365d-8d45" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7d1-5580-9847-d3e4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f06a-2efb-365d-8d45" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7d1-5580-9847-d3e4" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="969f-c322-11bd-9c65" name="Juggernaut&apos;s bladed horn" hidden="false" collective="false" import="true" targetId="8c33-e283-55f6-dbde" type="selectionEntry"/>
+        <entryLink id="969f-c322-11bd-9c65" name="Juggernaut&apos;s bladed horn" hidden="false" collective="false" import="true" targetId="8c33-e283-55f6-dbde" type="selectionEntry" />
         <entryLink id="2c3e-d919-82dd-334c" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f5c-63a8-b284-5e06" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f223-eb74-cba3-c7e5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f5c-63a8-b284-5e06" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f223-eb74-cba3-c7e5" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="764e-f35b-abc4-0918" name="Warlord" hidden="false" collective="false" import="true" targetId="c798-5187-ae58-d556" type="selectionEntry"/>
-        <entryLink id="b66b-dc72-3364-ec9d" name="Stratagem: Warlord Trait" hidden="false" collective="false" import="true" targetId="6771-6ab3-1672-6a39" type="selectionEntry"/>
+        <entryLink id="764e-f35b-abc4-0918" name="Warlord" hidden="false" collective="false" import="true" targetId="c798-5187-ae58-d556" type="selectionEntry" />
+        <entryLink id="b66b-dc72-3364-ec9d" name="Stratagem: Warlord Trait" hidden="false" collective="false" import="true" targetId="6771-6ab3-1672-6a39" type="selectionEntry" />
       </entryLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
-        <cost name="pts" typeId="points" value="160.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0" />
+        <cost name="pts" typeId="points" value="160.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="8c33-e283-55f6-dbde" name="Juggernaut&apos;s bladed horn" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f69-65e2-ef71-cfd4" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b30-bda2-47d0-9c54" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f69-65e2-ef71-cfd4" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b30-bda2-47d0-9c54" type="max" />
       </constraints>
       <profiles>
         <profile id="b7c4-ec4c-c317-6aaa" name="Juggernaut&apos;s bladed horn" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -819,33 +819,33 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="19b5-e189-b896-f8d5" name="World Eaters Daemon Prince" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="increment" field="84e8-a132-adc0-c1e6" value="1.0">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cbd4-34fb-6ba6-9593" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cbd4-34fb-6ba6-9593" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84e8-a132-adc0-c1e6" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84e8-a132-adc0-c1e6" type="max" />
       </constraints>
       <profiles>
         <profile id="64fe-bc44-644c-009c" name="World Eaters Daemon Prince" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <modifiers>
             <modifier type="set" field="0bdf-a96e-9e38-7779" value="12&quot;">
               <conditions>
-                <condition field="selections" scope="19b5-e189-b896-f8d5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="13e8-96de-68fa-d7c4" type="equalTo"/>
+                <condition field="selections" scope="19b5-e189-b896-f8d5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="13e8-96de-68fa-d7c4" type="equalTo" />
               </conditions>
             </modifier>
             <modifier type="increment" field="f330-5e6e-4110-0978" value="1">
               <conditions>
-                <condition field="selections" scope="19b5-e189-b896-f8d5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9aad-1c65-1c8e-a77c" type="equalTo"/>
+                <condition field="selections" scope="19b5-e189-b896-f8d5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9aad-1c65-1c8e-a77c" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -873,40 +873,40 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="f259-031f-b998-5dc1" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="e8e0-61e8-aafa-65a3" name="Fearsome (Aura)" hidden="false" targetId="a372-a03b-a7b3-864c" type="profile"/>
-        <infoLink id="ed8b-fd82-b1b5-4869" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="f259-031f-b998-5dc1" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="e8e0-61e8-aafa-65a3" name="Fearsome (Aura)" hidden="false" targetId="a372-a03b-a7b3-864c" type="profile" />
+        <infoLink id="ed8b-fd82-b1b5-4869" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2c3c-c57b-5d74-1699" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
-        <categoryLink id="2871-f8ae-dfb5-f6fe" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="e283-64b9-b486-dbe9" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="5c46-3c34-9181-8983" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="69ff-4fa6-1267-53ee" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="ded8-cee3-90c5-a61b" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
-        <categoryLink id="6aa7-ce3c-080d-e697" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
-        <categoryLink id="0670-7a7d-4e38-56a4" name="Monster" hidden="false" targetId="3b77-decb-d468-6bcc" primary="false"/>
-        <categoryLink id="6d9d-b35e-ef47-c032" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false"/>
-        <categoryLink id="a654-a312-2664-9901" name="Daemon Prince" hidden="false" targetId="d8d3-6bf7-9b21-8e58" primary="false"/>
+        <categoryLink id="2c3c-c57b-5d74-1699" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true" />
+        <categoryLink id="2871-f8ae-dfb5-f6fe" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="e283-64b9-b486-dbe9" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="5c46-3c34-9181-8983" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="69ff-4fa6-1267-53ee" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="ded8-cee3-90c5-a61b" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
+        <categoryLink id="6aa7-ce3c-080d-e697" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false" />
+        <categoryLink id="0670-7a7d-4e38-56a4" name="Monster" hidden="false" targetId="3b77-decb-d468-6bcc" primary="false" />
+        <categoryLink id="6d9d-b35e-ef47-c032" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false" />
+        <categoryLink id="a654-a312-2664-9901" name="Daemon Prince" hidden="false" targetId="d8d3-6bf7-9b21-8e58" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="13e8-96de-68fa-d7c4" name="Wings" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d45-75e4-a287-e3e0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d45-75e4-a287-e3e0" type="max" />
           </constraints>
           <categoryLinks>
-            <categoryLink id="4ad6-cd4d-a68a-c1ae" name="Fly" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false"/>
+            <categoryLink id="4ad6-cd4d-a68a-c1ae" name="Fly" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false" />
           </categoryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="35.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="35.0" />
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="2d81-b075-925a-2f11" name="Infernal cannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b044-ceb4-8a47-c2fc" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e987-69b2-a86b-cff4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b044-ceb4-8a47-c2fc" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e987-69b2-a86b-cff4" type="max" />
           </constraints>
           <profiles>
             <profile id="9c42-3203-1147-fdc9" name="Infernal cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -921,17 +921,17 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="fd36-1020-67f5-bceb" name="Hellforged sword options" hidden="false" collective="false" import="true" defaultSelectionEntryId="d31d-b680-59a7-8f44">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3b9-444b-217d-df4e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30b4-eb00-671a-84b9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3b9-444b-217d-df4e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30b4-eb00-671a-84b9" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="0d79-b472-5777-60c2" name="Daemonic axe" hidden="false" collective="false" import="true" type="upgrade">
@@ -948,9 +948,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="d31d-b680-59a7-8f44" name="Hellforged sword" hidden="false" collective="false" import="true" type="upgrade">
@@ -967,34 +967,34 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="dc11-b78c-c8f6-0ee3" name="Malefic talons" hidden="false" collective="false" import="true" targetId="1239-a9d9-5941-fcc2" type="selectionEntry"/>
+            <entryLink id="dc11-b78c-c8f6-0ee3" name="Malefic talons" hidden="false" collective="false" import="true" targetId="1239-a9d9-5941-fcc2" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="259a-00dd-31c8-7175" name="Warlord" hidden="false" collective="false" import="true" targetId="c798-5187-ae58-d556" type="selectionEntry"/>
-        <entryLink id="6bfa-0608-78dd-2020" name="Stratagem: Warlord Trait" hidden="false" collective="false" import="true" targetId="6771-6ab3-1672-6a39" type="selectionEntry"/>
-        <entryLink id="8d02-63f2-37e8-0572" name="Stratagem: Relic" hidden="false" collective="false" import="true" targetId="c470-54ac-0863-8848" type="selectionEntry"/>
+        <entryLink id="259a-00dd-31c8-7175" name="Warlord" hidden="false" collective="false" import="true" targetId="c798-5187-ae58-d556" type="selectionEntry" />
+        <entryLink id="6bfa-0608-78dd-2020" name="Stratagem: Warlord Trait" hidden="false" collective="false" import="true" targetId="6771-6ab3-1672-6a39" type="selectionEntry" />
+        <entryLink id="8d02-63f2-37e8-0572" name="Stratagem: Relic" hidden="false" collective="false" import="true" targetId="c470-54ac-0863-8848" type="selectionEntry" />
         <entryLink id="02e1-f02a-4f23-cd09" name="Malefic talons" hidden="false" collective="false" import="true" targetId="1239-a9d9-5941-fcc2" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cd3-d77b-7e8e-7cd9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e7c6-01d9-a76e-53c6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cd3-d77b-7e8e-7cd9" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e7c6-01d9-a76e-53c6" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="9b6a-9dcf-8244-4768" name="Relics" hidden="false" collective="false" import="true" targetId="6cc9-72bf-bcb0-d363" type="selectionEntryGroup"/>
-        <entryLink id="d20f-0c5b-2a70-5267" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="08ae-516d-0095-4a60" type="selectionEntryGroup"/>
+        <entryLink id="9b6a-9dcf-8244-4768" name="Relics" hidden="false" collective="false" import="true" targetId="6cc9-72bf-bcb0-d363" type="selectionEntryGroup" />
+        <entryLink id="d20f-0c5b-2a70-5267" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="08ae-516d-0095-4a60" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
-        <cost name="pts" typeId="points" value="130.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0" />
+        <cost name="pts" typeId="points" value="130.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="1239-a9d9-5941-fcc2" name="Malefic talons" hidden="false" collective="false" import="true" type="upgrade">
@@ -1011,9 +1011,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="8328-9c8a-56f1-4066" name="World Eaters Lord on Juggernaut" hidden="false" collective="false" import="true" type="model">
@@ -1022,7 +1022,7 @@ In a Boarding Action, this ability only affects friendly units that are visible 
           <modifiers>
             <modifier type="increment" field="f330-5e6e-4110-0978" value="1">
               <conditions>
-                <condition field="selections" scope="8328-9c8a-56f1-4066" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9aad-1c65-1c8e-a77c" type="equalTo"/>
+                <condition field="selections" scope="8328-9c8a-56f1-4066" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9aad-1c65-1c8e-a77c" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -1040,28 +1040,28 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="d426-1931-d0ec-2251" name="Leading the Charge (Aura)" hidden="false" targetId="ba46-e3a8-a227-7982" type="profile"/>
-        <infoLink id="9e68-0936-a5eb-cbfb" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="7277-a1e2-e8e8-c1e0" name="Sigil of Corruption" hidden="false" targetId="be83-9fb0-70fb-44f4" type="profile"/>
-        <infoLink id="b5cb-0ef8-8c70-f0fd" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="d426-1931-d0ec-2251" name="Leading the Charge (Aura)" hidden="false" targetId="ba46-e3a8-a227-7982" type="profile" />
+        <infoLink id="9e68-0936-a5eb-cbfb" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="7277-a1e2-e8e8-c1e0" name="Sigil of Corruption" hidden="false" targetId="be83-9fb0-70fb-44f4" type="profile" />
+        <infoLink id="b5cb-0ef8-8c70-f0fd" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0eb0-13af-e8aa-3d17" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
-        <categoryLink id="8cde-e451-5125-a8dc" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="bcbd-c727-1702-45e4" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="c537-a388-49ba-f3b6" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="1796-abce-a049-d5f9" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="5fff-f7e0-7b89-5b33" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
-        <categoryLink id="cac6-5889-47dd-fdcc" name="Cavalry" hidden="false" targetId="ad01-caec-17d9-cb8d" primary="false"/>
-        <categoryLink id="a13a-2ef8-1494-f6b8" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
-        <categoryLink id="93cb-3f9a-df51-a692" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false"/>
-        <categoryLink id="973d-e1c3-39cb-dbad" name="World Eaters Lord" hidden="false" targetId="6672-bdc5-34dc-68f2" primary="false"/>
+        <categoryLink id="0eb0-13af-e8aa-3d17" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true" />
+        <categoryLink id="8cde-e451-5125-a8dc" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="bcbd-c727-1702-45e4" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="c537-a388-49ba-f3b6" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="1796-abce-a049-d5f9" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="5fff-f7e0-7b89-5b33" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
+        <categoryLink id="cac6-5889-47dd-fdcc" name="Cavalry" hidden="false" targetId="ad01-caec-17d9-cb8d" primary="false" />
+        <categoryLink id="a13a-2ef8-1494-f6b8" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false" />
+        <categoryLink id="93cb-3f9a-df51-a692" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false" />
+        <categoryLink id="973d-e1c3-39cb-dbad" name="World Eaters Lord" hidden="false" targetId="6672-bdc5-34dc-68f2" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b897-4c20-8b4f-4513" name="Exalted chainblade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9612-f498-627c-e7cc" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12c1-e4e6-c42a-398f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9612-f498-627c-e7cc" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12c1-e4e6-c42a-398f" type="max" />
           </constraints>
           <profiles>
             <profile id="7dfe-3f48-3db2-8ed5" name="Exalted chainblade" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -1076,55 +1076,55 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="b252-d1b0-72e3-ba31" name="Plasma pistol" hidden="false" collective="false" import="true" targetId="83be-1ba9-c326-4760" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="518a-776e-fa1f-3537" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1989-6afc-b42b-d5f3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="518a-776e-fa1f-3537" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1989-6afc-b42b-d5f3" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="9e22-4c53-ad53-9544" name="Juggernaut&apos;s bladed horn" hidden="false" collective="false" import="true" targetId="8c33-e283-55f6-dbde" type="selectionEntry"/>
+        <entryLink id="9e22-4c53-ad53-9544" name="Juggernaut&apos;s bladed horn" hidden="false" collective="false" import="true" targetId="8c33-e283-55f6-dbde" type="selectionEntry" />
         <entryLink id="b885-ab2b-39e4-6a20" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a667-92be-591e-34c2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91e2-0b33-75c7-2c1d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a667-92be-591e-34c2" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91e2-0b33-75c7-2c1d" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="1522-cbeb-fe17-b463" name="Warlord" hidden="false" collective="false" import="true" targetId="c798-5187-ae58-d556" type="selectionEntry"/>
-        <entryLink id="56d8-9996-59e4-1438" name="Stratagem: Relic" hidden="false" collective="false" import="true" targetId="c470-54ac-0863-8848" type="selectionEntry"/>
-        <entryLink id="460e-420e-ee5c-6424" name="Stratagem: Warlord Trait" hidden="false" collective="false" import="true" targetId="6771-6ab3-1672-6a39" type="selectionEntry"/>
-        <entryLink id="3b4d-8bee-53bd-317d" name="Relics" hidden="false" collective="false" import="true" targetId="6cc9-72bf-bcb0-d363" type="selectionEntryGroup"/>
-        <entryLink id="64c1-578e-e79c-5294" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="08ae-516d-0095-4a60" type="selectionEntryGroup"/>
+        <entryLink id="1522-cbeb-fe17-b463" name="Warlord" hidden="false" collective="false" import="true" targetId="c798-5187-ae58-d556" type="selectionEntry" />
+        <entryLink id="56d8-9996-59e4-1438" name="Stratagem: Relic" hidden="false" collective="false" import="true" targetId="c470-54ac-0863-8848" type="selectionEntry" />
+        <entryLink id="460e-420e-ee5c-6424" name="Stratagem: Warlord Trait" hidden="false" collective="false" import="true" targetId="6771-6ab3-1672-6a39" type="selectionEntry" />
+        <entryLink id="3b4d-8bee-53bd-317d" name="Relics" hidden="false" collective="false" import="true" targetId="6cc9-72bf-bcb0-d363" type="selectionEntryGroup" />
+        <entryLink id="64c1-578e-e79c-5294" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="08ae-516d-0095-4a60" type="selectionEntryGroup" />
         <entryLink id="e0b6-76de-9db7-7af1" name="Boarding Action Enhancements" hidden="false" collective="false" import="true" targetId="4c50-9343-b5fb-872d" type="selectionEntryGroup">
           <entryLinks>
-            <entryLink id="26b7-5316-512a-66b5" name="Battle Lust (World Eaters)" hidden="false" collective="false" import="true" targetId="5f56-3e66-62d8-d2f0" type="selectionEntry"/>
-            <entryLink id="3fbf-10c5-7e20-86ed" name="Burning Plate (World Eaters)" hidden="false" collective="false" import="true" targetId="5906-060d-ef33-f8cf" type="selectionEntry"/>
-            <entryLink id="4f7e-472c-e32d-8021" name="Mutable Form (World Eaters)" hidden="false" collective="false" import="true" targetId="bca6-9f88-efc2-3b7f" type="selectionEntry"/>
+            <entryLink id="26b7-5316-512a-66b5" name="Battle Lust (World Eaters)" hidden="false" collective="false" import="true" targetId="5f56-3e66-62d8-d2f0" type="selectionEntry" />
+            <entryLink id="3fbf-10c5-7e20-86ed" name="Burning Plate (World Eaters)" hidden="false" collective="false" import="true" targetId="5906-060d-ef33-f8cf" type="selectionEntry" />
+            <entryLink id="4f7e-472c-e32d-8021" name="Mutable Form (World Eaters)" hidden="false" collective="false" import="true" targetId="bca6-9f88-efc2-3b7f" type="selectionEntry" />
           </entryLinks>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="125.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="125.0" />
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="d96e-ed0c-06f8-4fa5" name="World Eaters Master of Executions" page="" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="deb7-1e7a-2710-77e3" value="1.0">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="deb7-1e7a-2710-77e3" type="max"/>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="deb7-1e7a-2710-77e3" type="max" />
       </constraints>
       <profiles>
         <profile id="023d-b32e-17d4-adf0" name="Trophy-taker" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1141,7 +1141,7 @@ In a Boarding Action, this ability only affects friendly units that are visible 
           <modifiers>
             <modifier type="increment" field="f330-5e6e-4110-0978" value="1">
               <conditions>
-                <condition field="selections" scope="d96e-ed0c-06f8-4fa5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9aad-1c65-1c8e-a77c" type="equalTo"/>
+                <condition field="selections" scope="d96e-ed0c-06f8-4fa5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9aad-1c65-1c8e-a77c" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -1159,24 +1159,24 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="db88-3b54-da8d-42a8" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="db88-3b54-da8d-42a8" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2da4-6f88-e03d-766e" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="72f8-0d56-d254-3bc4" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-        <categoryLink id="4707-f0a3-339d-621f" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
-        <categoryLink id="20de-caef-24cf-47e7" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
-        <categoryLink id="ffd4-7518-1d85-25f4" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="9409-56ef-b5ce-69f4" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="6319-58ca-7221-2c9f" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="596b-0da0-a138-fe8b" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
-        <categoryLink id="94df-a733-4faf-3875" name="Master of Executions" hidden="false" targetId="9375-72bf-28af-27aa" primary="false"/>
+        <categoryLink id="2da4-6f88-e03d-766e" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="72f8-0d56-d254-3bc4" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false" />
+        <categoryLink id="4707-f0a3-339d-621f" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false" />
+        <categoryLink id="20de-caef-24cf-47e7" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true" />
+        <categoryLink id="ffd4-7518-1d85-25f4" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="9409-56ef-b5ce-69f4" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="6319-58ca-7221-2c9f" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="596b-0da0-a138-fe8b" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
+        <categoryLink id="94df-a733-4faf-3875" name="Master of Executions" hidden="false" targetId="9375-72bf-28af-27aa" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="25ff-476c-ef1a-d84e" name="Axe of dismemberment" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c94-39df-bad0-1824" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08dc-bc04-781d-6d49" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c94-39df-bad0-1824" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08dc-bc04-781d-6d49" type="max" />
           </constraints>
           <profiles>
             <profile id="8875-120c-4b0e-e74e" name="Axe of dismemberment" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -1191,50 +1191,50 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="4949-2cb0-615f-6611" name="Warlord" hidden="false" collective="false" import="true" targetId="c798-5187-ae58-d556" type="selectionEntry"/>
+        <entryLink id="4949-2cb0-615f-6611" name="Warlord" hidden="false" collective="false" import="true" targetId="c798-5187-ae58-d556" type="selectionEntry" />
         <entryLink id="0c17-86c3-1732-f31d" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="0334-f487-8229-0c1a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6b1-ce3a-4876-f38e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afe3-d0e3-3723-e5f1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6b1-ce3a-4876-f38e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afe3-d0e3-3723-e5f1" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="39b4-bae7-aa41-614c" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b81-e6b4-09f5-2156" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c981-a765-e39d-9a0d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b81-e6b4-09f5-2156" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c981-a765-e39d-9a0d" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="7f76-0d9c-8fc4-3945" name="Stratagem: Warlord Trait" hidden="false" collective="false" import="true" targetId="6771-6ab3-1672-6a39" type="selectionEntry"/>
-        <entryLink id="f80a-1c4a-fa65-1819" name="Stratagem: Relic" hidden="false" collective="false" import="true" targetId="c470-54ac-0863-8848" type="selectionEntry"/>
-        <entryLink id="a99c-be6e-bcd6-26b1" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup"/>
-        <entryLink id="40d0-e6b5-e73a-2ebb" name="Relics" hidden="false" collective="false" import="true" targetId="6cc9-72bf-bcb0-d363" type="selectionEntryGroup"/>
-        <entryLink id="43b4-5e92-a6d2-186b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="08ae-516d-0095-4a60" type="selectionEntryGroup"/>
+        <entryLink id="7f76-0d9c-8fc4-3945" name="Stratagem: Warlord Trait" hidden="false" collective="false" import="true" targetId="6771-6ab3-1672-6a39" type="selectionEntry" />
+        <entryLink id="f80a-1c4a-fa65-1819" name="Stratagem: Relic" hidden="false" collective="false" import="true" targetId="c470-54ac-0863-8848" type="selectionEntry" />
+        <entryLink id="a99c-be6e-bcd6-26b1" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup" />
+        <entryLink id="40d0-e6b5-e73a-2ebb" name="Relics" hidden="false" collective="false" import="true" targetId="6cc9-72bf-bcb0-d363" type="selectionEntryGroup" />
+        <entryLink id="43b4-5e92-a6d2-186b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="08ae-516d-0095-4a60" type="selectionEntryGroup" />
         <entryLink id="bbcb-343e-64f5-8c17" name="Boarding Action Enhancements" hidden="false" collective="false" import="true" targetId="4c50-9343-b5fb-872d" type="selectionEntryGroup">
           <entryLinks>
-            <entryLink id="4ea5-63fb-502e-2df6" name="Battle Lust (World Eaters)" hidden="false" collective="false" import="true" targetId="5f56-3e66-62d8-d2f0" type="selectionEntry"/>
-            <entryLink id="75b2-88a4-7605-6ec5" name="Burning Plate (World Eaters)" hidden="false" collective="false" import="true" targetId="5906-060d-ef33-f8cf" type="selectionEntry"/>
-            <entryLink id="180e-1511-e0ff-7592" name="Mutable Form (World Eaters)" hidden="false" collective="false" import="true" targetId="bca6-9f88-efc2-3b7f" type="selectionEntry"/>
+            <entryLink id="4ea5-63fb-502e-2df6" name="Battle Lust (World Eaters)" hidden="false" collective="false" import="true" targetId="5f56-3e66-62d8-d2f0" type="selectionEntry" />
+            <entryLink id="75b2-88a4-7605-6ec5" name="Burning Plate (World Eaters)" hidden="false" collective="false" import="true" targetId="5906-060d-ef33-f8cf" type="selectionEntry" />
+            <entryLink id="180e-1511-e0ff-7592" name="Mutable Form (World Eaters)" hidden="false" collective="false" import="true" targetId="bca6-9f88-efc2-3b7f" type="selectionEntry" />
           </entryLinks>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="65.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="65.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="da50-32c3-ef5f-2baf" name="Khorne Berserkers" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="e356-c769-5920-6e14" value="12.0">
           <conditions>
-            <condition field="selections" scope="da50-32c3-ef5f-2baf" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+            <condition field="selections" scope="da50-32c3-ef5f-2baf" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
@@ -1243,7 +1243,7 @@ In a Boarding Action, this ability only affects friendly units that are visible 
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
               </conditions>
             </modifier>
           </modifiers>
@@ -1253,26 +1253,26 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="08c8-5e08-74fb-45b5" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="b80c-e160-6795-116e" name="Objective Secured" hidden="false" targetId="e07e-8dbf-0b15-7485" type="rule"/>
-        <infoLink id="b449-f964-f067-416e" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="08c8-5e08-74fb-45b5" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="b80c-e160-6795-116e" name="Objective Secured" hidden="false" targetId="e07e-8dbf-0b15-7485" type="rule" />
+        <infoLink id="b449-f964-f067-416e" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a9a9-c777-c4f4-2907" name="New CategoryLink" hidden="false" targetId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" primary="true"/>
-        <categoryLink id="d3df-934a-b52d-e53b" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="686f-da2d-6e5a-24b3" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="7a78-ab2a-98e2-3d26" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="79fb-f513-5be2-53ca" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="b7eb-f4d4-76bd-3a71" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
-        <categoryLink id="d0a5-5a9c-bbbc-7967" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-        <categoryLink id="59d9-b294-ab04-5de7" name="Core" hidden="false" targetId="08f1-d244-eb44-7e01" primary="false"/>
-        <categoryLink id="27cf-2a7b-abf2-b3b6" name="Khorne Berserkers" hidden="false" targetId="a010-81a3-ed60-ba97" primary="false"/>
+        <categoryLink id="a9a9-c777-c4f4-2907" name="New CategoryLink" hidden="false" targetId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" primary="true" />
+        <categoryLink id="d3df-934a-b52d-e53b" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="686f-da2d-6e5a-24b3" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="7a78-ab2a-98e2-3d26" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="79fb-f513-5be2-53ca" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="b7eb-f4d4-76bd-3a71" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
+        <categoryLink id="d0a5-5a9c-bbbc-7967" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false" />
+        <categoryLink id="59d9-b294-ab04-5de7" name="Core" hidden="false" targetId="08f1-d244-eb44-7e01" primary="false" />
+        <categoryLink id="27cf-2a7b-abf2-b3b6" name="Khorne Berserkers" hidden="false" targetId="a010-81a3-ed60-ba97" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="debe-8d93-2998-05af" name="Khorne Berserker Champion" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af3d-ec81-2948-7fa9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="687d-c0a9-6754-77f6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af3d-ec81-2948-7fa9" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="687d-c0a9-6754-77f6" type="max" />
           </constraints>
           <profiles>
             <profile id="1bae-ba1f-90db-8b84" name="Khorne Berserker Champion" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -1292,14 +1292,14 @@ In a Boarding Action, this ability only affects friendly units that are visible 
           <selectionEntryGroups>
             <selectionEntryGroup id="d031-1ed5-a284-6fcd" name="Pistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="ff4d-5b19-7ced-2329">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1981-9298-0bdb-74ff" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6888-2d2e-92e0-6243" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1981-9298-0bdb-74ff" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6888-2d2e-92e0-6243" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="ff4d-5b19-7ced-2329" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="0334-f487-8229-0c1a" type="selectionEntry"/>
+                <entryLink id="ff4d-5b19-7ced-2329" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="0334-f487-8229-0c1a" type="selectionEntry" />
                 <entryLink id="fda7-46c7-ba3e-1c95" name="Plasma pistol" hidden="false" collective="false" import="true" targetId="83be-1ba9-c326-4760" type="selectionEntry">
                   <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
+                    <cost name="pts" typeId="points" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1308,19 +1308,19 @@ In a Boarding Action, this ability only affects friendly units that are visible 
           <entryLinks>
             <entryLink id="a1c7-ed49-5212-337d" name="Berserker chainblade" hidden="false" collective="false" import="true" targetId="e237-802f-ab61-9faa" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="880d-2d0b-81ad-aa97" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="880d-2d0b-81ad-aa97" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="22.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="22.0" />
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="563e-091f-0870-f344" name="Berserker icon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce58-0e77-5916-b2e0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce58-0e77-5916-b2e0" type="max" />
           </constraints>
           <profiles>
             <profile id="b9cc-069a-1bee-8a4a" name="Berserker icon" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1330,25 +1330,25 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="48c5-c7cd-6bca-6789" name="Icon" hidden="false" targetId="3db4-481a-d6ce-d2ad" primary="false"/>
+            <categoryLink id="48c5-c7cd-6bca-6789" name="Icon" hidden="false" targetId="3db4-481a-d6ce-d2ad" primary="false" />
           </categoryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="5.0" />
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="f8f9-5fa6-74df-aba0" name="4 - 9 Khorne Berserkers" hidden="false" collective="false" import="true" defaultSelectionEntryId="2131-697a-228e-0884">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f650-d002-733d-6956" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7632-e054-6af2-2fd8" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f650-d002-733d-6956" type="min" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7632-e054-6af2-2fd8" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="2131-697a-228e-0884" name="Khorne Berserker w/ chainblade" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47ea-0861-bea6-93be" type="max"/>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47ea-0861-bea6-93be" type="max" />
               </constraints>
               <profiles>
                 <profile id="5740-a485-faa8-dcdf" name="Khorne Berserker" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -1368,35 +1368,35 @@ In a Boarding Action, this ability only affects friendly units that are visible 
               <entryLinks>
                 <entryLink id="efb5-4b2d-3493-39ab" name="Berserker chainblade" hidden="false" collective="false" import="true" targetId="e237-802f-ab61-9faa" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70bf-93d0-0310-a072" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70bf-93d0-0310-a072" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="f9db-87d1-9636-1e0f" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="37d3-7098-d596-9948" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c178-a53d-f201-4af2" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ceed-53c7-f8cf-6348" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c178-a53d-f201-4af2" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ceed-53c7-f8cf-6348" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="22.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="22.0" />
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="d1fc-41b4-1ae1-0fa6" name="Khorne Berserker w/ weapon upgrade" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="9b81-d400-1c6d-e22e" value="2.0">
                   <conditions>
-                    <condition field="selections" scope="da50-32c3-ef5f-2baf" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                    <condition field="selections" scope="da50-32c3-ef5f-2baf" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="name" value="Khorne Berserker w/ eviscerator">
                   <conditionGroups>
                     <conditionGroup type="and">
                       <conditions>
-                        <condition field="selections" scope="d1fc-41b4-1ae1-0fa6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83be-1ba9-c326-4760" type="equalTo"/>
-                        <condition field="selections" scope="d1fc-41b4-1ae1-0fa6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45a4-d5cd-d5cc-472a" type="equalTo"/>
+                        <condition field="selections" scope="d1fc-41b4-1ae1-0fa6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83be-1ba9-c326-4760" type="equalTo" />
+                        <condition field="selections" scope="d1fc-41b4-1ae1-0fa6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45a4-d5cd-d5cc-472a" type="equalTo" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -1405,8 +1405,8 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                   <conditionGroups>
                     <conditionGroup type="and">
                       <conditions>
-                        <condition field="selections" scope="d1fc-41b4-1ae1-0fa6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83be-1ba9-c326-4760" type="equalTo"/>
-                        <condition field="selections" scope="d1fc-41b4-1ae1-0fa6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45a4-d5cd-d5cc-472a" type="equalTo"/>
+                        <condition field="selections" scope="d1fc-41b4-1ae1-0fa6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83be-1ba9-c326-4760" type="equalTo" />
+                        <condition field="selections" scope="d1fc-41b4-1ae1-0fa6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45a4-d5cd-d5cc-472a" type="equalTo" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -1415,15 +1415,15 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                   <conditionGroups>
                     <conditionGroup type="and">
                       <conditions>
-                        <condition field="selections" scope="d1fc-41b4-1ae1-0fa6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83be-1ba9-c326-4760" type="equalTo"/>
-                        <condition field="selections" scope="d1fc-41b4-1ae1-0fa6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45a4-d5cd-d5cc-472a" type="equalTo"/>
+                        <condition field="selections" scope="d1fc-41b4-1ae1-0fa6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83be-1ba9-c326-4760" type="equalTo" />
+                        <condition field="selections" scope="d1fc-41b4-1ae1-0fa6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45a4-d5cd-d5cc-472a" type="equalTo" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b81-d400-1c6d-e22e" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b81-d400-1c6d-e22e" type="max" />
               </constraints>
               <profiles>
                 <profile id="97c6-5844-6f38-d234" name="Khorne Berserker" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -1443,20 +1443,20 @@ In a Boarding Action, this ability only affects friendly units that are visible 
               <selectionEntryGroups>
                 <selectionEntryGroup id="ea2f-ed8f-f73e-436b" name="Melee weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="3f23-b0ae-8116-da63">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5467-6b6b-1c0d-5d3a" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f88-28fa-e8d2-6977" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5467-6b6b-1c0d-5d3a" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f88-28fa-e8d2-6977" type="max" />
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="45a4-d5cd-d5cc-472a" name="Khornate eviscerator" hidden="false" collective="false" import="true" type="upgrade">
                       <modifiers>
                         <modifier type="set" field="adf6-cd59-a880-d38c" value="2.0">
                           <conditions>
-                            <condition field="selections" scope="da50-32c3-ef5f-2baf" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                            <condition field="selections" scope="da50-32c3-ef5f-2baf" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast" />
                           </conditions>
                         </modifier>
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="da50-32c3-ef5f-2baf" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="adf6-cd59-a880-d38c" type="max"/>
+                        <constraint field="selections" scope="da50-32c3-ef5f-2baf" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="adf6-cd59-a880-d38c" type="max" />
                       </constraints>
                       <profiles>
                         <profile id="d852-fe67-e2e1-5f71" name="Khornate eviscerator" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -1471,116 +1471,116 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="5.0"/>
-                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                        <cost name="pts" typeId="points" value="5.0" />
+                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3f23-b0ae-8116-da63" name="Berserker chainblade" hidden="false" collective="false" import="true" type="upgrade">
                       <infoLinks>
-                        <infoLink id="b4e1-d573-16b4-c8bf" name="Berserker chainblade" hidden="false" targetId="42a2-738d-5f61-c288" type="profile"/>
+                        <infoLink id="b4e1-d573-16b4-c8bf" name="Berserker chainblade" hidden="false" targetId="42a2-738d-5f61-c288" type="profile" />
                       </infoLinks>
                       <costs>
-                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                        <cost name="pts" typeId="points" value="0.0" />
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="9f27-9047-87c7-8392" name="Pistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="95d6-be73-b37b-fa98">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3377-8080-f0a2-7547" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ed4-327d-b2af-ff99" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3377-8080-f0a2-7547" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ed4-327d-b2af-ff99" type="max" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="95d6-be73-b37b-fa98" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="0334-f487-8229-0c1a" type="selectionEntry"/>
+                    <entryLink id="95d6-be73-b37b-fa98" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="0334-f487-8229-0c1a" type="selectionEntry" />
                     <entryLink id="fa26-25ca-782e-588f" name="Plasma pistol" hidden="false" collective="false" import="true" targetId="83be-1ba9-c326-4760" type="selectionEntry">
                       <modifiers>
                         <modifier type="set" field="05e4-1a1a-53d1-507c" value="2.0">
                           <conditions>
-                            <condition field="selections" scope="da50-32c3-ef5f-2baf" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                            <condition field="selections" scope="da50-32c3-ef5f-2baf" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast" />
                           </conditions>
                         </modifier>
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="da50-32c3-ef5f-2baf" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="05e4-1a1a-53d1-507c" type="max"/>
+                        <constraint field="selections" scope="da50-32c3-ef5f-2baf" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="05e4-1a1a-53d1-507c" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name="pts" typeId="points" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="22.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="22.0" />
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="e237-802f-ab61-9faa" name="Berserker chainblade" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="430a-809e-c653-1d1a" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="430a-809e-c653-1d1a" type="max" />
       </constraints>
       <infoLinks>
-        <infoLink id="e489-9dd2-2cee-2b2e" name="Berserker chainblade" hidden="false" targetId="42a2-738d-5f61-c288" type="profile"/>
+        <infoLink id="e489-9dd2-2cee-2b2e" name="Berserker chainblade" hidden="false" targetId="42a2-738d-5f61-c288" type="profile" />
       </infoLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="e78b-9e61-5a84-8f0f" name="Plasma pistol" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b6d-f07c-bf93-6f49" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b6d-f07c-bf93-6f49" type="max" />
       </constraints>
       <infoLinks>
-        <infoLink id="3ae4-6b32-3aba-fede" name="Plasma pistol, Standard" hidden="false" targetId="ff12-161a-ca85-339f" type="profile"/>
-        <infoLink id="bf26-05f0-17f9-e17c" name="Plasma pistol, Supercharge" hidden="false" targetId="5779-2931-fe17-2b27" type="profile"/>
+        <infoLink id="3ae4-6b32-3aba-fede" name="Plasma pistol, Standard" hidden="false" targetId="ff12-161a-ca85-339f" type="profile" />
+        <infoLink id="bf26-05f0-17f9-e17c" name="Plasma pistol, Supercharge" hidden="false" targetId="5779-2931-fe17-2b27" type="profile" />
       </infoLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="809d-95c5-b578-3010" name="Jakhals" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="e356-c769-5920-6e14" value="8.0">
           <conditions>
-            <condition field="selections" scope="809d-95c5-b578-3010" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+            <condition field="selections" scope="809d-95c5-b578-3010" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="cd54-f74e-23c3-fcd4" name="Objective Secured" hidden="false" targetId="e07e-8dbf-0b15-7485" type="rule"/>
-        <infoLink id="ceec-6979-2324-de6d" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="cd54-f74e-23c3-fcd4" name="Objective Secured" hidden="false" targetId="e07e-8dbf-0b15-7485" type="rule" />
+        <infoLink id="ceec-6979-2324-de6d" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4dc0-2081-d9d9-bff1" name="Troops" hidden="false" targetId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" primary="true"/>
-        <categoryLink id="049a-0e75-2dd0-9515" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="0338-6eac-a727-ed27" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="21c3-039b-6890-11bf" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
-        <categoryLink id="9cd8-85c7-6105-f4a0" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-        <categoryLink id="b2a3-dc24-a384-d84d" name="Cultists" hidden="false" targetId="184d-2f9a-fb60-ba22" primary="false"/>
-        <categoryLink id="93c5-c0e8-5931-2892" name="Jakhals" hidden="false" targetId="d520-aa13-3b1f-0a72" primary="false"/>
+        <categoryLink id="4dc0-2081-d9d9-bff1" name="Troops" hidden="false" targetId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" primary="true" />
+        <categoryLink id="049a-0e75-2dd0-9515" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="0338-6eac-a727-ed27" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="21c3-039b-6890-11bf" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
+        <categoryLink id="9cd8-85c7-6105-f4a0" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false" />
+        <categoryLink id="b2a3-dc24-a384-d84d" name="Cultists" hidden="false" targetId="184d-2f9a-fb60-ba22" primary="false" />
+        <categoryLink id="93c5-c0e8-5931-2892" name="Jakhals" hidden="false" targetId="d520-aa13-3b1f-0a72" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="dd10-d022-f7fa-869d" name="Jakhal Pack Leader" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d882-9d4a-44ac-38e3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3e3-581c-b584-f92e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d882-9d4a-44ac-38e3" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3e3-581c-b584-f92e" type="max" />
           </constraints>
           <profiles>
             <profile id="902c-fb26-5510-464b" name="Jakhal Pack Leader" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -1598,30 +1598,30 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="3b84-cec9-7628-7cd9" name="Jakhal chainblades" hidden="false" collective="false" import="true" targetId="1161-bbcc-350d-0dad" type="selectionEntry"/>
+            <entryLink id="3b84-cec9-7628-7cd9" name="Jakhal chainblades" hidden="false" collective="false" import="true" targetId="1161-bbcc-350d-0dad" type="selectionEntry" />
             <entryLink id="f10f-20c1-23bd-07f5" name="Autopistol" hidden="false" collective="false" import="true" targetId="0507-a97d-4f7f-83b4" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c6c-baf6-c794-61f7" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36c6-b1d4-a2b6-1eec" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c6c-baf6-c794-61f7" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36c6-b1d4-a2b6-1eec" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="7.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="7.0" />
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="c56c-4ce1-6f7d-a6b5" name="Jakhal icon" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="5223-aeec-e9f8-cec8" value="2.0">
               <conditions>
-                <condition field="selections" scope="809d-95c5-b578-3010" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="equalTo"/>
+                <condition field="selections" scope="809d-95c5-b578-3010" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5223-aeec-e9f8-cec8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5223-aeec-e9f8-cec8" type="max" />
           </constraints>
           <profiles>
             <profile id="9806-2b30-5635-0085" name="Jakhal icon" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -1631,12 +1631,12 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="bf16-18d4-5bd5-68d9" name="Icon" hidden="false" targetId="3db4-481a-d6ce-d2ad" primary="false"/>
+            <categoryLink id="bf16-18d4-5bd5-68d9" name="Icon" hidden="false" targetId="3db4-481a-d6ce-d2ad" primary="false" />
           </categoryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="5.0" />
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1645,18 +1645,18 @@ In a Boarding Action, this ability only affects friendly units that are visible 
           <modifiers>
             <modifier type="set" field="200f-7b97-fb43-7d7f" value="8.0">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a207-a133-6adb-25f3" type="instanceOf" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8f4-125a-27fd-2c48" type="min"/>
-            <constraint field="selections" scope="parent" value="17.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="200f-7b97-fb43-7d7f" type="max"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8f4-125a-27fd-2c48" type="min" />
+            <constraint field="selections" scope="parent" value="17.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="200f-7b97-fb43-7d7f" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="907e-c284-2aa6-f263" name="Jakhal w/ chainblades" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="17.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ca4-15a9-eb8e-2291" type="max"/>
+                <constraint field="selections" scope="parent" value="17.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ca4-15a9-eb8e-2291" type="max" />
               </constraints>
               <profiles>
                 <profile id="d728-a5c5-8909-385c" name="Jakhal" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -1674,31 +1674,31 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="e39d-08b1-0403-5b3e" name="Jakhal chainblades" hidden="false" collective="false" import="true" targetId="1161-bbcc-350d-0dad" type="selectionEntry"/>
-                <entryLink id="90b6-a3c1-5bc9-6a6d" name="Autopistol" hidden="false" collective="false" import="true" targetId="be3f-99ec-e010-422c" type="selectionEntry"/>
+                <entryLink id="e39d-08b1-0403-5b3e" name="Jakhal chainblades" hidden="false" collective="false" import="true" targetId="1161-bbcc-350d-0dad" type="selectionEntry" />
+                <entryLink id="90b6-a3c1-5bc9-6a6d" name="Autopistol" hidden="false" collective="false" import="true" targetId="be3f-99ec-e010-422c" type="selectionEntry" />
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="7.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="7.0" />
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="5932-8e7c-dc1f-288b" name="Jakhal w/ mauler chainblade" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="set" field="82e9-b318-d65b-ea3f" value="2.0">
                   <conditions>
-                    <condition field="selections" scope="809d-95c5-b578-3010" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="equalTo"/>
+                    <condition field="selections" scope="809d-95c5-b578-3010" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82e9-b318-d65b-ea3f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82e9-b318-d65b-ea3f" type="max" />
               </constraints>
               <selectionEntries>
                 <selectionEntry id="8409-a4fc-ac75-5370" name="Mauler chainblade" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1b1-7239-753d-ca55" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a719-b96a-4779-d63f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1b1-7239-753d-ca55" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a719-b96a-4779-d63f" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="2cf6-0096-5ad5-0d72" name="Mauler chainblade" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -1713,19 +1713,19 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
-                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                    <cost name="pts" typeId="points" value="5.0" />
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="0e7e-685a-af3a-6615" name="Autopistol" hidden="false" collective="false" import="true" targetId="be3f-99ec-e010-422c" type="selectionEntry"/>
+                <entryLink id="0e7e-685a-af3a-6615" name="Autopistol" hidden="false" collective="false" import="true" targetId="be3f-99ec-e010-422c" type="selectionEntry" />
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="7.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="7.0" />
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1734,13 +1734,13 @@ In a Boarding Action, this ability only affects friendly units that are visible 
           <modifiers>
             <modifier type="set" field="b242-2b14-4398-5ca0" value="2.0">
               <conditions>
-                <condition field="selections" scope="809d-95c5-b578-3010" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="equalTo"/>
+                <condition field="selections" scope="809d-95c5-b578-3010" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e50-6a8e-f806-bb05" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b242-2b14-4398-5ca0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e50-6a8e-f806-bb05" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b242-2b14-4398-5ca0" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="0168-93fd-918f-836b" name="Dishonoured" hidden="false" collective="false" import="true" type="model">
@@ -1760,12 +1760,12 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="6303-cabb-556a-ce10" name="Jakhal chainblades" hidden="false" collective="false" import="true" targetId="1161-bbcc-350d-0dad" type="selectionEntry"/>
+                <entryLink id="6303-cabb-556a-ce10" name="Jakhal chainblades" hidden="false" collective="false" import="true" targetId="1161-bbcc-350d-0dad" type="selectionEntry" />
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="7.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="7.0" />
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="80b5-907a-12af-c77d" name="Dishonoured w/ skullsmasher" hidden="false" collective="false" import="true" type="model">
@@ -1787,8 +1787,8 @@ In a Boarding Action, this ability only affects friendly units that are visible 
               <selectionEntries>
                 <selectionEntry id="1fa4-015f-6bd6-7c15" name="Skullsmasher" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="744d-a57c-26e2-29e0" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff91-67df-733b-22bb" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="744d-a57c-26e2-29e0" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff91-67df-733b-22bb" type="min" />
                   </constraints>
                   <profiles>
                     <profile id="4b8a-fa62-a252-3f25" name="Skullsmasher" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -1803,34 +1803,34 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
-                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                    <cost name="pts" typeId="points" value="5.0" />
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="5593-58ef-91e4-2ee7" name="Jakhal chainblades" hidden="false" collective="false" import="true" targetId="1161-bbcc-350d-0dad" type="selectionEntry"/>
+                <entryLink id="5593-58ef-91e4-2ee7" name="Jakhal chainblades" hidden="false" collective="false" import="true" targetId="1161-bbcc-350d-0dad" type="selectionEntry" />
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="7.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="7.0" />
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="1161-bbcc-350d-0dad" name="Jakhal chainblades" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a20-7102-ad38-2d8b" type="max"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d24-4537-eb97-ed17" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a20-7102-ad38-2d8b" type="max" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d24-4537-eb97-ed17" type="min" />
       </constraints>
       <profiles>
         <profile id="2ee3-d9cd-1864-5cb6" name="Jakhal chainblades" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -1845,30 +1845,30 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="be3f-99ec-e010-422c" name="Autopistol" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4326-858b-9e93-6acb" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35c1-1807-5349-2365" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4326-858b-9e93-6acb" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35c1-1807-5349-2365" type="max" />
       </constraints>
       <infoLinks>
-        <infoLink id="7f53-90e5-eb61-5655" name="Autopistol" hidden="false" targetId="2481-001b-00f9-501b" type="profile"/>
+        <infoLink id="7f53-90e5-eb61-5655" name="Autopistol" hidden="false" targetId="2481-001b-00f9-501b" type="profile" />
       </infoLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="dbd8-6d68-468e-67ff" name="World Eaters Terminator Squad" page="" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="9.0">
           <conditions>
-            <condition field="selections" scope="dbd8-6d68-468e-67ff" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+            <condition field="selections" scope="dbd8-6d68-468e-67ff" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
@@ -1880,25 +1880,25 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="7e00-27f3-8763-79bb" name="Warp Strike" hidden="false" targetId="04e9-0e24-3b6e-8f06" type="rule"/>
-        <infoLink id="1264-3f0f-20de-fc47" name="Malicious Volleys" hidden="false" targetId="fc3c-c42b-493a-3c94" type="rule"/>
-        <infoLink id="441c-5a8b-a83b-7e48" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="bec6-9895-04ca-8482" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="7e00-27f3-8763-79bb" name="Warp Strike" hidden="false" targetId="04e9-0e24-3b6e-8f06" type="rule" />
+        <infoLink id="1264-3f0f-20de-fc47" name="Malicious Volleys" hidden="false" targetId="fc3c-c42b-493a-3c94" type="rule" />
+        <infoLink id="441c-5a8b-a83b-7e48" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="bec6-9895-04ca-8482" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b147-a390-0630-1e61" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="b8a1-58b9-1a4b-85e1" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
-        <categoryLink id="d21f-265c-6ff3-8d2c" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-        <categoryLink id="6b48-ee30-c5cb-aebb" name="Core" hidden="false" targetId="08f1-d244-eb44-7e01" primary="false"/>
-        <categoryLink id="9a78-940e-4ff8-6240" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="1ce8-7371-4e86-9217" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="a8de-f6f6-71be-49b2" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
+        <categoryLink id="b147-a390-0630-1e61" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="b8a1-58b9-1a4b-85e1" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true" />
+        <categoryLink id="d21f-265c-6ff3-8d2c" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false" />
+        <categoryLink id="6b48-ee30-c5cb-aebb" name="Core" hidden="false" targetId="08f1-d244-eb44-7e01" primary="false" />
+        <categoryLink id="9a78-940e-4ff8-6240" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="1ce8-7371-4e86-9217" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="a8de-f6f6-71be-49b2" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a410-0176-b67e-5d96" name="World Eaters Terminator Champion" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c417-56aa-bf90-e5b8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1517-282c-3e4c-b148" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c417-56aa-bf90-e5b8" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1517-282c-3e4c-b148" type="min" />
           </constraints>
           <profiles>
             <profile id="e088-9e0e-3817-955e" name="World Eaters Terminator Champion" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -1918,134 +1918,134 @@ In a Boarding Action, this ability only affects friendly units that are visible 
           <selectionEntryGroups>
             <selectionEntryGroup id="17ac-eca4-d1af-90a6" name="Replace combi-bolter" hidden="false" collective="false" import="true" defaultSelectionEntryId="e5ad-5415-f6d8-2e3d">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc84-e450-c852-6a3b" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90cf-35c5-360e-ffb2" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc84-e450-c852-6a3b" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90cf-35c5-360e-ffb2" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="e5ad-5415-f6d8-2e3d" name="Combi-bolter" hidden="false" collective="false" import="true" targetId="eba0-9fc6-5334-a390" type="selectionEntry"/>
+                <entryLink id="e5ad-5415-f6d8-2e3d" name="Combi-bolter" hidden="false" collective="false" import="true" targetId="eba0-9fc6-5334-a390" type="selectionEntry" />
                 <entryLink id="a256-6f75-7f33-dc08" name="Combi-plasma" hidden="false" collective="false" import="true" targetId="fdce-cdf7-21a9-f9ac" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="863f-b917-5bce-ed47" value="2.0">
                       <conditions>
-                        <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                        <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="863f-b917-5bce-ed47" type="max"/>
+                    <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="863f-b917-5bce-ed47" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
+                    <cost name="pts" typeId="points" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="6730-00be-7a4b-5ca1" name="Combi-flamer" hidden="false" collective="false" import="true" targetId="c6a1-e0c4-c1b1-dce1" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="9692-035d-801a-0e4b" value="4.0">
                       <conditions>
-                        <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                        <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9692-035d-801a-0e4b" type="max"/>
+                    <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9692-035d-801a-0e4b" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
+                    <cost name="pts" typeId="points" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="968b-1de7-f37d-a955" name="Combi-melta" hidden="false" collective="false" import="true" targetId="c445-e211-f316-5d83" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="201c-ec42-96ac-00ac" value="4.0">
                       <conditions>
-                        <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                        <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="201c-ec42-96ac-00ac" type="max"/>
+                    <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="201c-ec42-96ac-00ac" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
+                    <cost name="pts" typeId="points" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="9b1e-00f9-b3b0-a675" name="Accursed weapon" hidden="false" collective="false" import="true" targetId="2e50-ad85-fd79-e8c1" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="2039-e21e-0384-c5d2" value="2.0">
                       <conditions>
-                        <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                        <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2039-e21e-0384-c5d2" type="max"/>
+                    <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2039-e21e-0384-c5d2" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="5ffe-d20a-822a-8213" name="Replace accursed weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="a14d-88b4-78f1-fe9e">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d156-52d8-b658-e444" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10b0-703d-6c21-e9db" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d156-52d8-b658-e444" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10b0-703d-6c21-e9db" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="a14d-88b4-78f1-fe9e" name="Accursed weapon" hidden="false" collective="false" import="true" targetId="6737-a57b-fbcc-2027" type="selectionEntry"/>
+                <entryLink id="a14d-88b4-78f1-fe9e" name="Accursed weapon" hidden="false" collective="false" import="true" targetId="6737-a57b-fbcc-2027" type="selectionEntry" />
                 <entryLink id="4e72-db71-1269-1189" name="Power fist" hidden="false" collective="false" import="true" targetId="f122-3720-fa32-4215" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="4405-900c-73b8-5e46" value="6.0">
                       <conditions>
-                        <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                        <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast" />
                       </conditions>
                     </modifier>
                     <modifier type="set" field="e8e3-35e4-c3d5-db68" value="0.0">
                       <conditions>
-                        <condition field="selections" scope="a410-0176-b67e-5d96" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e50-ad85-fd79-e8c1" type="equalTo"/>
+                        <condition field="selections" scope="a410-0176-b67e-5d96" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e50-ad85-fd79-e8c1" type="equalTo" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4405-900c-73b8-5e46" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8e3-35e4-c3d5-db68" type="max"/>
+                    <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4405-900c-73b8-5e46" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8e3-35e4-c3d5-db68" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
+                    <cost name="pts" typeId="points" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="61a1-07eb-54f6-3eb5" name="Chainfist" hidden="false" collective="false" import="true" targetId="e464-77c1-12bb-e52f" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="fc89-3460-b902-8563" value="2.0">
                       <conditions>
-                        <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                        <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast" />
                       </conditions>
                     </modifier>
                     <modifier type="set" field="37e0-529c-b9c7-8baa" value="0.0">
                       <conditions>
-                        <condition field="selections" scope="a410-0176-b67e-5d96" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e50-ad85-fd79-e8c1" type="equalTo"/>
+                        <condition field="selections" scope="a410-0176-b67e-5d96" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e50-ad85-fd79-e8c1" type="equalTo" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fc89-3460-b902-8563" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37e0-529c-b9c7-8baa" type="max"/>
+                    <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fc89-3460-b902-8563" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37e0-529c-b9c7-8baa" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
+                    <cost name="pts" typeId="points" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="pts" typeId="points" value="35.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="35.0" />
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="adc9-6221-ec23-60ce" name="4 - 9 World Eaters Terminators" hidden="false" collective="false" import="true" defaultSelectionEntryId="1061-1bde-ff7b-2833">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="707b-6f50-9921-7936" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58fc-e53a-2645-e0bc" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="707b-6f50-9921-7936" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58fc-e53a-2645-e0bc" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="1061-1bde-ff7b-2833" name="World Eaters Terminator" hidden="false" collective="false" import="true" type="model">
@@ -2067,154 +2067,154 @@ In a Boarding Action, this ability only affects friendly units that are visible 
               <selectionEntryGroups>
                 <selectionEntryGroup id="5145-a23f-48b4-4dc5" name="Replace accursed weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="ab94-2e3a-52c0-c12e">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a4d-6d98-719d-2e18" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f019-c69d-82dc-728f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a4d-6d98-719d-2e18" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f019-c69d-82dc-728f" type="max" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="ab94-2e3a-52c0-c12e" name="Accursed weapon A" hidden="false" collective="false" import="true" targetId="6737-a57b-fbcc-2027" type="selectionEntry"/>
+                    <entryLink id="ab94-2e3a-52c0-c12e" name="Accursed weapon A" hidden="false" collective="false" import="true" targetId="6737-a57b-fbcc-2027" type="selectionEntry" />
                     <entryLink id="0aae-9188-2df8-b7dd" name="Power fist" hidden="false" collective="false" import="true" targetId="f122-3720-fa32-4215" type="selectionEntry">
                       <modifiers>
                         <modifier type="set" field="caa0-0bc1-1426-34e8" value="0.0">
                           <conditions>
-                            <condition field="selections" scope="1061-1bde-ff7b-2833" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e50-ad85-fd79-e8c1" type="equalTo"/>
+                            <condition field="selections" scope="1061-1bde-ff7b-2833" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e50-ad85-fd79-e8c1" type="equalTo" />
                           </conditions>
                         </modifier>
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="caa0-0bc1-1426-34e8" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="caa0-0bc1-1426-34e8" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name="pts" typeId="points" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="cb55-b942-bcc0-ce0f" name="Chainfist" hidden="false" collective="false" import="true" targetId="e464-77c1-12bb-e52f" type="selectionEntry">
                       <modifiers>
                         <modifier type="set" field="af68-2612-b478-910a" value="0.0">
                           <conditions>
-                            <condition field="selections" scope="1061-1bde-ff7b-2833" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e50-ad85-fd79-e8c1" type="equalTo"/>
+                            <condition field="selections" scope="1061-1bde-ff7b-2833" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e50-ad85-fd79-e8c1" type="equalTo" />
                           </conditions>
                         </modifier>
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af68-2612-b478-910a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af68-2612-b478-910a" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name="pts" typeId="points" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="c921-016d-3790-f4f3" name="Replace combi-bolter" hidden="false" collective="false" import="true" defaultSelectionEntryId="dc74-e6a9-5bd7-e73d">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e11e-d72e-8cd6-eba3" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f11-aa0a-d939-61ef" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e11e-d72e-8cd6-eba3" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f11-aa0a-d939-61ef" type="max" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="dc74-e6a9-5bd7-e73d" name="Combi-bolter" hidden="false" collective="false" import="true" targetId="eba0-9fc6-5334-a390" type="selectionEntry"/>
-                    <entryLink id="f4be-79ee-0f8b-2d47" name="Accursed weapon" hidden="false" collective="false" import="true" targetId="2e50-ad85-fd79-e8c1" type="selectionEntry"/>
+                    <entryLink id="dc74-e6a9-5bd7-e73d" name="Combi-bolter" hidden="false" collective="false" import="true" targetId="eba0-9fc6-5334-a390" type="selectionEntry" />
+                    <entryLink id="f4be-79ee-0f8b-2d47" name="Accursed weapon" hidden="false" collective="false" import="true" targetId="2e50-ad85-fd79-e8c1" type="selectionEntry" />
                     <entryLink id="fa40-045e-088b-3133" name="Combi-flamer" hidden="false" collective="false" import="true" targetId="c6a1-e0c4-c1b1-dce1" type="selectionEntry">
                       <costs>
-                        <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name="pts" typeId="points" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="f356-8c25-e3c4-14f8" name="Combi-melta" hidden="false" collective="false" import="true" targetId="c445-e211-f316-5d83" type="selectionEntry">
                       <costs>
-                        <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name="pts" typeId="points" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="ac76-7e7b-01c9-7c58" name="Combi-plasma" hidden="false" collective="false" import="true" targetId="fdce-cdf7-21a9-f9ac" type="selectionEntry">
                       <costs>
-                        <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name="pts" typeId="points" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="69fb-cad3-713b-f8d2" name="Reaper autocannon" hidden="false" collective="false" import="true" targetId="5ab4-1ee7-95ad-7e15" type="selectionEntry">
                       <modifiers>
                         <modifier type="set" field="23a2-de26-a445-1d30" value="2.0">
                           <conditions>
-                            <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                            <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast" />
                           </conditions>
                         </modifier>
                         <modifier type="decrement" field="23a2-de26-a445-1d30" value="1.0">
                           <repeats>
-                            <repeat field="selections" scope="dbd8-6d68-468e-67ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="18bc-b335-29c2-2ae2" repeats="1" roundUp="false"/>
+                            <repeat field="selections" scope="dbd8-6d68-468e-67ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="18bc-b335-29c2-2ae2" repeats="1" roundUp="false" />
                           </repeats>
                         </modifier>
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23a2-de26-a445-1d30" type="max"/>
+                        <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23a2-de26-a445-1d30" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name="pts" typeId="points" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="54d8-ed9c-baf2-f0e1" name="Heavy flamer" hidden="false" collective="false" import="true" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
                       <modifiers>
                         <modifier type="set" field="c35a-7544-2035-fe6c" value="2.0">
                           <conditions>
-                            <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                            <condition field="selections" scope="dbd8-6d68-468e-67ff" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast" />
                           </conditions>
                         </modifier>
                         <modifier type="decrement" field="c35a-7544-2035-fe6c" value="1.0">
                           <repeats>
-                            <repeat field="selections" scope="dbd8-6d68-468e-67ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ab4-1ee7-95ad-7e15" repeats="1" roundUp="false"/>
+                            <repeat field="selections" scope="dbd8-6d68-468e-67ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ab4-1ee7-95ad-7e15" repeats="1" roundUp="false" />
                           </repeats>
                         </modifier>
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c35a-7544-2035-fe6c" type="max"/>
+                        <constraint field="selections" scope="dbd8-6d68-468e-67ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c35a-7544-2035-fe6c" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name="pts" typeId="points" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="35.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="35.0" />
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="735a-d4a7-8071-5439" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup"/>
+        <entryLink id="735a-d4a7-8071-5439" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="9.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0" />
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="9.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="6737-a57b-fbcc-2027" name="Accursed weapon" hidden="false" collective="false" import="true" type="upgrade">
       <comment>Primary entry</comment>
       <infoLinks>
-        <infoLink id="9556-b975-fbd1-4d6c" name="Accursed weapon" hidden="false" targetId="f958-5381-6e15-385a" type="profile"/>
+        <infoLink id="9556-b975-fbd1-4d6c" name="Accursed weapon" hidden="false" targetId="f958-5381-6e15-385a" type="profile" />
       </infoLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="2e50-ad85-fd79-e8c1" name="Accursed weapon" hidden="false" collective="false" import="true" type="upgrade">
       <comment>Duplicate Entry for easier validation</comment>
       <infoLinks>
-        <infoLink id="6c14-4d98-8c79-21c7" name="Accursed weapon" hidden="false" targetId="f958-5381-6e15-385a" type="profile"/>
+        <infoLink id="6c14-4d98-8c79-21c7" name="Accursed weapon" hidden="false" targetId="f958-5381-6e15-385a" type="profile" />
       </infoLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="26cd-dc2c-1890-d51a" name="Eightbound" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="e356-c769-5920-6e14" value="12.0">
           <conditions>
-            <condition field="selections" scope="26cd-dc2c-1890-d51a" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+            <condition field="selections" scope="26cd-dc2c-1890-d51a" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
@@ -2231,27 +2231,27 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="f924-e6b3-32f6-461d" name="Fearsome (Aura)" hidden="false" targetId="a372-a03b-a7b3-864c" type="profile"/>
-        <infoLink id="d3c8-1b6d-ccb4-fee4" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="499a-5e15-c861-7cfa" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="f924-e6b3-32f6-461d" name="Fearsome (Aura)" hidden="false" targetId="a372-a03b-a7b3-864c" type="profile" />
+        <infoLink id="d3c8-1b6d-ccb4-fee4" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="499a-5e15-c861-7cfa" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4fe6-bb10-998d-b178" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
-        <categoryLink id="960a-0725-fa16-39e5" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="b6d6-b93a-eb26-5466" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="d2dd-f3b9-24e7-d687" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="4607-2e58-f528-94c6" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="1604-06fc-b476-2863" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
-        <categoryLink id="5872-c6f9-c915-7ed0" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-        <categoryLink id="9ade-f3ad-0198-3cac" name="Core" hidden="false" targetId="08f1-d244-eb44-7e01" primary="false"/>
-        <categoryLink id="9e08-503e-2c37-53a1" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false"/>
-        <categoryLink id="5a89-8fda-6fc1-e3cc" name="Eightbound" hidden="false" targetId="6dfa-171f-086c-a487" primary="false"/>
+        <categoryLink id="4fe6-bb10-998d-b178" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true" />
+        <categoryLink id="960a-0725-fa16-39e5" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="b6d6-b93a-eb26-5466" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="d2dd-f3b9-24e7-d687" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="4607-2e58-f528-94c6" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="1604-06fc-b476-2863" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
+        <categoryLink id="5872-c6f9-c915-7ed0" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false" />
+        <categoryLink id="9ade-f3ad-0198-3cac" name="Core" hidden="false" targetId="08f1-d244-eb44-7e01" primary="false" />
+        <categoryLink id="9e08-503e-2c37-53a1" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false" />
+        <categoryLink id="5a89-8fda-6fc1-e3cc" name="Eightbound" hidden="false" targetId="6dfa-171f-086c-a487" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a1f0-325c-0994-6859" name="Eightbound Champion" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b965-d44f-b7d5-26f5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6606-af12-462a-5eb0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b965-d44f-b7d5-26f5" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6606-af12-462a-5eb0" type="max" />
           </constraints>
           <profiles>
             <profile id="78c0-6069-82d8-027f" name="Eightbound Champion" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -2271,8 +2271,8 @@ In a Boarding Action, this ability only affects friendly units that are visible 
           <selectionEntryGroups>
             <selectionEntryGroup id="3555-3ac9-40d5-44b8" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="ff7e-7ed8-a6c4-6d36">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f3e-20ac-3a93-1fcc" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6afc-911b-0e2d-a645" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f3e-20ac-3a93-1fcc" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6afc-911b-0e2d-a645" type="max" />
               </constraints>
               <selectionEntries>
                 <selectionEntry id="ff7e-7ed8-a6c4-6d36" name="Lacerators" hidden="false" collective="false" import="true" type="upgrade">
@@ -2289,34 +2289,34 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                    <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                    <cost name="pts" typeId="points" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="d8f7-60f1-529e-a0b3" name="Heavy chainglaive" hidden="false" collective="false" import="true" targetId="db19-6724-2556-76f6" type="selectionEntry"/>
+                <entryLink id="d8f7-60f1-529e-a0b3" name="Heavy chainglaive" hidden="false" collective="false" import="true" targetId="db19-6724-2556-76f6" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="40.0" />
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="ddd1-bfb8-645f-2ea6" name="2-5 Eightbound" hidden="false" collective="false" import="true" defaultSelectionEntryId="cc9d-4303-3e79-4b1b">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23cc-7c36-9978-b87a" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23cc-7c36-9978-b87a" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="cc9d-4303-3e79-4b1b" name="Eightbound" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97e0-0f1b-6754-8016" type="min"/>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7704-4b9f-e514-3c3e" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97e0-0f1b-6754-8016" type="min" />
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7704-4b9f-e514-3c3e" type="max" />
               </constraints>
               <profiles>
                 <profile id="46d9-291e-dc8d-02c0" name="Eightbound" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -2336,27 +2336,27 @@ In a Boarding Action, this ability only affects friendly units that are visible 
               <entryLinks>
                 <entryLink id="1663-c94b-c4b8-c164" name="Eightbound eviscerator" hidden="false" collective="false" import="true" targetId="ead5-6e1f-80bd-6b9e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2232-bdcd-82f9-dadb" type="min"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03b8-b75e-4fc2-fd98" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2232-bdcd-82f9-dadb" type="min" />
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03b8-b75e-4fc2-fd98" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="40.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="40.0" />
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="ec0b-13d9-8dc8-f3a7" name="Daemonic Infusion" hidden="false" collective="false" import="true" targetId="6ac9-7c63-ea9e-6e22" type="selectionEntryGroup"/>
+        <entryLink id="ec0b-13d9-8dc8-f3a7" name="Daemonic Infusion" hidden="false" collective="false" import="true" targetId="6ac9-7c63-ea9e-6e22" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="ead5-6e1f-80bd-6b9e" name="Eightbound eviscerator" hidden="false" collective="true" import="true" type="upgrade">
@@ -2373,9 +2373,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="405b-f054-eaca-ce5c" name="Exalted Eightbound" hidden="false" collective="false" import="true" type="unit">
@@ -2392,28 +2392,28 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="3b46-8487-1f0e-350a" name="Fearsome (Aura)" hidden="false" targetId="a372-a03b-a7b3-864c" type="profile"/>
-        <infoLink id="acc7-8ceb-3c7d-233f" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="376e-f335-18ae-3a97" name="Warp Strike" hidden="false" targetId="04e9-0e24-3b6e-8f06" type="rule"/>
-        <infoLink id="7c70-ca21-b117-2829" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="3b46-8487-1f0e-350a" name="Fearsome (Aura)" hidden="false" targetId="a372-a03b-a7b3-864c" type="profile" />
+        <infoLink id="acc7-8ceb-3c7d-233f" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="376e-f335-18ae-3a97" name="Warp Strike" hidden="false" targetId="04e9-0e24-3b6e-8f06" type="rule" />
+        <infoLink id="7c70-ca21-b117-2829" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="1b42-d8ce-b941-7358" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
-        <categoryLink id="b4ef-e1e9-3ff6-a9a6" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="4903-2fe8-7a11-630a" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="819a-b5ff-75aa-d883" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="d354-2d5d-f74e-02e6" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="cf4f-c9f1-90de-e980" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
-        <categoryLink id="e4a8-fc66-44c9-c197" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-        <categoryLink id="cb02-f065-971b-d9c8" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false"/>
-        <categoryLink id="bda9-a05d-58ba-12a9" name="Eightbound" hidden="false" targetId="6dfa-171f-086c-a487" primary="false"/>
-        <categoryLink id="f122-ea55-a1ba-189c" name="Exalted Eightbound" hidden="false" targetId="ebbb-88ba-3fd2-ff8e" primary="false"/>
+        <categoryLink id="1b42-d8ce-b941-7358" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true" />
+        <categoryLink id="b4ef-e1e9-3ff6-a9a6" name="Faction: Chaos" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="4903-2fe8-7a11-630a" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="819a-b5ff-75aa-d883" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="d354-2d5d-f74e-02e6" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="cf4f-c9f1-90de-e980" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
+        <categoryLink id="e4a8-fc66-44c9-c197" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false" />
+        <categoryLink id="cb02-f065-971b-d9c8" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false" />
+        <categoryLink id="bda9-a05d-58ba-12a9" name="Eightbound" hidden="false" targetId="6dfa-171f-086c-a487" primary="false" />
+        <categoryLink id="f122-ea55-a1ba-189c" name="Exalted Eightbound" hidden="false" targetId="ebbb-88ba-3fd2-ff8e" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b68f-8abe-2047-df49" name="Exalted Eightbound Champion" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e892-4f84-7d6e-c193" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fef5-7b94-d5bd-8396" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e892-4f84-7d6e-c193" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fef5-7b94-d5bd-8396" type="max" />
           </constraints>
           <profiles>
             <profile id="02bb-ba0e-6b8e-342e" name="Exalted Eightbound Champion" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -2433,62 +2433,62 @@ In a Boarding Action, this ability only affects friendly units that are visible 
           <selectionEntryGroups>
             <selectionEntryGroup id="3689-c4bc-67f1-1bc6" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="d554-cf94-27a3-3d33">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6504-96e5-770e-75be" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a35e-7aec-65b8-7d83" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6504-96e5-770e-75be" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a35e-7aec-65b8-7d83" type="max" />
               </constraints>
               <selectionEntries>
                 <selectionEntry id="d554-cf94-27a3-3d33" name="Eviscerator and chainfist" hidden="false" collective="false" import="true" type="upgrade">
                   <entryLinks>
                     <entryLink id="6d71-362c-a22e-09f5" name="Eightbound chainfist" hidden="false" collective="false" import="true" targetId="847e-e336-8f83-e1fb" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b48b-1a0e-3259-3b03" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1522-3803-d5bb-42b3" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b48b-1a0e-3259-3b03" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1522-3803-d5bb-42b3" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="ac42-cf5d-a3b0-f19d" name="Eightbound eviscerator" hidden="false" collective="false" import="true" targetId="ead5-6e1f-80bd-6b9e" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="919d-ac70-096c-e27a" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e025-3def-a886-5ae6" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="919d-ac70-096c-e27a" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e025-3def-a886-5ae6" type="max" />
                       </constraints>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                    <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                    <cost name="pts" typeId="points" value="0.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0d60-76a7-bbfc-4291" name="Two Eightbound chainfists" hidden="false" collective="false" import="true" type="upgrade">
                   <entryLinks>
                     <entryLink id="44a8-e0cf-1b3d-da27" name="Eightbound chainfist" hidden="false" collective="false" import="true" targetId="847e-e336-8f83-e1fb" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="563a-18d4-e939-d985" type="min"/>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2f0-d9ee-1e71-ec7b" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="563a-18d4-e939-d985" type="min" />
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2f0-d9ee-1e71-ec7b" type="max" />
                       </constraints>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                    <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                    <cost name="pts" typeId="points" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="3e2b-4d0a-8cbe-c9e1" name="Heavy chainglaive" hidden="false" collective="false" import="true" targetId="db19-6724-2556-76f6" type="selectionEntry"/>
+                <entryLink id="3e2b-4d0a-8cbe-c9e1" name="Heavy chainglaive" hidden="false" collective="false" import="true" targetId="db19-6724-2556-76f6" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="a056-aeaf-e3bf-f625" name="Exalted Eightbound" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2421-9f7e-8b20-2330" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4766-95a2-2585-d1c6" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2421-9f7e-8b20-2330" type="min" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4766-95a2-2585-d1c6" type="max" />
           </constraints>
           <profiles>
             <profile id="3d23-5d80-f605-fc69" name="Exalted Eightbound" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -2508,31 +2508,31 @@ In a Boarding Action, this ability only affects friendly units that are visible 
           <entryLinks>
             <entryLink id="18c5-170f-2208-03c9" name="Eightbound eviscerator" hidden="false" collective="false" import="true" targetId="ead5-6e1f-80bd-6b9e" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5028-d358-ee6a-0a6a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e479-3630-e3f8-83b4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5028-d358-ee6a-0a6a" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e479-3630-e3f8-83b4" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="07f3-6d78-8545-e8d1" name="Eightbound chainfist" hidden="false" collective="false" import="true" targetId="847e-e336-8f83-e1fb" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c6a-1eeb-4bb8-bf8d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d20-0f2f-700d-e36b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c6a-1eeb-4bb8-bf8d" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d20-0f2f-700d-e36b" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="82aa-c6ac-3f55-30e3" name="Daemonic Infusion" hidden="false" collective="false" import="true" targetId="6ac9-7c63-ea9e-6e22" type="selectionEntryGroup"/>
+        <entryLink id="82aa-c6ac-3f55-30e3" name="Daemonic Infusion" hidden="false" collective="false" import="true" targetId="6ac9-7c63-ea9e-6e22" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="135.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="135.0" />
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="847e-e336-8f83-e1fb" name="Eightbound chainfist" hidden="false" collective="true" import="true" type="upgrade">
@@ -2549,9 +2549,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="db19-6724-2556-76f6" name="Heavy chainglaive" hidden="false" collective="false" import="true" type="upgrade">
@@ -2568,9 +2568,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="3699-b37d-4602-4dae" name="Helbrute fist" hidden="false" collective="false" import="true" type="upgrade">
@@ -2587,9 +2587,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="8f3c-44d3-a785-230f" name="Helbrute" page="" hidden="false" collective="false" import="true" type="model">
@@ -2624,48 +2624,48 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="8f93-1713-a2a0-fc06" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="8f93-1713-a2a0-fc06" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="d27f-c2e7-8df6-e9eb" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="425d-cae0-6005-1f4f" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
-        <categoryLink id="9802-00c7-ea1d-1108" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
-        <categoryLink id="4c1d-74f0-d0bb-4955" name="Helbrute" hidden="false" targetId="d9b9-e9ab-155a-8109" primary="false"/>
-        <categoryLink id="7c71-7064-af9c-e5bd" name="Core" hidden="false" targetId="08f1-d244-eb44-7e01" primary="false"/>
-        <categoryLink id="4fa8-fde1-3b83-d817" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="4244-4872-bf2b-39e7" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="009e-5816-bbc1-706d" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="ec5f-c0a3-e302-28bc" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
+        <categoryLink id="d27f-c2e7-8df6-e9eb" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="425d-cae0-6005-1f4f" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true" />
+        <categoryLink id="9802-00c7-ea1d-1108" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false" />
+        <categoryLink id="4c1d-74f0-d0bb-4955" name="Helbrute" hidden="false" targetId="d9b9-e9ab-155a-8109" primary="false" />
+        <categoryLink id="7c71-7064-af9c-e5bd" name="Core" hidden="false" targetId="08f1-d244-eb44-7e01" primary="false" />
+        <categoryLink id="4fa8-fde1-3b83-d817" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="4244-4872-bf2b-39e7" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="009e-5816-bbc1-706d" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="ec5f-c0a3-e302-28bc" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="60bf-4885-4f28-b57f" name="Fist weapons" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="6c16-62f7-590a-330b" value="1.0">
               <repeats>
-                <repeat field="selections" scope="8f3c-44d3-a785-230f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3699-b37d-4602-4dae" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8f3c-44d3-a785-230f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3699-b37d-4602-4dae" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c16-62f7-590a-330b" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c16-62f7-590a-330b" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="c0d7-9ca7-9f96-852e" name="Combi-bolter" hidden="false" collective="false" import="true" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ac6-bcb8-c2da-d923" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ac6-bcb8-c2da-d923" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="2387-5d09-f624-49f0" name="Heavy flamer" hidden="false" collective="false" import="true" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="185a-6eee-5e2d-d3a3" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="185a-6eee-5e2d-d3a3" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="fb0d-a0d7-c5a7-fab4" name="Replace twin heavy bolter" hidden="false" collective="false" import="true" defaultSelectionEntryId="18c2-49e8-902c-67ef">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a40-758b-21d0-e0de" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ff2-e9d2-6a7f-2ed6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a40-758b-21d0-e0de" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ff2-e9d2-6a7f-2ed6" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="8ced-60fd-df83-8734" name="Helbrute plasma cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -2682,33 +2682,33 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="18c2-49e8-902c-67ef" name="Twin heavy bolter" hidden="false" collective="false" import="true" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry"/>
-            <entryLink id="1926-5b26-fdd5-c071" name="Multi-melta" hidden="false" collective="false" import="true" targetId="2b37-65ee-9443-b4ef" type="selectionEntry"/>
-            <entryLink id="9ee5-d034-0e9e-f401" name="Reaper autocannon" hidden="false" collective="false" import="true" targetId="5ab4-1ee7-95ad-7e15" type="selectionEntry"/>
+            <entryLink id="18c2-49e8-902c-67ef" name="Twin heavy bolter" hidden="false" collective="false" import="true" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry" />
+            <entryLink id="1926-5b26-fdd5-c071" name="Multi-melta" hidden="false" collective="false" import="true" targetId="2b37-65ee-9443-b4ef" type="selectionEntry" />
+            <entryLink id="9ee5-d034-0e9e-f401" name="Reaper autocannon" hidden="false" collective="false" import="true" targetId="5ab4-1ee7-95ad-7e15" type="selectionEntry" />
             <entryLink id="c01a-db2d-c7ff-f399" name="Twin lascannon" hidden="false" collective="false" import="true" targetId="ee18-b1cd-6b60-464d" type="selectionEntry">
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10.0" />
               </costs>
             </entryLink>
-            <entryLink id="6011-56c4-903e-2f2f" name="Helbrute fist" hidden="false" collective="false" import="true" targetId="3699-b37d-4602-4dae" type="selectionEntry"/>
+            <entryLink id="6011-56c4-903e-2f2f" name="Helbrute fist" hidden="false" collective="false" import="true" targetId="3699-b37d-4602-4dae" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="6710-e4e8-6ef2-5684" name="Replace missile launcher" hidden="false" collective="false" import="true" defaultSelectionEntryId="0c5a-a3b4-8fa9-7960">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="007c-4131-e2cc-58e4" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9397-3352-ef90-2e15" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="007c-4131-e2cc-58e4" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9397-3352-ef90-2e15" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="2f5f-4a26-9b5c-cac3" name="Helbrute hammer" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a9a-fd01-9e49-dec7" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a9a-fd01-9e49-dec7" type="max" />
               </constraints>
               <profiles>
                 <profile id="e621-1a84-a5b3-494f" name="Helbrute hammer" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -2723,14 +2723,14 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="656d-18ec-baf3-ced5" name="Power scourge" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9820-2f81-3e95-a4ce" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9820-2f81-3e95-a4ce" type="max" />
               </constraints>
               <profiles>
                 <profile id="2380-5243-831a-fff7" name="Power scourge" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -2745,25 +2745,25 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="0c5a-a3b4-8fa9-7960" name="Missile launcher" hidden="false" collective="false" import="true" targetId="1469-1964-7a91-94d4" type="selectionEntry"/>
-            <entryLink id="8543-93d4-818e-e547" name="Helbrute fist" hidden="false" collective="false" import="true" targetId="3699-b37d-4602-4dae" type="selectionEntry"/>
+            <entryLink id="0c5a-a3b4-8fa9-7960" name="Missile launcher" hidden="false" collective="false" import="true" targetId="1469-1964-7a91-94d4" type="selectionEntry" />
+            <entryLink id="8543-93d4-818e-e547" name="Helbrute fist" hidden="false" collective="false" import="true" targetId="3699-b37d-4602-4dae" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="3576-4c50-dfa5-bbcf" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup"/>
+        <entryLink id="3576-4c50-dfa5-bbcf" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="105.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="105.0" />
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="1af0-305a-0ebe-5b0e" name="Chaos Spawn" page="" hidden="false" collective="false" import="true" type="unit">
@@ -2795,24 +2795,24 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="e74a-ec4e-bcc3-e375" name="Fearsome (Aura)" hidden="false" targetId="a372-a03b-a7b3-864c" type="profile"/>
-        <infoLink id="6111-2e5e-1ac9-8be0" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="5fbe-eb23-a774-16f4" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="e74a-ec4e-bcc3-e375" name="Fearsome (Aura)" hidden="false" targetId="a372-a03b-a7b3-864c" type="profile" />
+        <infoLink id="6111-2e5e-1ac9-8be0" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="5fbe-eb23-a774-16f4" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a667-4555-18ae-1e16" name="New CategoryLink" hidden="false" targetId="c274d0b0-5866-44bc-9810-91c136ae7438" primary="true"/>
-        <categoryLink id="3626-fc91-b9f0-9665" name="New CategoryLink" hidden="false" targetId="7892-58f7-e769-4d87" primary="false"/>
-        <categoryLink id="ca1f-ad6c-0e7f-40c3" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="4a5b-b785-8120-67d0" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="7a23-5fe0-408f-6439" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="2aa8-54d4-d65f-193e" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="9834-90ea-73d4-3765" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
+        <categoryLink id="a667-4555-18ae-1e16" name="New CategoryLink" hidden="false" targetId="c274d0b0-5866-44bc-9810-91c136ae7438" primary="true" />
+        <categoryLink id="3626-fc91-b9f0-9665" name="New CategoryLink" hidden="false" targetId="7892-58f7-e769-4d87" primary="false" />
+        <categoryLink id="ca1f-ad6c-0e7f-40c3" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="4a5b-b785-8120-67d0" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="7a23-5fe0-408f-6439" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="2aa8-54d4-d65f-193e" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="9834-90ea-73d4-3765" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4659-52df-359f-5cf5" name="Chaos Spawn" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd5d-4770-93b7-7b9a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc2e-eca7-fe7d-65d0" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd5d-4770-93b7-7b9a" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc2e-eca7-fe7d-65d0" type="min" />
           </constraints>
           <profiles>
             <profile id="88cc-fd24-11e8-8524" name="Chaos Spawn" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -2832,8 +2832,8 @@ In a Boarding Action, this ability only affects friendly units that are visible 
           <selectionEntries>
             <selectionEntry id="f480-0f26-94e9-7f7f" name="Hideous mutations" hidden="false" collective="true" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25eb-0b6a-450f-ef4b" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e58-5196-7844-7c97" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25eb-0b6a-450f-ef4b" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e58-5196-7844-7c97" type="min" />
               </constraints>
               <profiles>
                 <profile id="b70f-ae79-f58a-c7b4" name="Hideous mutations" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -2848,26 +2848,26 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0" />
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="25.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="1.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="25.0" />
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="1.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="f2e5-64a4-0023-a166" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup"/>
+        <entryLink id="f2e5-64a4-0023-a166" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0" />
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="ba7e-a053-3b01-0f3a" name="Chaos Land Raider" page="" hidden="false" collective="false" import="true" type="model">
@@ -2923,45 +2923,45 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="2bde-3efe-60c3-bbdc" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="e199-1572-1f63-88fe" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="2bde-3efe-60c3-bbdc" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="e199-1572-1f63-88fe" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="5b0e-6271-f586-5ab1" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
-        <categoryLink id="17c1-250d-80a9-694b" name="New CategoryLink" hidden="false" targetId="6cc4-1b62-8e8a-05cd" primary="false"/>
-        <categoryLink id="42b0-2014-6f80-2475" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
-        <categoryLink id="8289-a971-8040-e47f" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="89f7-9d27-86dc-5826" name="Smokescreen" hidden="false" targetId="23b1-90ca-1e8a-d29f" primary="false"/>
-        <categoryLink id="f662-5075-3767-fcc2" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="054a-818d-cc81-3f91" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="823d-eeaf-5272-1a51" name="Faction: Traitoris Astartes" hidden="false" targetId="95ae-effa-c9f2-d11b" primary="false"/>
-        <categoryLink id="88dc-3fc7-0e28-7e37" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
+        <categoryLink id="5b0e-6271-f586-5ab1" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true" />
+        <categoryLink id="17c1-250d-80a9-694b" name="New CategoryLink" hidden="false" targetId="6cc4-1b62-8e8a-05cd" primary="false" />
+        <categoryLink id="42b0-2014-6f80-2475" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false" />
+        <categoryLink id="8289-a971-8040-e47f" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="89f7-9d27-86dc-5826" name="Smokescreen" hidden="false" targetId="23b1-90ca-1e8a-d29f" primary="false" />
+        <categoryLink id="f662-5075-3767-fcc2" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="054a-818d-cc81-3f91" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="823d-eeaf-5272-1a51" name="Faction: Traitoris Astartes" hidden="false" targetId="95ae-effa-c9f2-d11b" primary="false" />
+        <categoryLink id="88dc-3fc7-0e28-7e37" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
       </categoryLinks>
       <entryLinks>
         <entryLink id="0ba0-1117-13cc-2814" name="Twin heavy bolter" hidden="false" collective="false" import="true" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d510-df83-5387-41a2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1348-ac9e-09ae-d546" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d510-df83-5387-41a2" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1348-ac9e-09ae-d546" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="88b5-52ce-2c47-09fb" name="Havoc launcher" hidden="false" collective="false" import="true" targetId="c81f-1a15-8987-7cd1" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="5.0" />
           </costs>
         </entryLink>
-        <entryLink id="88a8-580c-9161-04bb" name="Combi-weapons" hidden="false" collective="false" import="true" targetId="ac17-643d-7660-d2f4" type="selectionEntryGroup"/>
+        <entryLink id="88a8-580c-9161-04bb" name="Combi-weapons" hidden="false" collective="false" import="true" targetId="ac17-643d-7660-d2f4" type="selectionEntryGroup" />
         <entryLink id="a3bb-2231-e59d-3228" name="Twin soulshatter lascannon" hidden="false" collective="false" import="true" targetId="e3be-793b-4ed0-a9fa" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcb2-8406-593e-14e8" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e5c-7f0a-2f15-4e03" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcb2-8406-593e-14e8" type="min" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e5c-7f0a-2f15-4e03" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="0e3e-ab38-ea1d-26cf" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup"/>
+        <entryLink id="0e3e-ab38-ea1d-26cf" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="265.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="14.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="265.0" />
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="14.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="e3be-793b-4ed0-a9fa" name="Twin soulshatter lascannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -2978,9 +2978,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="313a-4c20-4c98-d020" name="Defiler" page="" hidden="false" collective="false" import="true" type="model">
@@ -3031,27 +3031,27 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="e2d3-a9f4-1f9b-cf3d" name="Daemon Engine" hidden="false" targetId="4545-12b9-a779-3dc4" type="rule"/>
-        <infoLink id="5876-e96c-c5b7-6038" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="f718-73a9-8f7c-5647" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="e2d3-a9f4-1f9b-cf3d" name="Daemon Engine" hidden="false" targetId="4545-12b9-a779-3dc4" type="rule" />
+        <infoLink id="5876-e96c-c5b7-6038" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="f718-73a9-8f7c-5647" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="486f-9c72-a5e6-3cad" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
-        <categoryLink id="2e43-8a67-1b36-f4d9" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="49b7-8577-8ed5-838f" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
-        <categoryLink id="cd58-77e8-3cd4-edf8" name="Smokescreen" hidden="false" targetId="23b1-90ca-1e8a-d29f" primary="false"/>
-        <categoryLink id="9895-e508-6402-ce3d" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="0f73-eb52-603d-9938" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="69aa-0867-2f10-710d" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="1ba7-67d3-cbda-7652" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
-        <categoryLink id="d4e2-f3c2-2dfb-0e2c" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false"/>
-        <categoryLink id="bc75-fa60-d87f-7417" name="Daemon Engine" hidden="false" targetId="1c96-d14c-b0c7-53e3" primary="false"/>
+        <categoryLink id="486f-9c72-a5e6-3cad" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true" />
+        <categoryLink id="2e43-8a67-1b36-f4d9" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="49b7-8577-8ed5-838f" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false" />
+        <categoryLink id="cd58-77e8-3cd4-edf8" name="Smokescreen" hidden="false" targetId="23b1-90ca-1e8a-d29f" primary="false" />
+        <categoryLink id="9895-e508-6402-ce3d" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="0f73-eb52-603d-9938" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="69aa-0867-2f10-710d" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="1ba7-67d3-cbda-7652" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
+        <categoryLink id="d4e2-f3c2-2dfb-0e2c" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false" />
+        <categoryLink id="bc75-fa60-d87f-7417" name="Daemon Engine" hidden="false" targetId="1c96-d14c-b0c7-53e3" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="779c-6283-f8bf-3111" name="Defiler claws" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee30-e99c-a285-d9c0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4d9-cf81-75cb-a5af" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee30-e99c-a285-d9c0" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4d9-cf81-75cb-a5af" type="min" />
           </constraints>
           <profiles>
             <profile id="ce69-7e91-6f5f-cb26" name="Defiler claws" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -3066,15 +3066,15 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0" />
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="998e-6d19-582f-8189" name="Defiler cannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddb4-0318-4657-cf2e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7509-31cf-c1df-d690" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddb4-0318-4657-cf2e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7509-31cf-c1df-d690" type="max" />
           </constraints>
           <profiles>
             <profile id="f546-023f-46f6-44d7" name="Defiler cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -3089,17 +3089,17 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="7f92-37f7-c6ad-7e2b" name="Twin heavy flamer options" hidden="false" collective="false" import="true" defaultSelectionEntryId="5c68-c67d-5f97-e92e">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f9d-67e3-02c7-1c40" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b67-ba46-1c69-8554" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f9d-67e3-02c7-1c40" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b67-ba46-1c69-8554" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="0c72-9afc-b5a1-9fa9" name="Defiler scourge" hidden="false" collective="false" import="true" type="upgrade">
@@ -3116,53 +3116,53 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="10.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="5c68-c67d-5f97-e92e" name="Twin heavy flamer" hidden="false" collective="false" import="true" targetId="8d70-a6af-cbad-f08c" type="selectionEntry">
               <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
+                <cost name="pts" typeId="points" value="15.0" />
               </costs>
             </entryLink>
             <entryLink id="c848-37e9-f220-164e" name="Havoc launcher" hidden="false" collective="false" import="true" targetId="c81f-1a15-8987-7cd1" type="selectionEntry">
               <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
+                <cost name="pts" typeId="points" value="5.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="1f79-e5ca-31dc-8a4e" name="Reaper autocannon options" hidden="false" collective="false" import="true" defaultSelectionEntryId="5496-867f-bca1-c90e">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2155-093e-aa85-a6fb" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed4f-010d-e61b-b396" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2155-093e-aa85-a6fb" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed4f-010d-e61b-b396" type="min" />
           </constraints>
           <entryLinks>
             <entryLink id="4e1e-e3b1-f6a9-5093" name="Twin lascannon" hidden="false" collective="false" import="true" targetId="ee18-b1cd-6b60-464d" type="selectionEntry">
               <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
+                <cost name="pts" typeId="points" value="20.0" />
               </costs>
             </entryLink>
             <entryLink id="72fd-8500-4600-dc11" name="Twin heavy bolter" hidden="false" collective="false" import="true" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10.0" />
               </costs>
             </entryLink>
-            <entryLink id="5496-867f-bca1-c90e" name="Reaper autocannon" hidden="false" collective="false" import="true" targetId="5ab4-1ee7-95ad-7e15" type="selectionEntry"/>
+            <entryLink id="5496-867f-bca1-c90e" name="Reaper autocannon" hidden="false" collective="false" import="true" targetId="5ab4-1ee7-95ad-7e15" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="4dc6-c8e6-5efd-8152" name="Combi-weapons" hidden="false" collective="false" import="true" targetId="ac17-643d-7660-d2f4" type="selectionEntryGroup"/>
-        <entryLink id="0ee4-a4cc-9c7f-1a36" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup"/>
+        <entryLink id="4dc6-c8e6-5efd-8152" name="Combi-weapons" hidden="false" collective="false" import="true" targetId="ac17-643d-7660-d2f4" type="selectionEntryGroup" />
+        <entryLink id="0ee4-a4cc-9c7f-1a36" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="165.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="10.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="165.0" />
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="10.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="c58f-9c1c-6876-07d3" name="Chaos Predator Destructor" page="" hidden="false" collective="false" import="true" type="model">
@@ -3213,24 +3213,24 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="b66c-5f49-e5c5-c0d4" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="fb1b-5028-c7a3-a48e" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="b66c-5f49-e5c5-c0d4" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="fb1b-5028-c7a3-a48e" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="be64-728a-f6fe-6ecc" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="b4b1-a8ec-5379-951f" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
-        <categoryLink id="9ec0-55f6-fb58-7127" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
-        <categoryLink id="09a1-5575-ab39-bd7d" name="Smokescreen" hidden="false" targetId="23b1-90ca-1e8a-d29f" primary="false"/>
-        <categoryLink id="3146-f553-83f3-c32a" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="07ed-11d7-9147-6370" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="91ce-deef-f410-4fef" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="dc31-880e-ac35-4282" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
+        <categoryLink id="be64-728a-f6fe-6ecc" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="b4b1-a8ec-5379-951f" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true" />
+        <categoryLink id="9ec0-55f6-fb58-7127" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false" />
+        <categoryLink id="09a1-5575-ab39-bd7d" name="Smokescreen" hidden="false" targetId="23b1-90ca-1e8a-d29f" primary="false" />
+        <categoryLink id="3146-f553-83f3-c32a" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="07ed-11d7-9147-6370" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="91ce-deef-f410-4fef" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="dc31-880e-ac35-4282" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e715-d68a-de37-58bd" name="Predator autocannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60a6-20b2-3da7-e1d2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fbe-2e85-aaea-3b06" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60a6-20b2-3da7-e1d2" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fbe-2e85-aaea-3b06" type="max" />
           </constraints>
           <profiles>
             <profile id="352d-7941-9d39-884a" name="Predator autocannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -3245,52 +3245,52 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="ee97-85a8-2837-b571" name="2x Weapon options" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d41-838c-09d0-6cb8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d41-838c-09d0-6cb8" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="ce2e-2c50-d6e4-4b42" name="Two heavy bolters" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
                 <entryLink id="af9b-8a5d-e7e0-04bf" name="Heavy bolter" hidden="false" collective="false" import="true" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3add-2460-f4ef-6819" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="507c-58ce-c017-e38d" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3add-2460-f4ef-6819" type="max" />
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="507c-58ce-c017-e38d" type="min" />
                   </constraints>
                   <costs>
-                    <cost name="pts" typeId="points" value="10.0"/>
+                    <cost name="pts" typeId="points" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="3822-242c-541c-6cc2" name="Two lascannons" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
                 <entryLink id="4a2d-25e1-402f-51c1" name="Lascannon" hidden="false" collective="false" import="true" targetId="a908-4664-11cd-f8b2" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6623-3f7a-740e-0865" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bc7-5848-7cda-3b00" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6623-3f7a-740e-0865" type="max" />
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bc7-5848-7cda-3b00" type="min" />
                   </constraints>
                   <costs>
-                    <cost name="pts" typeId="points" value="20.0"/>
+                    <cost name="pts" typeId="points" value="20.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3299,16 +3299,16 @@ In a Boarding Action, this ability only affects friendly units that are visible 
       <entryLinks>
         <entryLink id="84c6-8e87-8a9a-1107" name="Havoc launcher" hidden="false" collective="false" import="true" targetId="c81f-1a15-8987-7cd1" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="5.0" />
           </costs>
         </entryLink>
-        <entryLink id="9ece-ced8-e78e-99ce" name="Combi-weapons" hidden="false" collective="false" import="true" targetId="ac17-643d-7660-d2f4" type="selectionEntryGroup"/>
-        <entryLink id="403a-a18b-412f-4396" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup"/>
+        <entryLink id="9ece-ced8-e78e-99ce" name="Combi-weapons" hidden="false" collective="false" import="true" targetId="ac17-643d-7660-d2f4" type="selectionEntryGroup" />
+        <entryLink id="403a-a18b-412f-4396" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="140.0" />
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="fff3-f04a-9856-e10a" name="Chaos Predator Annihilator" page="" hidden="false" collective="false" import="true" type="model">
@@ -3359,58 +3359,58 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="6800-85b4-6fec-7e58" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="6800-85b4-6fec-7e58" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="88c6-f217-57a2-2199" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="08d3-875b-2898-4198" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
-        <categoryLink id="d23d-44b2-eb16-0268" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
-        <categoryLink id="27a0-21d3-ff05-7a17" name="Smokescreen" hidden="false" targetId="23b1-90ca-1e8a-d29f" primary="false"/>
-        <categoryLink id="b810-f3ac-638e-82b1" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="757d-4f40-ed0d-4b6d" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="e053-a411-8745-934f" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="6a6f-1301-48fc-c457" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
+        <categoryLink id="88c6-f217-57a2-2199" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="08d3-875b-2898-4198" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true" />
+        <categoryLink id="d23d-44b2-eb16-0268" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false" />
+        <categoryLink id="27a0-21d3-ff05-7a17" name="Smokescreen" hidden="false" targetId="23b1-90ca-1e8a-d29f" primary="false" />
+        <categoryLink id="b810-f3ac-638e-82b1" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="757d-4f40-ed0d-4b6d" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="e053-a411-8745-934f" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="6a6f-1301-48fc-c457" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9156-d5fc-71cf-9a2e" name="2x Weapon options" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c49-0544-0ac6-409e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c49-0544-0ac6-409e" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="87d0-887b-ff0d-c170" name="Two heavy bolters" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
                 <entryLink id="5e0d-8150-a871-0af1" name="Heavy bolter" hidden="false" collective="false" import="true" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="649d-372d-742e-c755" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7897-3d50-3244-eebf" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="649d-372d-742e-c755" type="max" />
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7897-3d50-3244-eebf" type="min" />
                   </constraints>
                   <costs>
-                    <cost name="pts" typeId="points" value="10.0"/>
+                    <cost name="pts" typeId="points" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="2dbf-d75e-6eed-cae5" name="Two lascannons" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
                 <entryLink id="6a9b-162a-17b8-3a9a" name="Lascannon" hidden="false" collective="false" import="true" targetId="a908-4664-11cd-f8b2" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1248-9fc5-238f-77f7" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c55-5170-9bc7-92cc" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1248-9fc5-238f-77f7" type="max" />
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c55-5170-9bc7-92cc" type="min" />
                   </constraints>
                   <costs>
-                    <cost name="pts" typeId="points" value="20.0"/>
+                    <cost name="pts" typeId="points" value="20.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3419,22 +3419,22 @@ In a Boarding Action, this ability only affects friendly units that are visible 
       <entryLinks>
         <entryLink id="5e3f-cdfc-339a-9442" name="Havoc launcher" hidden="false" collective="false" import="true" targetId="c81f-1a15-8987-7cd1" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="5.0" />
           </costs>
         </entryLink>
-        <entryLink id="7284-b3d0-ac7a-8504" name="Combi-weapons" hidden="false" collective="false" import="true" targetId="ac17-643d-7660-d2f4" type="selectionEntryGroup"/>
+        <entryLink id="7284-b3d0-ac7a-8504" name="Combi-weapons" hidden="false" collective="false" import="true" targetId="ac17-643d-7660-d2f4" type="selectionEntryGroup" />
         <entryLink id="d9cc-3177-1739-9669" name="Twin soulshatter lascannon" hidden="false" collective="false" import="true" targetId="e3be-793b-4ed0-a9fa" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4b7-4248-b635-8def" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53db-3d46-e1ea-7250" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4b7-4248-b635-8def" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53db-3d46-e1ea-7250" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="2c9c-812b-f91e-1763" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup"/>
+        <entryLink id="2c9c-812b-f91e-1763" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="130.0" />
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="27e7-3a9c-bfac-d50a" name="Forgefiend" page="" hidden="false" collective="false" import="true" type="model">
@@ -3485,26 +3485,26 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="023f-085a-7af8-c931" name="Daemon Engine" hidden="false" targetId="4545-12b9-a779-3dc4" type="rule"/>
-        <infoLink id="051f-ff04-15a2-395b" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="b3cf-8a1b-794c-ce7c" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="023f-085a-7af8-c931" name="Daemon Engine" hidden="false" targetId="4545-12b9-a779-3dc4" type="rule" />
+        <infoLink id="051f-ff04-15a2-395b" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="b3cf-8a1b-794c-ce7c" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="cf26-33d3-74bc-bb4d" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
-        <categoryLink id="34a3-c9b2-e798-8c42" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="2309-e5c4-2d42-3eda" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
-        <categoryLink id="30ca-da41-9675-aa50" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="054b-c298-d1f6-a101" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="ce7a-6749-275e-32c7" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="3814-3812-17ab-a762" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
-        <categoryLink id="86b3-bee7-219c-9a5e" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false"/>
-        <categoryLink id="edb5-e5a2-14ca-d8b1" name="Daemon Engine" hidden="false" targetId="1c96-d14c-b0c7-53e3" primary="false"/>
+        <categoryLink id="cf26-33d3-74bc-bb4d" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true" />
+        <categoryLink id="34a3-c9b2-e798-8c42" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="2309-e5c4-2d42-3eda" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false" />
+        <categoryLink id="30ca-da41-9675-aa50" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="054b-c298-d1f6-a101" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="ce7a-6749-275e-32c7" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="3814-3812-17ab-a762" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
+        <categoryLink id="86b3-bee7-219c-9a5e" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false" />
+        <categoryLink id="edb5-e5a2-14ca-d8b1" name="Daemon Engine" hidden="false" targetId="1c96-d14c-b0c7-53e3" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b879-fe4d-62f4-b9b3" name="2x Heavy hades autocannons options" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ded-24fa-a349-7d65" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96b6-2c78-fd03-55a6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ded-24fa-a349-7d65" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96b6-2c78-fd03-55a6" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="b66f-bc32-dede-3dcd" name="2x Heavy hades autocannons" hidden="false" collective="false" import="true" type="upgrade">
@@ -3521,27 +3521,27 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="50.0" />
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="1e84-e743-1e22-3dec" name="2x Ectoplasma cannons" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
-                <infoLink id="e465-39fa-0441-0638" name="Ectoplasma cannon" hidden="false" targetId="8fbd-ffea-6ad7-b306" type="profile"/>
+                <infoLink id="e465-39fa-0441-0638" name="Ectoplasma cannon" hidden="false" targetId="8fbd-ffea-6ad7-b306" type="profile" />
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="30.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="30.0" />
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="5c8f-3f3d-4e8a-bce8" name="Daemon jaws options" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83af-1a19-c3d5-8d8d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24e9-a022-c434-ff1f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83af-1a19-c3d5-8d8d" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24e9-a022-c434-ff1f" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="c99c-d782-8b86-e4af" name="Daemon jaws" hidden="false" collective="false" import="true" type="upgrade">
@@ -3558,31 +3558,31 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="4d07-92a8-54e5-758b" name="Ectoplasma cannon" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
-                <infoLink id="ecb4-6ce1-c1fb-6ee7" name="Ectoplasma cannon" hidden="false" targetId="8fbd-ffea-6ad7-b306" type="profile"/>
+                <infoLink id="ecb4-6ce1-c1fb-6ee7" name="Ectoplasma cannon" hidden="false" targetId="8fbd-ffea-6ad7-b306" type="profile" />
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="15.0" />
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1b9d-63eb-0d27-ada5" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup"/>
+        <entryLink id="1b9d-63eb-0d27-ada5" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="110.0" />
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="450e-7c11-cee7-d6bf" name="Maulerfiend" page="" hidden="false" collective="false" import="true" type="model">
@@ -3638,26 +3638,26 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="afda-3588-5d02-146a" name="Daemon Engine" hidden="false" targetId="4545-12b9-a779-3dc4" type="rule"/>
-        <infoLink id="0135-80a6-721e-3439" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="4ab3-4fcd-56ab-e559" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="afda-3588-5d02-146a" name="Daemon Engine" hidden="false" targetId="4545-12b9-a779-3dc4" type="rule" />
+        <infoLink id="0135-80a6-721e-3439" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="4ab3-4fcd-56ab-e559" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="1595-1852-3d55-88d8" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
-        <categoryLink id="ce0e-963b-ffea-40af" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="9689-43d0-20f0-e911" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
-        <categoryLink id="9b23-2a6e-2d0d-ed05" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="eaff-857b-1f0e-c30d" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="6344-f49c-0cf9-aa94" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="9e6d-b1ea-096c-0ae4" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
-        <categoryLink id="ba2e-9de2-2065-fe34" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false"/>
-        <categoryLink id="ceaf-c244-28ce-9322" name="Daemon Engine" hidden="false" targetId="1c96-d14c-b0c7-53e3" primary="false"/>
+        <categoryLink id="1595-1852-3d55-88d8" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true" />
+        <categoryLink id="ce0e-963b-ffea-40af" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="9689-43d0-20f0-e911" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false" />
+        <categoryLink id="9b23-2a6e-2d0d-ed05" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="eaff-857b-1f0e-c30d" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="6344-f49c-0cf9-aa94" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="9e6d-b1ea-096c-0ae4" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
+        <categoryLink id="ba2e-9de2-2065-fe34" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false" />
+        <categoryLink id="ceaf-c244-28ce-9322" name="Daemon Engine" hidden="false" targetId="1c96-d14c-b0c7-53e3" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="21d2-abee-d70c-4dc8" name="Maulerfiend fists" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7642-50ae-9efb-dfb0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3aee-b5f7-734e-029f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7642-50ae-9efb-dfb0" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3aee-b5f7-734e-029f" type="max" />
           </constraints>
           <profiles>
             <profile id="ac7a-4ddb-61cf-cd22" name="Maulerfiend fists" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -3672,17 +3672,17 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="3228-9ebe-fce1-591e" name="Magma cutters or Lasher tendrils" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b0f-6413-f736-196a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f0e-6699-53d5-c74f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b0f-6413-f736-196a" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f0e-6699-53d5-c74f" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="bc26-55b2-5614-7e13" name="2x Magma cutter" hidden="false" collective="false" import="true" type="upgrade">
@@ -3699,9 +3699,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="378d-384b-edee-01b5" name="Lasher tendrils" hidden="false" collective="false" import="true" type="upgrade">
@@ -3718,21 +3718,21 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="10.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="ba0c-8d5b-cdc8-ed70" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup"/>
+        <entryLink id="ba0c-8d5b-cdc8-ed70" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="140.0" />
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="4c72-2748-d17c-9ba1" name="Chaos Rhino" page="" hidden="false" collective="false" import="true" type="model">
@@ -3788,39 +3788,39 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="8170-6720-0102-0bb0" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="51c9-ad10-8b3d-26bc" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="8170-6720-0102-0bb0" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="51c9-ad10-8b3d-26bc" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="e8d7-9163-65e6-385a" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="d211-93cc-ff6e-be7c" name="New CategoryLink" hidden="false" targetId="1b66-3f5f-6705-079a" primary="true"/>
-        <categoryLink id="8bad-27fa-d6af-0f56" name="New CategoryLink" hidden="false" targetId="6cc4-1b62-8e8a-05cd" primary="false"/>
-        <categoryLink id="c7aa-e7dc-82c4-e627" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
-        <categoryLink id="4744-f6ac-63b7-ae54" name="Smokescreen" hidden="false" targetId="23b1-90ca-1e8a-d29f" primary="false"/>
-        <categoryLink id="b1b1-1d73-9585-a5dc" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="0dc8-22a4-cca9-3455" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="8fbe-eee5-e689-4c3d" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="65cc-e298-7da7-e637" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
+        <categoryLink id="e8d7-9163-65e6-385a" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="d211-93cc-ff6e-be7c" name="New CategoryLink" hidden="false" targetId="1b66-3f5f-6705-079a" primary="true" />
+        <categoryLink id="8bad-27fa-d6af-0f56" name="New CategoryLink" hidden="false" targetId="6cc4-1b62-8e8a-05cd" primary="false" />
+        <categoryLink id="c7aa-e7dc-82c4-e627" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false" />
+        <categoryLink id="4744-f6ac-63b7-ae54" name="Smokescreen" hidden="false" targetId="23b1-90ca-1e8a-d29f" primary="false" />
+        <categoryLink id="b1b1-1d73-9585-a5dc" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="0dc8-22a4-cca9-3455" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="8fbe-eee5-e689-4c3d" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="65cc-e298-7da7-e637" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="c415-e994-9313-0443" name="Combi-weapons" hidden="false" collective="false" import="true" targetId="ac17-643d-7660-d2f4" type="selectionEntryGroup"/>
+        <entryLink id="c415-e994-9313-0443" name="Combi-weapons" hidden="false" collective="false" import="true" targetId="ac17-643d-7660-d2f4" type="selectionEntryGroup" />
         <entryLink id="1a4e-9553-b3b8-702a" name="Combi-bolter" hidden="false" collective="false" import="true" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8497-c44a-27f0-5f38" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad1a-359e-d614-fee8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8497-c44a-27f0-5f38" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad1a-359e-d614-fee8" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="66d9-bf5d-ad36-c01f" name="Havoc launcher" hidden="false" collective="false" import="true" targetId="c81f-1a15-8987-7cd1" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="5.0" />
           </costs>
         </entryLink>
-        <entryLink id="fdbd-3c08-2af3-b110" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup"/>
+        <entryLink id="fdbd-3c08-2af3-b110" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="80.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="80.0" />
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="7935-7aa6-2360-63d5" name="Heldrake" page="" hidden="false" collective="false" import="true" type="model">
@@ -3886,30 +3886,30 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="54bf-2d25-a10b-1f63" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="a2cb-1201-ff36-9c0c" name="Daemon Engine" hidden="false" targetId="4545-12b9-a779-3dc4" type="rule"/>
-        <infoLink id="479f-5326-e168-1422" name="Supersonic" hidden="false" targetId="9207-9786-0a5b-faaf" type="profile"/>
-        <infoLink id="f9ff-1cf0-279d-0145" name="Hard to Hit" hidden="false" targetId="2567-8e02-9663-8055" type="profile"/>
-        <infoLink id="1baf-750b-c6b9-e78c" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="54bf-2d25-a10b-1f63" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="a2cb-1201-ff36-9c0c" name="Daemon Engine" hidden="false" targetId="4545-12b9-a779-3dc4" type="rule" />
+        <infoLink id="479f-5326-e168-1422" name="Supersonic" hidden="false" targetId="9207-9786-0a5b-faaf" type="profile" />
+        <infoLink id="f9ff-1cf0-279d-0145" name="Hard to Hit" hidden="false" targetId="2567-8e02-9663-8055" type="profile" />
+        <infoLink id="1baf-750b-c6b9-e78c" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="e48a-36ca-379b-c9e4" hidden="false" targetId="e888-1504-aa61-95ff" primary="true"/>
-        <categoryLink id="3310-e217-f310-aee0" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
-        <categoryLink id="1077-0f85-23e1-25c6" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="fc52-21bd-f360-e6aa" name="New CategoryLink" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false"/>
-        <categoryLink id="0021-02b6-71c0-3ee0" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="6bd5-d669-22ad-b80e" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="31f3-5dde-4583-082c" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="f39e-2244-c951-fc37" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
-        <categoryLink id="7085-2bb8-9103-1bf6" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false"/>
-        <categoryLink id="3f1b-6994-7024-b498" name="Daemon Engine" hidden="false" targetId="1c96-d14c-b0c7-53e3" primary="false"/>
-        <categoryLink id="89ce-a571-391c-134f" name="Aircraft" hidden="false" targetId="d569-3d56-cd24-6a31" primary="false"/>
+        <categoryLink id="e48a-36ca-379b-c9e4" hidden="false" targetId="e888-1504-aa61-95ff" primary="true" />
+        <categoryLink id="3310-e217-f310-aee0" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false" />
+        <categoryLink id="1077-0f85-23e1-25c6" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="fc52-21bd-f360-e6aa" name="New CategoryLink" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false" />
+        <categoryLink id="0021-02b6-71c0-3ee0" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="6bd5-d669-22ad-b80e" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="31f3-5dde-4583-082c" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="f39e-2244-c951-fc37" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
+        <categoryLink id="7085-2bb8-9103-1bf6" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false" />
+        <categoryLink id="3f1b-6994-7024-b498" name="Daemon Engine" hidden="false" targetId="1c96-d14c-b0c7-53e3" primary="false" />
+        <categoryLink id="89ce-a571-391c-134f" name="Aircraft" hidden="false" targetId="d569-3d56-cd24-6a31" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="886f-8521-2bd9-e70c" name="Heldrake claws" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="461c-563a-bc9a-681e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae5f-4bfd-105d-4918" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="461c-563a-bc9a-681e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae5f-4bfd-105d-4918" type="min" />
           </constraints>
           <profiles>
             <profile id="6358-7335-e8b0-07f9" name="Heldrake claws" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -3924,17 +3924,17 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="e046-a192-8614-ee52" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="085f-6634-9be9-3924">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4360-b20c-bf04-d23b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5684-2aa6-bf0d-733d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4360-b20c-bf04-d23b" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5684-2aa6-bf0d-733d" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="085f-6634-9be9-3924" name="Hades autocannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3951,9 +3951,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="7298-5c9a-f87f-9635" name="Baleflamer" hidden="false" collective="false" import="true" type="upgrade">
@@ -3970,21 +3970,21 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="bd20-18be-d1d6-c4f4" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup"/>
+        <entryLink id="bd20-18be-d1d6-c4f4" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="165.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="9.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="165.0" />
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="9.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="a091-f3a1-d9d7-5ab9" name="Khorne Lord of Skulls" page="" hidden="false" collective="false" import="true" type="model">
@@ -4045,28 +4045,28 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="2529-2437-6165-27d8" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule"/>
-        <infoLink id="58f9-c39f-c2eb-c8f9" name="Daemon Engine" hidden="false" targetId="4545-12b9-a779-3dc4" type="rule"/>
-        <infoLink id="27e1-89d8-4632-48fb" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule"/>
+        <infoLink id="2529-2437-6165-27d8" name="The Blood Tithe" hidden="false" targetId="41c2-7dbe-72b3-24de" type="rule" />
+        <infoLink id="58f9-c39f-c2eb-c8f9" name="Daemon Engine" hidden="false" targetId="4545-12b9-a779-3dc4" type="rule" />
+        <infoLink id="27e1-89d8-4632-48fb" name="Relentless Rage" hidden="false" targetId="f0b4-dc5f-4885-c15b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="49d9-c243-4ee5-b330" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
-        <categoryLink id="5e65-21f4-e6a5-2aea" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false"/>
-        <categoryLink id="dad5-83ed-5f81-91bd" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
-        <categoryLink id="3fbf-8633-21bb-ead6" name="Titanic" hidden="false" targetId="bdda-36f0-4f32-1639" primary="false"/>
-        <categoryLink id="0ba3-cef7-11f1-5f0a" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false"/>
-        <categoryLink id="2bb0-ec0a-01f6-1b9f" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false"/>
-        <categoryLink id="72e5-21d9-ac70-f300" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false"/>
-        <categoryLink id="bf89-ec5c-34be-fac5" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false"/>
-        <categoryLink id="166a-1803-7f89-077a" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false"/>
-        <categoryLink id="8bb1-f498-727f-6cd6" name="Daemon Engine" hidden="false" targetId="1c96-d14c-b0c7-53e3" primary="false"/>
-        <categoryLink id="67d8-4079-b60d-4584" name="Warp Locus" hidden="false" targetId="9c4d-556e-5ec1-7ad6" primary="false"/>
+        <categoryLink id="49d9-c243-4ee5-b330" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true" />
+        <categoryLink id="5e65-21f4-e6a5-2aea" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false" />
+        <categoryLink id="dad5-83ed-5f81-91bd" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false" />
+        <categoryLink id="3fbf-8633-21bb-ead6" name="Titanic" hidden="false" targetId="bdda-36f0-4f32-1639" primary="false" />
+        <categoryLink id="0ba3-cef7-11f1-5f0a" name="Faction: Khorne" hidden="false" targetId="fe84-0aa8-259f-b94d" primary="false" />
+        <categoryLink id="2bb0-ec0a-01f6-1b9f" name="Faction: Heretic Astartes" hidden="false" targetId="ea5c-26b3-aa78-7253" primary="false" />
+        <categoryLink id="72e5-21d9-ac70-f300" name="Faction: Butcher Astartes" hidden="false" targetId="f096-f6b1-0904-2985" primary="false" />
+        <categoryLink id="bf89-ec5c-34be-fac5" name="Faction: World Eaters" hidden="false" targetId="e12a-408e-574b-4a6c" primary="false" />
+        <categoryLink id="166a-1803-7f89-077a" name="Daemon" hidden="false" targetId="37db-2713-c0e0-df20" primary="false" />
+        <categoryLink id="8bb1-f498-727f-6cd6" name="Daemon Engine" hidden="false" targetId="1c96-d14c-b0c7-53e3" primary="false" />
+        <categoryLink id="67d8-4079-b60d-4584" name="Warp Locus" hidden="false" targetId="9c4d-556e-5ec1-7ad6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="fbea-fd3f-dad5-0182" name="Great cleaver of Khorne" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa5f-bb29-140b-ed8b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abd3-0eff-9412-aaa4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa5f-bb29-140b-ed8b" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abd3-0eff-9412-aaa4" type="min" />
           </constraints>
           <profiles>
             <profile id="69e8-efaa-3974-72e0" name="Great cleaver of Khorne - Smash" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -4091,17 +4091,17 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0" />
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="abfb-73fe-6815-2e74" name="Gorestorm cannon options" hidden="false" collective="false" import="true" defaultSelectionEntryId="0497-89a2-649d-6825">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6c1-ac4d-c6e5-e7ee" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cda-55df-93f4-09c5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6c1-ac4d-c6e5-e7ee" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cda-55df-93f4-09c5" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="0497-89a2-649d-6825" name="Gorestorm cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -4118,9 +4118,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="ff13-f9d4-a660-27d2" name="Ichor cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -4137,9 +4137,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="f21c-baa6-4c38-9c83" name="Daemongore cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -4156,17 +4156,17 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="f246-140d-efeb-39c3" name="Hades gatling cannon options" hidden="false" collective="false" import="true" defaultSelectionEntryId="f3c1-ba58-5a58-8810">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d51-e86d-de11-88ca" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f224-23dc-94b0-2cd3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d51-e86d-de11-88ca" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f224-23dc-94b0-2cd3" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="f3c1-ba58-5a58-8810" name="Hades gatling cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -4183,9 +4183,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="7a9f-42ba-3ca6-f6bc" name="Skullhurler" hidden="false" collective="false" import="true" type="upgrade">
@@ -4202,21 +4202,21 @@ In a Boarding Action, this ability only affects friendly units that are visible 
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="6f74-de9b-4f92-c1c6" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup"/>
+        <entryLink id="6f74-de9b-4f92-c1c6" name="Battle Scars" hidden="false" collective="false" import="true" targetId="cec4-9abd-dcdb-c9c2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="575.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="29.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="575.0" />
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="29.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="5f56-3e66-62d8-d2f0" name="Battle Lust (World Eaters)" hidden="false" collective="false" import="true" type="upgrade">
@@ -4228,9 +4228,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="5906-060d-ef33-f8cf" name="Burning Plate (World Eaters)" hidden="false" collective="false" import="true" type="upgrade">
@@ -4243,9 +4243,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="bca6-9f88-efc2-3b7f" name="Mutable Form (World Eaters)" hidden="false" collective="false" import="true" type="upgrade">
@@ -4258,31 +4258,31 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </profile>
       </profiles>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+        <cost name="pts" typeId="points" value="0.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="ac17-643d-7660-d2f4" name="Combi-weapons" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c283-426a-9b59-7c3b" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c283-426a-9b59-7c3b" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="591b-96ae-2967-a7f2" name="Combi-flamer" hidden="false" collective="false" import="true" targetId="c6a1-e0c4-c1b1-dce1" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10.0" />
           </costs>
         </entryLink>
         <entryLink id="9cab-9ebf-be12-738d" name="Combi-melta" hidden="false" collective="false" import="true" targetId="c445-e211-f316-5d83" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10.0" />
           </costs>
         </entryLink>
         <entryLink id="0487-668d-cc10-65d4" name="Combi-bolter" hidden="false" collective="false" import="true" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="5.0" />
           </costs>
         </entryLink>
       </entryLinks>
@@ -4293,18 +4293,18 @@ In a Boarding Action, this ability only affects friendly units that are visible 
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo" />
               </conditions>
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c798-5187-ae58-d556" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c798-5187-ae58-d556" type="equalTo" />
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="and">
                       <conditions>
-                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
-                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76d2-6e71-243f-ad3d" type="equalTo"/>
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77a-cc54-efcf-a09a" type="equalTo" />
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76d2-6e71-243f-ad3d" type="equalTo" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -4315,19 +4315,19 @@ In a Boarding Action, this ability only affects friendly units that are visible 
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3697-6fc8-c68f-3637" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3697-6fc8-c68f-3637" type="max" />
       </constraints>
       <selectionEntries>
         <selectionEntry id="1d4c-1815-2b1a-bc65" name="Helm of Brazen Ire" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a767-04ba-ff37-1531" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a767-04ba-ff37-1531" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6efc-fe45-a85b-f15d" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6efc-fe45-a85b-f15d" type="max" />
           </constraints>
           <profiles>
             <profile id="4140-9150-ab75-83a0" name="Helm of Brazen Ire" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -4337,9 +4337,9 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="f1d7-d004-ab6e-d2df" name="Berzerker Glaive" hidden="false" collective="false" import="true" type="upgrade">
@@ -4348,13 +4348,13 @@ In a Boarding Action, this ability only affects friendly units that are visible 
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a767-04ba-ff37-1531" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a767-04ba-ff37-1531" type="equalTo" />
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="and">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b897-4c20-8b4f-4513" type="equalTo"/>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="25ff-476c-ef1a-d84e" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b897-4c20-8b4f-4513" type="equalTo" />
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="25ff-476c-ef1a-d84e" type="equalTo" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -4363,7 +4363,7 @@ In a Boarding Action, this ability only affects friendly units that are visible 
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f215-bfd2-20b7-164c" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f215-bfd2-20b7-164c" type="max" />
           </constraints>
           <profiles>
             <profile id="05fe-1b34-f4de-6b43" name="Berzerker Glaive" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -4380,21 +4380,21 @@ Each time an attack is made with this weapon, an unmodified hit roll of 6 scores
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="824e-a9ce-28b4-edb2" name="Talisman of Rage" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a767-04ba-ff37-1531" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a767-04ba-ff37-1531" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9313-77c6-2365-4861" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9313-77c6-2365-4861" type="max" />
           </constraints>
           <profiles>
             <profile id="ca61-0288-4279-8273" name="Talisman of Rage" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -4404,21 +4404,21 @@ Each time an attack is made with this weapon, an unmodified hit roll of 6 scores
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="9aad-1c65-1c8e-a77c" name="Burning Plate" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dab1-08bf-2023-86e7" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dab1-08bf-2023-86e7" type="max" />
           </constraints>
           <profiles>
             <profile id="f2ac-f04d-adb3-c12d" name="Burning Plate" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -4429,9 +4429,9 @@ Each time an attack is made with this weapon, an unmodified hit roll of 6 scores
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="4f21-f10d-747f-83bb" name="Soulburner" hidden="false" collective="false" import="true" type="upgrade">
@@ -4440,15 +4440,15 @@ Each time an attack is made with this weapon, an unmodified hit roll of 6 scores
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="19b5-e189-b896-f8d5" type="notInstanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="19b5-e189-b896-f8d5" type="notInstanceOf" />
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e398-1f53-086d-969e" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e398-1f53-086d-969e" type="max" />
           </constraints>
           <profiles>
             <profile id="031b-8a1f-3324-789e" name="Soulburner" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -4465,21 +4465,21 @@ Each time an attack is made with this weapon, that attack automatically hits the
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="594a-d47a-8ccc-ed58" name="The Skull of An&apos;gr&apos;ant" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bf4f-d352-82a3-0cd2" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bf4f-d352-82a3-0cd2" type="max" />
           </constraints>
           <profiles>
             <profile id="d455-d22e-ace6-63f4" name="The Skull of An&apos;gr&apos;ant" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -4489,9 +4489,9 @@ Each time an attack is made with this weapon, that attack automatically hits the
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -4502,18 +4502,18 @@ Each time an attack is made with this weapon, that attack automatically hits the
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6771-6ab3-1672-6a39" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6771-6ab3-1672-6a39" type="equalTo" />
               </conditions>
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c798-5187-ae58-d556" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c798-5187-ae58-d556" type="equalTo" />
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="and">
                       <conditions>
-                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
-                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76d2-6e71-243f-ad3d" type="equalTo"/>
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77a-cc54-efcf-a09a" type="equalTo" />
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="76d2-6e71-243f-ad3d" type="equalTo" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -4524,24 +4524,24 @@ Each time an attack is made with this weapon, that attack automatically hits the
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32d3-4271-c5c7-f9c0" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32d3-4271-c5c7-f9c0" type="max" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="1f59-d4ed-7b0e-9e65" name="Warlord Traits (World Eaters)" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc58-e5ec-7ace-9e91" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc58-e5ec-7ace-9e91" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="7358-68fb-4033-72be" name="True Berserker" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a3f-2d97-cd7a-3654" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a3f-2d97-cd7a-3654" type="max" />
               </constraints>
               <profiles>
                 <profile id="3440-c88d-8c77-7650" name="True Berserker" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -4551,14 +4551,14 @@ Each time an attack is made with this weapon, that attack automatically hits the
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="ab39-3c79-8e18-4cd0" name="Favoured of Khorne" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24d6-89eb-f2bd-ec72" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24d6-89eb-f2bd-ec72" type="max" />
               </constraints>
               <profiles>
                 <profile id="d7fc-7bb6-f756-6b94" name="Favoured of Khorne" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -4568,14 +4568,14 @@ Each time an attack is made with this weapon, that attack automatically hits the
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="7d65-5674-6552-cb00" name="Battle Lust" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67ee-d77b-4e63-237b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67ee-d77b-4e63-237b" type="max" />
               </constraints>
               <profiles>
                 <profile id="8541-020a-9778-1aef" name="Battle Lust" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -4586,29 +4586,29 @@ Each time an attack is made with this weapon, that attack automatically hits the
                 </profile>
               </profiles>
               <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+                <cost name="pts" typeId="points" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="13e9-9da3-f289-81f1" name="Warlord Traits (BRB)" hidden="false" collective="false" import="true" targetId="d442-1f03-d9da-e77f" type="selectionEntryGroup"/>
+        <entryLink id="13e9-9da3-f289-81f1" name="Warlord Traits (BRB)" hidden="false" collective="false" import="true" targetId="d442-1f03-d9da-e77f" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="6ac9-7c63-ea9e-6e22" name="Daemonic Infusion" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1029-5185-faaa-11ea" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b26-453b-8293-27f3" type="max"/>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c27a-2021-6b50-4190" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b26-453b-8293-27f3" type="max" />
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c27a-2021-6b50-4190" type="max" />
       </constraints>
       <selectionEntries>
         <selectionEntry id="80b5-757f-0f53-1227" name="Drawn to Power" hidden="false" collective="false" import="true" type="upgrade">
@@ -4620,9 +4620,9 @@ Each time an attack is made with this weapon, that attack automatically hits the
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="af7a-dda7-4d1b-def0" name="Mutable Form" hidden="false" collective="false" import="true" type="upgrade">
@@ -4634,9 +4634,9 @@ Each time an attack is made with this weapon, that attack automatically hits the
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="34bc-6192-ae53-5535" name="Brazen Skin" hidden="false" collective="false" import="true" type="upgrade">
@@ -4648,16 +4648,16 @@ Each time an attack is made with this weapon, that attack automatically hits the
             </profile>
           </profiles>
           <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0" />
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0" />
+            <cost name="pts" typeId="points" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="7ed6-daaf-4d6b-3f83" name="Boarding Action Enhancements" hidden="false" collective="false" import="true">
       <entryLinks>
-        <entryLink id="72c9-0b5d-18d2-e048" name="Boarding Action Enhancements" hidden="false" collective="false" import="true" targetId="4c50-9343-b5fb-872d" type="selectionEntryGroup"/>
+        <entryLink id="72c9-0b5d-18d2-e048" name="Boarding Action Enhancements" hidden="false" collective="false" import="true" targetId="4c50-9343-b5fb-872d" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
@@ -4733,6 +4733,6 @@ For the purposes of this ability, a Rapid Fire bolt weapon is any bolt weapon (a
     </profile>
   </sharedProfiles>
   <catalogueLinks>
-    <catalogueLink id="3a33-5f67-bad9-d887" name="Chaos - FW Heretic Astartes" targetId="2128-f196-8f1c-b352" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="3a33-5f67-bad9-d887" name="Chaos - FW Heretic Astartes" targetId="2128-f196-8f1c-b352" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>


### PR DESCRIPTION
Corrected Angron's Move characteristic when he is using the 1-5 wounds remaining profile.

Was `10"`, should have been `8"`

Fixes #12512